### PR TITLE
Eliminate memory exhaustion on webserver with high rate, LARGE binary data

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -244,7 +244,7 @@ class Protocol:
                     time.sleep(self.delay_between_messages)
             # else send message as it is
             else:
-                self.outgoing(serialized)
+                self.outgoing(serialized, message.get("topic"))
                 time.sleep(self.delay_between_messages)
 
     def finish(self):


### PR DESCRIPTION
In using rosbridge, I was passing VERY dense, LARGE pointclouds at 20Hz.  I noticed that after a while, the tornado write buffer for the websocket was monotonically increasing because the web client wasn't pulling data as fast as it was written.

This simple change addresses this by creating blocking binary data on a topic until the tornado websocket buffer is flushed out.  This keeps the tornado buffer from monotonically increasing and filling up system memory until the entire machine crashes.