### PR TITLE
 more natural json for call service result

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -75,7 +75,7 @@ class CallService(Capability):
             "op": "service_response",
             "service": service,
             "values": message,
-            "result": "true"
+            "result": True
         }
         if cid is not None:
             outgoing_message["id"] = cid
@@ -89,7 +89,7 @@ class CallService(Capability):
         outgoing_message = {
             "op": "service_response",
             "service": service,
-            "result": "false"
+            "result": False
         }
         if cid is not None:
             outgoing_message["id"] = cid

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -54,7 +54,7 @@ class TestCallService(unittest.TestCase):
 
         time.sleep(0.5)
 
-        self.assertEqual("true", received["msg"]["result"])
+        self.assertTrue(received["msg"]["result"])
         for x, y in zip(ret.loggers, received["msg"]["values"]["loggers"]):
             self.assertEqual(x.name, y["name"])
             self.assertEqual(x.level, y["level"])
@@ -75,7 +75,7 @@ class TestCallService(unittest.TestCase):
 
         time.sleep(0.5)
 
-        self.assertEqual("false", received["msg"]["result"])
+        self.assertFalse(received["msg"]["result"])
 
 
 PKG = 'rosbridge_library'


### PR DESCRIPTION
This patch enable to generate more natural json.
Natural means boolean value in json format.

Current version generates like this.
{id: "call_service:/add_two_ints:1", values: Object, result: "true", service: "/add_two_ints", op: "service_response"}

This patched version:
{id: "call_service:/add_two_ints:1", values: Object, result: true, service: "/add_two_ints", op: "service_response"}
