### PR TITLE
Windows-related fix for PIL Image module import

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
+++ b/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import Image
+from PIL import Image
 from base64 import standard_b64encode, standard_b64decode
 from StringIO import StringIO
 from math import floor, ceil, sqrt


### PR DESCRIPTION
I'm working on getting rosbridge_suite working in my win64 ROS environment.  The following is a simple python error I ran into in install space out of the box:

```
Traceback (most recent call last):
  File "C:\opt\ros\hydro\x64\lib\rosbridge_server\rosbridge_websocket.py", line 46, in <module>
    from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
  File "C:\opt\ros\hydro\x64\lib\site-packages\rosbridge_library\rosbridge_protocol.py", line 37, in <module>
    from rosbridge_library.capabilities.subscribe import Subscribe
  File "C:\opt\ros\hydro\x64\lib\site-packages\rosbridge_library\capabilities\subscribe.py", line 39, in
<module>
    from rosbridge_library.internal.pngcompression import encode
  File "C:\opt\ros\hydro\x64\lib\site-packages\rosbridge_library\internal\pngcompression.py", line 34, in <module>
    import Image
ImportError: No module named Image
```

As mentioned in the warnings at the top of the Pillow documentation here: http://pillow.readthedocs.org/en/latest/installation.html the use of `import Image` has been deprecated. Although the original works fine on my ubuntu box, it causes the above error in my Win64 python environment. This pull request fixes the issue on windows and should not disrupt other OS distributions.
