### PR TITLE
Add default strings for certfile and keyfile

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -2,8 +2,8 @@
   <arg name="port" default="9090" />
   <arg name="address" default="" />
   <arg name="ssl" default="false" />
-  <arg name="certfile" />
-  <arg name="keyfile" />
+  <arg name="certfile" default=""/>
+  <arg name="keyfile" default="" />
   <arg name="authenticate" default="false" />
   
   <group if="$(arg ssl)">


### PR DESCRIPTION
This allows downstream packages with roslaunch_add_file_check tests to pass.