### PR TITLE
support publishing non-ascii letters

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -207,7 +207,7 @@ def _to_primitive_inst(msg, rostype, roottype, stack):
     if msgtype in primitive_types and rostype in type_map[msgtype.__name__]:
         return msg
     elif msgtype in string_types and rostype in type_map[msgtype.__name__]:
-        return msg.encode("ascii", "ignore")
+        return msg.encode("utf-8", "ignore")
     raise FieldTypeMismatchException(roottype, stack, rostype, msgtype)
 
 


### PR DESCRIPTION
All non-ascii letter (e.g. Japanese, Cyrilic, etc.) in ros message is removed because of encoding to ascii.
