### PR TITLE
Fixed wrong unicode encoding

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -207,7 +207,7 @@ def _to_primitive_inst(msg, rostype, roottype, stack):
     if msgtype in primitive_types and rostype in type_map[msgtype.__name__]:
         return msg
     elif msgtype in string_types and rostype in type_map[msgtype.__name__]:
-        return msg.encode("ascii", "ignore")
+        return msg.encode("utf-8", "ignore")
     raise FieldTypeMismatchException(roottype, stack, rostype, msgtype)
 
 


### PR DESCRIPTION
Is there a reason why you used "ascii"?
I ran into the problem that if a message contained a unicode string like `Ölsoße` (represented as type `unicode` in python) it got encoded to `lsoe`.

By changing the line in the commit, this issue got fixed.
