### PR TITLE
Fix: Set default to publish all topics

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -13,9 +13,9 @@
 
   <arg name="authenticate" default="false" />
 
-  <arg name="topics_glob" default="[]" />
-  <arg name="services_glob" default="[]" />
-  <arg name="params_glob" default="[]" />
+  <arg name="topics_glob" default="[*]" />
+  <arg name="services_glob" default="[*]" />
+  <arg name="params_glob" default="[*]" />
 
   <group if="$(arg ssl)">
     <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket" output="screen">


### PR DESCRIPTION
Without better doc, one does not understand why no topics are published. I thought, something is broken.
With this defaults, everything is working out of the box. And for a more secure setup, one can change it.