### PR TITLE
Allow TCP Server to reuse address after restart

### DIFF
--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -180,6 +180,7 @@ if __name__ == "__main__":
 
             # Server host is a tuple ('host', port)
             # empty string for host makes server listen on all available interfaces
+            SocketServer.ThreadingTCPServer.allow_reuse_address = True
             server = SocketServer.ThreadingTCPServer((host, port), RosbridgeTcpSocket)
             on_shutdown(partial(shutdown_hook, server))
 


### PR DESCRIPTION
After killing (Ctrl-C) a rosbridge_tcp server instance which has
connected clients, starting a new instance (on the same port) can
fail with the error: '[Errno 98] Address already in use'. Although the
node retries until the server starts, this can take up to a few minutes.

Instruct the ThreadingTCPServer to allow the reuse of the same address.