### PR TITLE
Handle float infinity and NAN s

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -61,7 +61,7 @@ ros_primitive_types = ["bool", "byte", "char", "int8", "uint8", "int16",
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
 ros_binary_types = ["uint8[]", "char[]"]
 list_braces = re.compile(r'\[[^\]]*\]')
-ros_binary_types_list_braces = [("uint8[]", re.compile(r'uint8\[[^\]]*\]')), 
+ros_binary_types_list_braces = [("uint8[]", re.compile(r'uint8\[[^\]]*\]')),
                                 ("char[]", re.compile(r'char\[[^\]]*\]'))]
 
 
@@ -108,10 +108,10 @@ def _from_inst(inst, rostype):
 
     # Check for primitive types
     if rostype in ros_primitive_types:
-        #JSON does not support Inf and NaN. They are mapped to 0.
+        #JSON does not support Inf and NaN. They are mapped to None and encoded as null.
         if rostype in ["float32", "float64"]:
             if math.isnan(inst) or math.isinf(inst):
-                return 0
+                return None
         return inst
 
     # Check if it's a list or tuple
@@ -129,7 +129,7 @@ def _from_list_inst(inst, rostype):
 
     # Remove the list indicators from the rostype
     rostype = list_braces.sub("", rostype)
-    
+
     # Shortcut for primitives
     if rostype in ros_primitive_types and not rostype in ["float32", "float64"]:
         return list(inst)

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -90,6 +90,13 @@ class TestMessageConversion(unittest.TestCase):
             for rostype in ["float32", "float64"]:
                 self.assertEqual(c._to_primitive_inst(msg, rostype, rostype, []), msg)
                 self.assertEqual(c._to_inst(msg, rostype, rostype), msg)
+                c._to_inst(msg, rostype, rostype)
+
+    def test_float_special_cases(self):
+        for msg in [1e9999999, -1e9999999, float('nan')]:
+            for rostype in ["float32", "float64"]:
+                self.assertEqual(c._from_inst(msg, rostype), None)
+                self.assertEqual(dumps({"data":c._from_inst(msg, rostype)}), "{\"data\": null}")
 
     def test_signed_int_base_msgs(self):
         int8s = range(-127, 128)
@@ -259,10 +266,9 @@ class TestMessageConversion(unittest.TestCase):
             b64str_int8s = standard_b64encode(str_int8s)
             ret = test_int8_msg(rostype, b64str_int8s)
             self.assertEqual(ret, str_int8s)
-            
+
 
 PKG = 'rosbridge_library'
 NAME = 'test_message_conversion'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestMessageConversion)
-


### PR DESCRIPTION
Encoding them as null is better than 0: [roslibjs/issues/#68](https://github.com/RobotWebTools/roslibjs/issues/68#issuecomment-48515539)
