### PR TITLE
Stop IOLoop on shutdown.

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -108,10 +108,13 @@ class RosbridgeWebSocket(WebSocketHandler):
     def check_origin(self, origin):
         return True
 
+def shutdown_hook():
+    IOLoop.instance().stop()
+
 if __name__ == "__main__":
     rospy.init_node("rosbridge_websocket")
-    signal(SIGINT, SIG_DFL)
-
+    rospy.on_shutdown(shutdown_hook)    # register shutdown hook to stop the server
+    
     # SSL options
     certfile = rospy.get_param('~certfile', None)
     keyfile = rospy.get_param('~keyfile', None)

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -114,7 +114,7 @@ def shutdown_hook():
 if __name__ == "__main__":
     rospy.init_node("rosbridge_websocket")
     rospy.on_shutdown(shutdown_hook)    # register shutdown hook to stop the server
-    
+
     # SSL options
     certfile = rospy.get_param('~certfile', None)
     keyfile = rospy.get_param('~keyfile', None)


### PR DESCRIPTION
This PR solves issue #181 for me.

The default ROS SIGINT handler is used and on shutdown the tornado server is stopped.