### PR TITLE
Boost thread is explicitly used, so link it

### DIFF
--- a/tf_smart_throttle/CMakeLists.txt
+++ b/tf_smart_throttle/CMakeLists.txt
@@ -26,4 +26,5 @@ rosbuild_gensrv()
 rosbuild_add_boost_directories()
 
 rosbuild_add_executable(${PROJECT_NAME} src/tf_smart_throttle.cpp)
+rosbuild_link_boost(${PROJECT_NAME} thread)
 


### PR DESCRIPTION
This fixes a broken compile in groovy. Should be there for fuerte anyway.
