### PR TITLE
Abort websocket server listen() retry on shutdown

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     application = Application([(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)])
 
     connected = False
-    while(not connected):
+    while not connected and not rospy.is_shutdown():
         try:
             if certfile is not None and keyfile is not None:
                 application.listen(port, address, ssl_options={ "certfile": certfile, "keyfile": keyfile})


### PR DESCRIPTION
This allows the server to shut down via SIGINT or SIGTERM during its listen() retry loop.