### PR TITLE
Type conversion convention correction, correcting issue #240

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -50,7 +50,7 @@ type_map = {
    "float":   ["float32", "float64"],
    "str":     ["string"],
    "unicode": ["string"],
-   "long":    ["uint64"]
+   "long":    ["int64", "uint64"]
 }
 primitive_types = [bool, int, long, float]
 string_types = [str, unicode]


### PR DESCRIPTION
Correction issue #240, according to the [ROS message convention](http://wiki.ros.org/msg#line-47) for the int64 type. 