### PR TITLE
Catch ResponseNotReady properly.

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -63,7 +63,7 @@ def get_param_obsessively(name, d):
     # Workaround to a rospy bug
     try:
         return rospy.get_param(name, d)
-    except CannotSendRequest, ResponseNotReady:
+    except (CannotSendRequest, ResponseNotReady):
         return get_param_obsessively(name, d)
 
 def has_param(name):


### PR DESCRIPTION
Without parens, the catch ends up capturing the CannotSendRequest
exception with the variable name ResponseNotReady.
