### PR TITLE
Added error message on result=False

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -89,6 +89,7 @@ class CallService(Capability):
         outgoing_message = {
             "op": "service_response",
             "service": service,
+            "values": str(exc),
             "result": False
         }
         if cid is not None:


### PR DESCRIPTION
When call_service returns False as result, values contains the error message.

PORTED from hydro-devel.
