### PR TITLE
Very Minor: Removes trailing commas

### DIFF
--- a/rosapi/setup.py
+++ b/rosapi/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rosapi'],
-    package_dir={'': 'src'},
+    package_dir={'': 'src'}
 )
 
 setup(**d)

--- a/rosbridge_server/setup.py
+++ b/rosbridge_server/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['tornado', 'tornado.platform'],
-    package_dir={'': 'src'},
+    package_dir={'': 'src'}
 )
 
 setup(**d)


### PR DESCRIPTION
Didn't know if Python would error out about trailing commas. Playing it safe.
