### PR TITLE
Refactor ws and tcp handlers for external use

### DIFF
--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from rospy import init_node, get_param, loginfo, logerr, on_shutdown
-from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
+from rosbridge_server import RosbridgeTcpSocket
 
 from functools import partial
 from signal import signal, SIGINT, SIG_DFL
@@ -13,100 +13,6 @@ import time
 #TODO: take care of socket timeouts and make sure to close sockets after killing programm to release network ports
 
 #TODO: add new parameters to websocket version! those of rosbridge_tcp.py might not be needed, but the others should work well when adding them to .._websocket.py
-
-# Global ID seed for clients
-client_id_seed = 0
-clients_connected = 0
-
-# list of possible parameters ( with internal default values <-- get overwritten from parameter server and commandline)
-# rosbridge_tcp.py:
-port = 9090                             # integer (portnumber)
-host = ""                               # hostname / IP as string
-incoming_buffer = 65536                 # bytes
-socket_timeout = 10                     # seconds
-retry_startup_delay = 5                 # seconds
-# advertise_service.py:
-service_request_timeout = 600           # seconds
-check_response_delay = 0.01             # seconds
-wait_for_busy_service_provider = 0.01   # seconds
-max_service_requests = 1000000          # requests
-# defragmentation.py:
-fragment_timeout = 600                  # seconds
-# protocol.py:
-delay_between_messages = 0.01           # seconds
-max_message_size = None                 # bytes
-
-
-class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
-    """
-    TCP Socket server for rosbridge
-    """
-
-    busy = False
-    queue = []
-
-    def setup(self):
-        global client_id_seed, clients_connected
-        parameters = {
-           "port": port,
-           "host": host,
-           "incoming_buffer": incoming_buffer,
-           "socket_timeout": socket_timeout,
-           "retry_startup_delay": retry_startup_delay,
-           "service_request_timeout": service_request_timeout,
-           "check_response_delay": check_response_delay,
-           "wait_for_busy_service_provider": wait_for_busy_service_provider,
-           "max_service_requests": max_service_requests,
-           "fragment_timeout": fragment_timeout,
-           "delay_between_messages": delay_between_messages,
-           "max_message_size": max_message_size
-         }
-
-        try:
-            self.protocol = RosbridgeProtocol(client_id_seed, parameters = parameters)
-            self.protocol.outgoing = self.send_message
-            client_id_seed = client_id_seed + 1
-            clients_connected = clients_connected + 1
-            self.protocol.log("info", "connected. " + str(clients_connected) + " client total.")
-        except Exception as exc:
-            logerr("Unable to accept incoming connection.  Reason: %s", str(exc))
-
-
-    def handle(self):
-        """
-        Listen for TCP messages
-        """
-        self.request.settimeout(socket_timeout)
-        while 1:
-            try:
-              data = self.request.recv(incoming_buffer)
-              # Exit on empty string
-              if data.strip() == '':
-                  break
-              elif len(data.strip()) > 0:
-                  #time.sleep(5)
-                  self.protocol.incoming(data.strip(''))
-              else:
-                  pass
-            except Exception, e:
-                pass
-                self.protocol.log("debug", "socket connection timed out! (ignore warning if client is only listening..)")
-
-    def finish(self):
-        """
-        Called when TCP connection finishes
-        """
-        global clients_connected
-        clients_connected = clients_connected - 1
-        self.protocol.finish()
-        self.protocol.log("info", "disconnected. " + str(clients_connected) + " client total." )
-
-    def send_message(self, message=None):
-        """
-        Callback from rosbridge
-        """
-
-        self.request.send(message)
 
 
 def shutdown_hook(server):
@@ -135,18 +41,18 @@ if __name__ == "__main__":
 #TODO: check if ROS parameter server uses None string for 'None-value' or Null or something else, then change code accordingly
 
             # update parameters from parameter server or use default value ( second parameter of get_param )
-            port = get_param('~port', port)
-            host = get_param('~host', host)
-            incoming_buffer = get_param('~incoming_buffer', incoming_buffer)
-            socket_timeout = get_param('~socket_timeout', socket_timeout)
-            retry_startup_delay = get_param('~retry_startup_delay', retry_startup_delay)
-            service_request_timeout = get_param('~service_request_timeout', service_request_timeout)
-            check_response_delay = get_param('~check_response_delay', check_response_delay)
-            wait_for_busy_service_provider = get_param('~wait_for_busy_service_provider', wait_for_busy_service_provider)
-            max_service_requests = get_param('~max_service_requests', max_service_requests)
-            fragment_timeout = get_param('~fragment_timeout', fragment_timeout)
-            delay_between_messages = get_param('~delay_between_messages', delay_between_messages)
-            max_message_size = get_param('~max_message_size', max_message_size)
+            port = get_param('~port', RosbridgeTcpSocket.port)
+            host = get_param('~host', RosbridgeTcpSocket.host)
+            incoming_buffer = get_param('~incoming_buffer', RosbridgeTcpSocket.incoming_buffer)
+            socket_timeout = get_param('~socket_timeout', RosbridgeTcpSocket.socket_timeout)
+            retry_startup_delay = get_param('~retry_startup_delay', RosbridgeTcpSocket.retry_startup_delay)
+            service_request_timeout = get_param('~service_request_timeout', RosbridgeTcpSocket.service_request_timeout)
+            check_response_delay = get_param('~check_response_delay', RosbridgeTcpSocket.check_response_delay)
+            wait_for_busy_service_provider = get_param('~wait_for_busy_service_provider', RosbridgeTcpSocket.wait_for_busy_service_provider)
+            max_service_requests = get_param('~max_service_requests', RosbridgeTcpSocket.max_service_requests)
+            fragment_timeout = get_param('~fragment_timeout', RosbridgeTcpSocket.fragment_timeout)
+            delay_between_messages = get_param('~delay_between_messages', RosbridgeTcpSocket.delay_between_messages)
+            max_message_size = get_param('~max_message_size', RosbridgeTcpSocket.max_message_size)
             if max_message_size == "None":
                 max_message_size = None
 
@@ -252,6 +158,20 @@ if __name__ == "__main__":
                 else:
                     print "--max_message_size argument provided without a value. (can be None or <Integer>)"
                     sys.exit(-1)
+
+            # export parameters to handler class
+            RosbridgeTcpSocket.port = port
+            RosbridgeTcpSocket.host = host
+            RosbridgeTcpSocket.incoming_buffer = incoming_buffer
+            RosbridgeTcpSocket.socket_timeout = socket_timeout
+            RosbridgeTcpSocket.retry_startup_delay = retry_startup_delay
+            RosbridgeTcpSocket.service_request_timeout = service_request_timeout
+            RosbridgeTcpSocket.check_response_delay = check_response_delay
+            RosbridgeTcpSocket.wait_for_busy_service_provider = wait_for_busy_service_provider
+            RosbridgeTcpSocket.max_service_requests = max_service_requests
+            RosbridgeTcpSocket.fragment_timeout = fragment_timeout
+            RosbridgeTcpSocket.delay_between_messages = delay_between_messages
+            RosbridgeTcpSocket.max_message_size = max_message_size
 
             """
             ...END (parameter handling)

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -34,81 +34,14 @@
 import rospy
 import sys
 
-from rosauth.srv import Authentication
-
-from signal import signal, SIGINT, SIG_DFL
-from functools import partial
 from socket import error
 
 from tornado.ioloop import IOLoop
 from tornado.ioloop import PeriodicCallback
 from tornado.web import Application
-from tornado.websocket import WebSocketHandler
 
-from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
-from rosbridge_library.util import json
+from rosbridge_server import RosbridgeWebSocket
 
-# Global ID seed for clients
-client_id_seed = 0
-clients_connected = 0
-# if authentication should be used
-authenticate = False
-
-class RosbridgeWebSocket(WebSocketHandler):
-
-    def open(self):
-        global client_id_seed, clients_connected, authenticate
-        try:
-            self.protocol = RosbridgeProtocol(client_id_seed)
-            self.protocol.outgoing = self.send_message
-            self.set_nodelay(True)
-            self.authenticated = False
-            client_id_seed = client_id_seed + 1
-            clients_connected = clients_connected + 1
-        except Exception as exc:
-            rospy.logerr("Unable to accept incoming connection.  Reason: %s", str(exc))
-        rospy.loginfo("Client connected.  %d clients total.", clients_connected)
-        if authenticate:
-            rospy.loginfo("Awaiting proper authentication...")
-
-    def on_message(self, message):
-        global authenticate
-        # check if we need to authenticate
-        if authenticate and not self.authenticated:
-            try:
-                msg = json.loads(message)
-                if msg['op'] == 'auth':
-                    # check the authorization information
-                    auth_srv = rospy.ServiceProxy('authenticate', Authentication)
-                    resp = auth_srv(msg['mac'], msg['client'], msg['dest'],
-                                                  msg['rand'], rospy.Time(msg['t']), msg['level'],
-                                                  rospy.Time(msg['end']))
-                    self.authenticated = resp.authenticated
-                    if self.authenticated:
-                        rospy.loginfo("Client %d has authenticated.", self.protocol.client_id)
-                        return
-                # if we are here, no valid authentication was given
-                rospy.logwarn("Client %d did not authenticate. Closing connection.",
-                              self.protocol.client_id)
-                self.close()
-            except:
-                # proper error will be handled in the protocol class
-                self.protocol.incoming(message)
-        else:
-            # no authentication required
-            self.protocol.incoming(message)
-
-    def on_close(self):
-        global clients_connected
-        clients_connected = clients_connected - 1
-        self.protocol.finish()
-        rospy.loginfo("Client disconnected. %d clients total.", clients_connected)
-
-    def send_message(self, message):
-        IOLoop.instance().add_callback(partial(self.write_message, message))
-
-    def check_origin(self, origin):
-        return True
 
 def shutdown_hook():
     IOLoop.instance().stop()
@@ -121,7 +54,7 @@ if __name__ == "__main__":
     certfile = rospy.get_param('~certfile', None)
     keyfile = rospy.get_param('~keyfile', None)
     # if authentication should be used
-    authenticate = rospy.get_param('~authenticate', False)
+    RosbridgeWebSocket.authenticate = rospy.get_param('~authenticate', False)
     port = rospy.get_param('~port', 9090)
     address = rospy.get_param('~address', "")
 

--- a/rosbridge_server/setup.py
+++ b/rosbridge_server/setup.py
@@ -9,7 +9,13 @@ from distutils.core import setup, Extension
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['backports', 'backports.ssl_match_hostname', 'tornado', 'tornado.platform'],
+    packages=[
+        'rosbridge_server',
+        'backports',
+        'backports.ssl_match_hostname',
+        'tornado',
+        'tornado.platform'
+    ],
     package_dir={'': 'src'}
 )
 

--- a/rosbridge_server/src/rosbridge_server/__init__.py
+++ b/rosbridge_server/src/rosbridge_server/__init__.py
@@ -1,0 +1,2 @@
+from websocket_handler import RosbridgeWebSocket
+

--- a/rosbridge_server/src/rosbridge_server/__init__.py
+++ b/rosbridge_server/src/rosbridge_server/__init__.py
@@ -1,2 +1,2 @@
 from websocket_handler import RosbridgeWebSocket
-
+from tcp_handler import RosbridgeTcpSocket

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -1,0 +1,94 @@
+import rospy
+from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
+
+import SocketServer
+
+
+class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
+    """
+    TCP Socket server for rosbridge
+    """
+
+    busy = False
+    queue = []
+    client_id_seed = 0
+    clients_connected = 0
+
+    # list of possible parameters ( with internal default values
+    port = 9090                             # integer (portnumber)
+    host = ""                               # hostname / IP as string
+    incoming_buffer = 65536                 # bytes
+    socket_timeout = 10                     # seconds
+    retry_startup_delay = 5                 # seconds
+    # advertise_service.py:
+    service_request_timeout = 600           # seconds
+    check_response_delay = 0.01             # seconds
+    wait_for_busy_service_provider = 0.01   # seconds
+    max_service_requests = 1000000          # requests
+    # defragmentation.py:
+    fragment_timeout = 600                  # seconds
+    # protocol.py:
+    delay_between_messages = 0.01           # seconds
+    max_message_size = None                 # bytes
+
+    def setup(self):
+        cls = self.__class__
+        parameters = {
+           "port": cls.port,
+           "host": cls.host,
+           "incoming_buffer": cls.incoming_buffer,
+           "socket_timeout": cls.socket_timeout,
+           "retry_startup_delay": cls.retry_startup_delay,
+           "service_request_timeout": cls.service_request_timeout,
+           "check_response_delay": cls.check_response_delay,
+           "wait_for_busy_service_provider": cls.wait_for_busy_service_provider,
+           "max_service_requests": cls.max_service_requests,
+           "fragment_timeout": cls.fragment_timeout,
+           "delay_between_messages": cls.delay_between_messages,
+           "max_message_size": cls.max_message_size
+         }
+
+        try:
+            self.protocol = RosbridgeProtocol(cls.client_id_seed, parameters = parameters)
+            self.protocol.outgoing = self.send_message
+            cls.client_id_seed += 1
+            cls.clients_connected += 1
+            self.protocol.log("info", "connected. " + str(cls.clients_connected) + " client total.")
+        except Exception as exc:
+            rospy.logerr("Unable to accept incoming connection.  Reason: %s", str(exc))
+
+    def handle(self):
+        """
+        Listen for TCP messages
+        """
+        cls = self.__class__
+        self.request.settimeout(cls.socket_timeout)
+        while 1:
+            try:
+              data = self.request.recv(cls.incoming_buffer)
+              # Exit on empty string
+              if data.strip() == '':
+                  break
+              elif len(data.strip()) > 0:
+                  self.protocol.incoming(data.strip(''))
+              else:
+                  pass
+            except Exception, e:
+                pass
+                self.protocol.log("debug", "socket connection timed out! (ignore warning if client is only listening..)")
+
+    def finish(self):
+        """
+        Called when TCP connection finishes
+        """
+        cls = self.__class__
+        cls.clients_connected -= 1
+        self.protocol.finish()
+        self.protocol.log("info", "disconnected. " + str(cls.clients_connected) + " client total." )
+
+    def send_message(self, message=None):
+        """
+        Callback from rosbridge
+        """
+
+        self.request.send(message)

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -34,19 +34,19 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     def setup(self):
         cls = self.__class__
         parameters = {
-           "port": cls.port,
-           "host": cls.host,
-           "incoming_buffer": cls.incoming_buffer,
-           "socket_timeout": cls.socket_timeout,
-           "retry_startup_delay": cls.retry_startup_delay,
-           "service_request_timeout": cls.service_request_timeout,
-           "check_response_delay": cls.check_response_delay,
-           "wait_for_busy_service_provider": cls.wait_for_busy_service_provider,
-           "max_service_requests": cls.max_service_requests,
-           "fragment_timeout": cls.fragment_timeout,
-           "delay_between_messages": cls.delay_between_messages,
-           "max_message_size": cls.max_message_size
-         }
+            "port": cls.port,
+            "host": cls.host,
+            "incoming_buffer": cls.incoming_buffer,
+            "socket_timeout": cls.socket_timeout,
+            "retry_startup_delay": cls.retry_startup_delay,
+            "service_request_timeout": cls.service_request_timeout,
+            "check_response_delay": cls.check_response_delay,
+            "wait_for_busy_service_provider": cls.wait_for_busy_service_provider,
+            "max_service_requests": cls.max_service_requests,
+            "fragment_timeout": cls.fragment_timeout,
+            "delay_between_messages": cls.delay_between_messages,
+            "max_message_size": cls.max_message_size
+        }
 
         try:
             self.protocol = RosbridgeProtocol(cls.client_id_seed, parameters = parameters)

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -1,0 +1,103 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2012, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+
+from rosauth.srv import Authentication
+
+from functools import partial
+
+from tornado.ioloop import IOLoop
+from tornado.websocket import WebSocketHandler
+
+from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
+from rosbridge_library.util import json
+
+
+class RosbridgeWebSocket(WebSocketHandler):
+    client_id_seed = 0
+    clients_connected = 0
+    authenticate = False
+
+    def open(self):
+        cls = self.__class__
+        try:
+            self.protocol = RosbridgeProtocol(cls.client_id_seed)
+            self.protocol.outgoing = self.send_message
+            self.set_nodelay(True)
+            self.authenticated = False
+            cls.client_id_seed += 1
+            cls.clients_connected += 1
+        except Exception as exc:
+            rospy.logerr("Unable to accept incoming connection.  Reason: %s", str(exc))
+        rospy.loginfo("Client connected.  %d clients total.", cls.clients_connected)
+        if cls.authenticate:
+            rospy.loginfo("Awaiting proper authentication...")
+
+    def on_message(self, message):
+        cls = self.__class__
+        # check if we need to authenticate
+        if cls.authenticate and not self.authenticated:
+            try:
+                msg = json.loads(message)
+                if msg['op'] == 'auth':
+                    # check the authorization information
+                    auth_srv = rospy.ServiceProxy('authenticate', Authentication)
+                    resp = auth_srv(msg['mac'], msg['client'], msg['dest'],
+                                                  msg['rand'], rospy.Time(msg['t']), msg['level'],
+                                                  rospy.Time(msg['end']))
+                    self.authenticated = resp.authenticated
+                    if self.authenticated:
+                        rospy.loginfo("Client %d has authenticated.", self.protocol.client_id)
+                        return
+                # if we are here, no valid authentication was given
+                rospy.logwarn("Client %d did not authenticate. Closing connection.",
+                              self.protocol.client_id)
+                self.close()
+            except:
+                # proper error will be handled in the protocol class
+                self.protocol.incoming(message)
+        else:
+            # no authentication required
+            self.protocol.incoming(message)
+
+    def on_close(self):
+        cls = self.__class__
+        cls.clients_connected -= 1
+        self.protocol.finish()
+        rospy.loginfo("Client disconnected. %d clients total.", cls.clients_connected)
+
+    def send_message(self, message):
+        IOLoop.instance().add_callback(partial(self.write_message, message))
+
+    def check_origin(self, origin):
+        return True


### PR DESCRIPTION
These changes move `RosbridgeWebSocket` and `RosbridgeTcpServer` into their own exported modules.  This allows an implementer to include the ws handler in a Tornado Application or embed the tcp handler in another node.

I wanted to do two things with my ROS node:

* Run a static or dynamic web server hitting the same state/logic class as rospy pub/sub.
* Decentralize rosbridge and add it as a handler on that web server.

This simplifies the webapp, it no longer needs to make any assumptions or queries about where to find rosbridge.  In this case, rosbridge is treated as a node component as opposed to a service riding on the graph, with the caveat that topic pub/sub implementations may override settings from elsewhere in the same node.