### PR TITLE
Added error message on result=False

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -89,6 +89,7 @@ class CallService(Capability):
         outgoing_message = {
             "op": "service_response",
             "service": service,
+            "values": str(exc),
             "result": False
         }
         if cid is not None:


### PR DESCRIPTION
When call_service returns False as result, values contains the error message.

Does it make sense to return the error in the field "values" or would it be better to return it in a new field like "message"
