### PR TITLE
Add run_depend on rospy-message-converter

### DIFF
--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -36,6 +36,7 @@
   <run_depend>rostopic</run_depend>
   <run_depend>python-imaging</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>rospy_message_converter</run_depend>
 <!--  <test_depend>roscpp</test_depend>-->
 
 </package>


### PR DESCRIPTION
Pull request #96 introduced a dependency on rospy-message-converter which wasn't declared in the package.xml file, causing an error on rosbridge's startup.
