### PR TITLE
Fixed time object field definitions to match documentation.

### DIFF
--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -149,7 +149,7 @@ def _get_special_typedef(type):
     if type=="time" or type=="duration":
         example = {
             "type": type,
-            "fieldnames": ["sec", "nsec"],
+            "fieldnames": ["secs", "nsecs"],
             "fieldtypes": ["int32", "int32"],
             "fieldarraylen": [-1, -1],
             "examples": [ "0", "0" ]


### PR DESCRIPTION
As mentioned by @T045T, this is a fix that should be its own commit and pull request, rather than a part of pull request #238.
