### PR TITLE
Fixed deprecated code in pillow

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
+++ b/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
@@ -45,7 +45,7 @@ def encode(string):
     while length < bytes_needed:
         string += '\n'
         length += 1
-    i = Image.fromstring('RGB', (int(width), int(height)), string)
+    i = Image.frombytes('RGB', (int(width), int(height)), string)
     buff = StringIO()
     i.save(buff, "png")
     encoded = standard_b64encode(buff.getvalue())


### PR DESCRIPTION
fromstring() method was completely removed since pillow 3.0.0 (https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#300-2015-10-01) and now has a direct replacement. 