### PR TITLE
setup.py includes all packages (fixes catkin_make install)

### DIFF
--- a/rosbridge_tools/setup.py
+++ b/rosbridge_tools/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['rosbridge_tools'],
+    packages=['rosbridge_tools', 'rosbridge_tools.tornado', 'rosbridge_tools.tornado.platform', 'rosbridge_tools.backports', 'rosbridge_tools.backports.ssl_match_hostname'],
     package_dir={'': 'src'}
 )
 


### PR DESCRIPTION
`catkin_make install` did not install tornado into the install space. This fixes that.
