### PR TITLE
Fix UDP handler shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.iml
+*.swp
 .project
 .pydevproject
 .DS_Store

--- a/rosbridge_server/scripts/rosbridge_udp.py
+++ b/rosbridge_server/scripts/rosbridge_udp.py
@@ -38,7 +38,7 @@ from socket import error
 from twisted.internet import reactor
 from rosbridge_server import RosbridgeUdpSocket,RosbridgeUdpFactory
 def shutdown_hook():
-    pass
+    reactor.stop()
 if __name__ == "__main__":
     rospy.init_node("rosbridge_websocket")
     rospy.on_shutdown(shutdown_hook)    # register shutdown hook to stop the server


### PR DESCRIPTION
* Update `.gitignore`
* Isolate rosbridge_server libraries from unnecessary imports
* Stop UDP server on ROS shutdown