### PR TITLE
Enabled TCP nodelay in Websocket handler

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -59,6 +59,7 @@ class RosbridgeWebSocket(WebSocketHandler):
         try:
             self.protocol = RosbridgeProtocol(client_id_seed)
             self.protocol.outgoing = self.send_message
+            self.set_nodelay(True)
             self.authenticated = False
             client_id_seed = client_id_seed + 1
             clients_connected = clients_connected + 1


### PR DESCRIPTION
This enables tcp_nodelay for websockets fixing issue #171.