### PR TITLE
map Inf and NaN to null

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -108,10 +108,10 @@ def _from_inst(inst, rostype):
 
     # Check for primitive types
     if rostype in ros_primitive_types:
-       #JSON does not support Inf and NaN. They are mapped to 0.
-       if rostype in ["float32", "float64"]:
-          if math.isnan(inst) or math.isinf(inst):
-             return 0
+        #JSON does not support Inf and NaN. They are mapped to 0.
+        if rostype in ["float32", "float64"]:
+            if math.isnan(inst) or math.isinf(inst):
+                return 0
         return inst
 
     # Check if it's a list or tuple


### PR DESCRIPTION
JSON does not support Inf and NaN values. Currently they are just written into the JSON and JSON.parse on the client side will fail. Correct is to map them to null which will then be parsed correctly by JSON.parse on the client side.
The issue with that is that the shortcut for lists of floats might be impossible (maybe someone else with more experience in python comes up with something else?). Maybe something similar is necessary in the to_inst case, but I can not really test them.

Real world application is to process laser scans, they contain inf and nan values for some drivers if the measurements are invalid or out of range.
