### PR TITLE
Update rosbridge_library/package.xml

### DIFF
--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -25,7 +25,6 @@
   <run_depend>rosservice</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>python-imaging</run_depend>
-  <test_depend>rospy</test_depend>
   <test_depend>roscpp</test_depend>
 
 </package>


### PR DESCRIPTION
removed <test_depend>rospy</test_depend>

This triggers a lot of warnings like this:

WARNING(s) in /home/im/code/src/rosbridge_suite/rosbridge_library/package.xml:
- The test dependency on "rospy" is redundant with: build_depend, run_depend
