### PR TITLE
remove python-imaging dependency. it is used in rosbridge_library

### DIFF
--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -18,10 +18,8 @@
   <build_depend>rosbridge_library</build_depend>
   <build_depend>rosapi</build_depend>
   <build_depend>rospy</build_depend>
-  <build_depend>python-imaging</build_depend>
   <run_depend>rosbridge_library</run_depend>
   <run_depend>rosapi</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>python-imaging</run_depend>
   <run_depend>rosauth</run_depend>
 </package>


### PR DESCRIPTION
rosbridge_library would only need python-imaging dependency. rosbridge_server does not need this.
