### PR TITLE
clean up parameters and handling

### DIFF
--- a/rosbridge_server/launch/rosbridge_tcp.launch
+++ b/rosbridge_server/launch/rosbridge_tcp.launch
@@ -1,61 +1,29 @@
 <launch>
   <arg name="port" default="9090" />
-
   <arg name="host" default="" />
+
   <arg name="incoming_buffer" default="65536" />
   <arg name="socket_timeout" default="10" />
   <arg name="retry_startup_delay" default="5" />
-  <arg name="service_request_timeout" default="600" />
-  <arg name="check_response_delay" default="0.1" />
-  <arg name="wait_for_busy_service_provider" default="0.1" />
-  <arg name="max_service_requests" default="1000000" />
+
   <arg name="fragment_timeout" default="600" />
-  <arg name="delay_between_messages" default="0.01" />
+  <arg name="delay_between_messages" default="0" />
   <arg name="max_message_size" default="None" />
 
-  <arg name="ssl" default="false" />
-  <arg name="certfile" />
-  <arg name="keyfile" />
   <arg name="authenticate" default="false" />
-  
-  <group if="$(arg ssl)">
-    <node name="rosbridge_tcp" pkg="rosbridge_server" type="rosbridge_tcp" output="screen">
-      <param name="certfile" value="$(arg certfile)" />
-      <param name="keyfile" value="$(arg keyfile)" />
-      <param name="authenticate" value="$(arg authenticate)" />
 
-      <param name="port" value="$(arg port)"/>
-      <param name="host" value="$(arg host)"/>
-      <param name="incoming_buffer" value="$(arg incoming_buffer)"/>
-      <param name="socket_timeout" value="$(arg socket_timeout)"/>
-      <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
-      <param name="service_request_timeout" value="$(arg service_request_timeout)"/>
-      <param name="check_response_delay" value="$(arg check_response_delay)"/>
-      <param name="wait_for_busy_service_provider" value="$(arg wait_for_busy_service_provider)"/>
-      <param name="max_service_requests" value="$(arg max_service_requests)"/>
-      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
-      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
-      <param name="max_message_size" value="$(arg max_message_size)"/>
-    </node>
-  </group>
-  <group unless="$(arg ssl)">
-    <node name="rosbridge_tcp" pkg="rosbridge_server" type="rosbridge_tcp" output="screen">
-      <param name="authenticate" value="$(arg authenticate)" />
+  <node name="rosbridge_tcp" pkg="rosbridge_server" type="rosbridge_tcp" output="screen">
+    <param name="authenticate" value="$(arg authenticate)" />
 
-      <param name="port" value="$(arg port)"/>
-      <param name="host" value="$(arg host)"/>
-      <param name="incoming_buffer" value="$(arg incoming_buffer)"/>
-      <param name="socket_timeout" value="$(arg socket_timeout)"/>
-      <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
-      <param name="service_request_timeout" value="$(arg service_request_timeout)"/>
-      <param name="check_response_delay" value="$(arg check_response_delay)"/>
-      <param name="wait_for_busy_service_provider" value="$(arg wait_for_busy_service_provider)"/>
-      <param name="max_service_requests" value="$(arg max_service_requests)"/>
-      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
-      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
-      <param name="max_message_size" value="$(arg max_message_size)"/>
-    </node>
-  </group>
-  
+    <param name="port" value="$(arg port)"/>
+    <param name="host" value="$(arg host)"/>
+    <param name="incoming_buffer" value="$(arg incoming_buffer)"/>
+    <param name="socket_timeout" value="$(arg socket_timeout)"/>
+    <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
+    <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
+    <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
+    <param name="max_message_size" value="$(arg max_message_size)"/>
+  </node>
+
   <node name="rosapi" pkg="rosapi" type="rosapi_node" />
 </launch>

--- a/rosbridge_server/launch/rosbridge_udp.launch
+++ b/rosbridge_server/launch/rosbridge_udp.launch
@@ -13,7 +13,6 @@
 
     <param name="port" value="$(arg port)"/>
     <param name="interface" value="$(arg interface)"/>
-    <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
     <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
     <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
     <param name="max_message_size" value="$(arg max_message_size)"/>

--- a/rosbridge_server/launch/rosbridge_udp.launch
+++ b/rosbridge_server/launch/rosbridge_udp.launch
@@ -1,61 +1,23 @@
 <launch>
   <arg name="port" default="9090" />
+  <arg name="interface" default="" />
 
-  <arg name="host" default="" />
-  <arg name="incoming_buffer" default="65536" />
-  <arg name="socket_timeout" default="10" />
-  <arg name="retry_startup_delay" default="5" />
-  <arg name="service_request_timeout" default="600" />
-  <arg name="check_response_delay" default="0.1" />
-  <arg name="wait_for_busy_service_provider" default="0.1" />
-  <arg name="max_service_requests" default="1000000" />
   <arg name="fragment_timeout" default="600" />
-  <arg name="delay_between_messages" default="0.01" />
+  <arg name="delay_between_messages" default="0" />
   <arg name="max_message_size" default="None" />
 
-  <arg name="ssl" default="false" />
-  <arg name="certfile" />
-  <arg name="keyfile" />
   <arg name="authenticate" default="false" />
-  
-  <group if="$(arg ssl)">
-    <node name="rosbridge_udp" pkg="rosbridge_server" type="rosbridge_udp" output="screen">
-      <param name="certfile" value="$(arg certfile)" />
-      <param name="keyfile" value="$(arg keyfile)" />
-      <param name="authenticate" value="$(arg authenticate)" />
 
-      <param name="port" value="$(arg port)"/>
-      <param name="host" value="$(arg host)"/>
-      <param name="incoming_buffer" value="$(arg incoming_buffer)"/>
-      <param name="socket_timeout" value="$(arg socket_timeout)"/>
-      <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
-      <param name="service_request_timeout" value="$(arg service_request_timeout)"/>
-      <param name="check_response_delay" value="$(arg check_response_delay)"/>
-      <param name="wait_for_busy_service_provider" value="$(arg wait_for_busy_service_provider)"/>
-      <param name="max_service_requests" value="$(arg max_service_requests)"/>
-      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
-      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
-      <param name="max_message_size" value="$(arg max_message_size)"/>
-    </node>
-  </group>
-  <group unless="$(arg ssl)">
-    <node name="rosbridge_udp" pkg="rosbridge_server" type="rosbridge_udp" output="screen">
-      <param name="authenticate" value="$(arg authenticate)" />
+  <node name="rosbridge_udp" pkg="rosbridge_server" type="rosbridge_udp" output="screen">
+    <param name="authenticate" value="$(arg authenticate)" />
 
-      <param name="port" value="$(arg port)"/>
-      <param name="host" value="$(arg host)"/>
-      <param name="incoming_buffer" value="$(arg incoming_buffer)"/>
-      <param name="socket_timeout" value="$(arg socket_timeout)"/>
-      <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
-      <param name="service_request_timeout" value="$(arg service_request_timeout)"/>
-      <param name="check_response_delay" value="$(arg check_response_delay)"/>
-      <param name="wait_for_busy_service_provider" value="$(arg wait_for_busy_service_provider)"/>
-      <param name="max_service_requests" value="$(arg max_service_requests)"/>
-      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
-      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
-      <param name="max_message_size" value="$(arg max_message_size)"/>
-    </node>
-  </group>
-  
+    <param name="port" value="$(arg port)"/>
+    <param name="interface" value="$(arg interface)"/>
+    <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
+    <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
+    <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
+    <param name="max_message_size" value="$(arg max_message_size)"/>
+  </node>
+
   <node name="rosapi" pkg="rosapi" type="rosapi_node" />
 </launch>

--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -4,8 +4,15 @@
   <arg name="ssl" default="false" />
   <arg name="certfile" default=""/>
   <arg name="keyfile" default="" />
+
+  <arg name="retry_startup_delay" default="5" />
+
+  <arg name="fragment_timeout" default="600" />
+  <arg name="delay_between_messages" default="0" />
+  <arg name="max_message_size" default="None" />
+
   <arg name="authenticate" default="false" />
-  
+
   <group if="$(arg ssl)">
     <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket" output="screen">
       <param name="certfile" value="$(arg certfile)" />
@@ -13,6 +20,10 @@
       <param name="authenticate" value="$(arg authenticate)" />
       <param name="port" value="$(arg port)"/>
       <param name="address" value="$(arg address)"/>
+      <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
+      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
+      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
+      <param name="max_message_size" value="$(arg max_message_size)"/>
     </node>
   </group>
   <group unless="$(arg ssl)">
@@ -20,8 +31,12 @@
       <param name="authenticate" value="$(arg authenticate)" />
       <param name="port" value="$(arg port)"/>
       <param name="address" value="$(arg address)"/>
+      <param name="retry_startup_delay" value="$(arg retry_startup_delay)"/>
+      <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
+      <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
+      <param name="max_message_size" value="$(arg max_message_size)"/>
     </node>
   </group>
-  
+
   <node name="rosapi" pkg="rosapi" type="rosapi_node" />
 </launch>

--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -41,15 +41,11 @@ if __name__ == "__main__":
 #TODO: check if ROS parameter server uses None string for 'None-value' or Null or something else, then change code accordingly
 
             # update parameters from parameter server or use default value ( second parameter of get_param )
-            port = get_param('~port', RosbridgeTcpSocket.port)
-            host = get_param('~host', RosbridgeTcpSocket.host)
+            port = get_param('~port', 9090)
+            host = get_param('~host', '')
             incoming_buffer = get_param('~incoming_buffer', RosbridgeTcpSocket.incoming_buffer)
             socket_timeout = get_param('~socket_timeout', RosbridgeTcpSocket.socket_timeout)
-            retry_startup_delay = get_param('~retry_startup_delay', RosbridgeTcpSocket.retry_startup_delay)
-            service_request_timeout = get_param('~service_request_timeout', RosbridgeTcpSocket.service_request_timeout)
-            check_response_delay = get_param('~check_response_delay', RosbridgeTcpSocket.check_response_delay)
-            wait_for_busy_service_provider = get_param('~wait_for_busy_service_provider', RosbridgeTcpSocket.wait_for_busy_service_provider)
-            max_service_requests = get_param('~max_service_requests', RosbridgeTcpSocket.max_service_requests)
+            retry_startup_delay = get_param('~retry_startup_delay', 5.0)  # seconds
             fragment_timeout = get_param('~fragment_timeout', RosbridgeTcpSocket.fragment_timeout)
             delay_between_messages = get_param('~delay_between_messages', RosbridgeTcpSocket.delay_between_messages)
             max_message_size = get_param('~max_message_size', RosbridgeTcpSocket.max_message_size)
@@ -99,38 +95,6 @@ if __name__ == "__main__":
                     print "--retry_startup_delay argument provided without a value."
                     sys.exit(-1)
 
-            if "--service_request_timeout" in sys.argv:
-                idx = sys.argv.index("--service_request_timeout") + 1
-                if idx < len(sys.argv):
-                    service_request_timeout = int(sys.argv[idx])
-                else:
-                    print "--service_request_timeout argument provided without a value."
-                    sys.exit(-1)
-
-            if "--check_response_delay" in sys.argv:
-                idx = sys.argv.index("--check_response_delay") + 1
-                if idx < len(sys.argv):
-                    check_response_delay = float(sys.argv[idx])
-                else:
-                    print "--check_response_delay argument provided without a value."
-                    sys.exit(-1)
-
-            if "--wait_for_busy_service_provider" in sys.argv:
-                idx = sys.argv.index("--wait_for_busy_service_provider") + 1
-                if idx < len(sys.argv):
-                    wait_for_busy_service_provider = float(sys.argv[idx])
-                else:
-                    print "--wait_for_busy_service_provider argument provided without a value."
-                    sys.exit(-1)
-
-            if "--max_service_requests" in sys.argv:
-                idx = sys.argv.index("--max_service_requests") + 1
-                if idx < len(sys.argv):
-                    max_service_requests = int(sys.argv[idx])
-                else:
-                    print "--max_service_requests argument provided without a value."
-                    sys.exit(-1)
-
             if "--fragment_timeout" in sys.argv:
                 idx = sys.argv.index("--fragment_timeout") + 1
                 if idx < len(sys.argv):
@@ -160,15 +124,8 @@ if __name__ == "__main__":
                     sys.exit(-1)
 
             # export parameters to handler class
-            RosbridgeTcpSocket.port = port
-            RosbridgeTcpSocket.host = host
             RosbridgeTcpSocket.incoming_buffer = incoming_buffer
             RosbridgeTcpSocket.socket_timeout = socket_timeout
-            RosbridgeTcpSocket.retry_startup_delay = retry_startup_delay
-            RosbridgeTcpSocket.service_request_timeout = service_request_timeout
-            RosbridgeTcpSocket.check_response_delay = check_response_delay
-            RosbridgeTcpSocket.wait_for_busy_service_provider = wait_for_busy_service_provider
-            RosbridgeTcpSocket.max_service_requests = max_service_requests
             RosbridgeTcpSocket.fragment_timeout = fragment_timeout
             RosbridgeTcpSocket.delay_between_messages = delay_between_messages
             RosbridgeTcpSocket.max_message_size = max_message_size

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -50,6 +50,21 @@ if __name__ == "__main__":
     rospy.init_node("rosbridge_websocket")
     rospy.on_shutdown(shutdown_hook)    # register shutdown hook to stop the server
 
+    ##################################################
+    # Parameter handling                             #
+    ##################################################
+    retry_startup_delay = get_param('~retry_startup_delay', 2.0)  # seconds
+
+    # get RosbridgeProtocol parameters
+    RosbridgeWebSocket.fragment_timeout = get_param('~fragment_timeout',
+                                                    RosbridgeWebSocket.fragment_timeout)
+    RosbridgeWebSocket.delay_between_messages = get_param('~delay_between_messages',
+                                                          RosbridgeWebSocket.delay_between_messages)
+    RosbridgeWebSocket.max_message_size = get_param('~max_message_size',
+                                                    RosbridgeWebSocket.max_message_size)
+    if RosbridgeWebSocket.max_message_size == "None":
+        RosbridgeWebSocket.max_message_size = None
+
     # SSL options
     certfile = rospy.get_param('~certfile', None)
     keyfile = rospy.get_param('~keyfile', None)
@@ -66,6 +81,54 @@ if __name__ == "__main__":
             print "--port argument provided without a value."
             sys.exit(-1)
 
+    if "--address" in sys.argv:
+        idx = sys.argv.index("--address")+1
+        if idx < len(sys.argv):
+            address = int(sys.argv[idx])
+        else:
+            print "--address argument provided without a value."
+            sys.exit(-1)
+
+    if "--retry_startup_delay" in sys.argv:
+        idx = sys.argv.index("--retry_startup_delay") + 1
+        if idx < len(sys.argv):
+            retry_startup_delay = int(sys.argv[idx])
+        else:
+            print "--retry_startup_delay argument provided without a value."
+            sys.exit(-1)
+
+    if "--fragment_timeout" in sys.argv:
+        idx = sys.argv.index("--fragment_timeout") + 1
+        if idx < len(sys.argv):
+            RosbridgeWebSocket.fragment_timeout = int(sys.argv[idx])
+        else:
+            print "--fragment_timeout argument provided without a value."
+            sys.exit(-1)
+
+    if "--delay_between_messages" in sys.argv:
+        idx = sys.argv.index("--delay_between_messages") + 1
+        if idx < len(sys.argv):
+            RosbridgeWebSocket.delay_between_messages = float(sys.argv[idx])
+        else:
+            print "--delay_between_messages argument provided without a value."
+            sys.exit(-1)
+
+    if "--max_message_size" in sys.argv:
+        idx = sys.argv.index("--max_message_size") + 1
+        if idx < len(sys.argv):
+            value = sys.argv[idx]
+            if value == "None":
+                RosbridgeWebSocket.max_message_size = None
+            else:
+                RosbridgeWebSocket.max_message_size = int(value)
+        else:
+            print "--max_message_size argument provided without a value. (can be None or <Integer>)"
+            sys.exit(-1)
+
+    ##################################################
+    # Done with parameter handling                   #
+    ##################################################
+
     application = Application([(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)])
 
     connected = False
@@ -78,7 +141,8 @@ if __name__ == "__main__":
             rospy.loginfo("Rosbridge WebSocket server started on port %d", port)
             connected = True
         except error as e:
-            rospy.logwarn("Unable to start server: " + str(e) + " Retrying in 2s.")
-            rospy.sleep(2.)
+            rospy.logwarn("Unable to start server: " + str(e) +
+                          " Retrying in " + str(retry_startup_delay) + "s.")
+            rospy.sleep(retry_startup_delay)
 
     IOLoop.instance().start()

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -13,35 +13,19 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     client_id_seed = 0
     clients_connected = 0
 
-    # list of possible parameters ( with internal default values
-    port = 9090                             # integer (portnumber)
-    host = ""                               # hostname / IP as string
+    # list of parameters
     incoming_buffer = 65536                 # bytes
     socket_timeout = 10                     # seconds
-    retry_startup_delay = 5                 # seconds
-    # advertise_service.py:
-    service_request_timeout = 600           # seconds
-    check_response_delay = 0.01             # seconds
-    wait_for_busy_service_provider = 0.01   # seconds
-    max_service_requests = 1000000          # requests
+    # The following are passed on to RosbridgeProtocol
     # defragmentation.py:
     fragment_timeout = 600                  # seconds
     # protocol.py:
-    delay_between_messages = 0.01           # seconds
+    delay_between_messages = 0              # seconds
     max_message_size = None                 # bytes
 
     def setup(self):
         cls = self.__class__
         parameters = {
-            "port": cls.port,
-            "host": cls.host,
-            "incoming_buffer": cls.incoming_buffer,
-            "socket_timeout": cls.socket_timeout,
-            "retry_startup_delay": cls.retry_startup_delay,
-            "service_request_timeout": cls.service_request_timeout,
-            "check_response_delay": cls.check_response_delay,
-            "wait_for_busy_service_provider": cls.wait_for_busy_service_provider,
-            "max_service_requests": cls.max_service_requests,
             "fragment_timeout": cls.fragment_timeout,
             "delay_between_messages": cls.delay_between_messages,
             "max_message_size": cls.max_message_size

--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -22,11 +22,25 @@ class RosbridgeUdpSocket:
     client_id_seed = 0
     clients_connected = 0
     authenticate = False
+
+    # The following parameters are passed on to RosbridgeProtocol
+    # defragmentation.py:
+    fragment_timeout = 600                  # seconds
+    # protocol.py:
+    delay_between_messages = 0              # seconds
+    max_message_size = None                 # bytes
+
     def __init__(self,write):
         self.write = write
+        self.authenticated = False
 
     def startProtocol(self):
         cls = self.__class__
+        parameters = {
+            "fragment_timeout": cls.fragment_timeout,
+            "delay_between_messages": cls.delay_between_messages,
+            "max_message_size": cls.max_message_size
+        }
         try:
             self.protocol = RosbridgeProtocol(cls.client_id_seed)
             self.protocol.outgoing = self.send_message

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -48,8 +48,20 @@ class RosbridgeWebSocket(WebSocketHandler):
     clients_connected = 0
     authenticate = False
 
+    # The following are passed on to RosbridgeProtocol
+    # defragmentation.py:
+    fragment_timeout = 600                  # seconds
+    # protocol.py:
+    delay_between_messages = 0              # seconds
+    max_message_size = None                 # bytes
+
     def open(self):
         cls = self.__class__
+        parameters = {
+            "fragment_timeout": cls.fragment_timeout,
+            "delay_between_messages": cls.delay_between_messages,
+            "max_message_size": cls.max_message_size
+        }
         try:
             self.protocol = RosbridgeProtocol(cls.client_id_seed)
             self.protocol.outgoing = self.send_message


### PR DESCRIPTION
This is a follow-up to #204 

* make parameters accessible via parameter server for all three versions
* remove old advertise_service parameters
* UDP and TCP can't do SSL
* TCP can't authenticate yet (because the RosbridgeTcpSocket class is instantiated for each request and hence does not hold state)
* UDP does not take a hostname or address, but rather an interface

**Note:** I haven't tested these changes yet! I'll be able to do so tomorrow, at least to see whether the launch files still work. I only have access to a system using ```rosbridge_websocket``` not the TCP or UDP version.