### PR TITLE
Use <test_depend> for test dependencies

### DIFF
--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -20,28 +20,28 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>geometry_msgs</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>rosservice</build_depend>
   <build_depend>rostopic</build_depend>
   <build_depend>python-imaging</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>rosservice</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>stereo_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>rospy_tutorials</run_depend>
-  <run_depend>actionlib_msgs</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>python-imaging</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
 
-  <test_depend>trajectory_msgs</test_depend>
-  <test_depend>tf2_msgs</test_depend>
+  <test_depend>actionlib_msgs</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
+  <test_depend>nav_msgs</test_depend>
+  <test_depend>rospy_tutorials</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
+  <test_depend>stereo_msgs</test_depend>
+  <test_depend>tf2_msgs</test_depend>
+  <test_depend>trajectory_msgs</test_depend>
   <test_depend>visualization_msgs</test_depend>
 </package>


### PR DESCRIPTION
All msgs except `geometry_msgs` are only used in the tests. The `<test_depend>` tag will make sure the generated .debs will not depend on them.

`geometry_msgs` is used to generate a message for a test, and the following thread suggested to still use `<build_depend>` for that: http://answers.ros.org/question/115526/is-test_depend-actually-used-for-anything/ 