### PR TITLE
Implemented a bson_only_mode flag for the TCP version of rosbridge

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -70,11 +70,13 @@ binary_encoder = None
 def get_encoder():
     global binary_encoder
     if binary_encoder is None:
-        binary_encoder_type = rospy.get_param('~binary_encoder', 'b64')
-        if binary_encoder_type == 'b64':
-            binary_encoder = standard_b64encode
-        elif binary_encoder_type == 'bson':
-            binary_encoder = bson.Binary   
+        binary_encoder_type = rospy.get_param('~binary_encoder', 'default')
+        bson_only_mode = rospy.get_param('~bson_only_mode', False)
+
+        if binary_encoder_type == 'bson' or bson_only_mode:
+            binary_encoder = bson.Binary
+        elif binary_encoder_type == 'default' or binary_encoder_type == 'b64':
+             binary_encoder = standard_b64encode
         else:
             print "Unknown encoder type '%s'"%binary_encoder_type
             exit(0)

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -248,7 +248,7 @@ class Protocol:
             # fragment list not empty -> send fragments
             if fragment_list != None:
                 for fragment in fragment_list:
-                    if bson_only_mode:
+                    if self.bson_only_mode:
                         self.outgoing(bson.BSON.encode(fragment))
                     else:
                         self.outgoing(json.dumps(fragment))

--- a/rosbridge_server/launch/rosbridge_tcp.launch
+++ b/rosbridge_server/launch/rosbridge_tcp.launch
@@ -15,6 +15,7 @@
   <arg name="topics_glob" default="[*]" />
   <arg name="services_glob" default="[*]" />
   <arg name="params_glob" default="[*]" />
+  <arg name="bson_only_mode" default="false" />
 
   <node name="rosbridge_tcp" pkg="rosbridge_server" type="rosbridge_tcp" output="screen">
     <param name="authenticate" value="$(arg authenticate)" />
@@ -31,6 +32,8 @@
     <param name="topics_glob" value="$(arg topics_glob)"/>
     <param name="services_glob" value="$(arg services_glob)"/>
     <param name="params_glob" value="$(arg params_glob)"/>
+
+    <param name="bson_only_mode" value="$(arg bson_only_mode)"/>
   </node>
 
   <node name="rosapi" pkg="rosapi" type="rosapi_node">

--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -56,6 +56,8 @@ if __name__ == "__main__":
             fragment_timeout = get_param('~fragment_timeout', RosbridgeTcpSocket.fragment_timeout)
             delay_between_messages = get_param('~delay_between_messages', RosbridgeTcpSocket.delay_between_messages)
             max_message_size = get_param('~max_message_size', RosbridgeTcpSocket.max_message_size)
+            bson_only_mode = get_param('~bson_only_mode', "false")
+
             if max_message_size == "None":
                 max_message_size = None
 
@@ -149,6 +151,7 @@ if __name__ == "__main__":
             RosbridgeTcpSocket.fragment_timeout = fragment_timeout
             RosbridgeTcpSocket.delay_between_messages = delay_between_messages
             RosbridgeTcpSocket.max_message_size = max_message_size
+            RosbridgeTcpSocket.bson_only_mode = bson_only_mode
 
 
             if "--topics_glob" in sys.argv:
@@ -186,6 +189,9 @@ if __name__ == "__main__":
                 else:
                     print "--params_glob argument provided without a value. (can be None or a list)"
                     sys.exit(-1)
+
+            if "--bson_only_mode" in sys.argv:
+                bson_only_mode = True
 
             # To be able to access the list of topics and services, you must be able to access the rosapi services.
             if RosbridgeTcpSocket.services_glob:

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -1,4 +1,5 @@
 import rospy
+import struct
 from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
 
 import SocketServer
@@ -22,13 +23,15 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     # protocol.py:
     delay_between_messages = 0              # seconds
     max_message_size = None                 # bytes
+    bson_only_mode = False
 
     def setup(self):
         cls = self.__class__
         parameters = {
             "fragment_timeout": cls.fragment_timeout,
             "delay_between_messages": cls.delay_between_messages,
-            "max_message_size": cls.max_message_size
+            "max_message_size": cls.max_message_size,
+            "bson_only_mode": cls.bson_only_mode
         }
 
         try:
@@ -40,6 +43,39 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
         except Exception as exc:
             rospy.logerr("Unable to accept incoming connection.  Reason: %s", str(exc))
 
+    def recvall(self,n):
+        # http://stackoverflow.com/questions/17667903/python-socket-receive-large-amount-of-data
+        # Helper function to recv n bytes or return None if EOF is hit
+        data = ''
+        while len(data) < n:
+            packet = self.request.recv(n - len(data))
+            if not packet:
+                return None
+            data += packet
+        return data
+
+    def recv_bson(self):
+        # Read 4 bytes to get the length of the BSON packet
+        BSON_LENGTH_IN_BYTES = 4
+        raw_msglen = self.recvall(BSON_LENGTH_IN_BYTES)
+        if not raw_msglen:
+            return None
+        msglen = struct.unpack('i', raw_msglen)[0]
+
+        # Retrieve the rest of the message
+        data = self.recvall(msglen - BSON_LENGTH_IN_BYTES)
+        if data == None:
+            return None
+        data = raw_msglen + data # Prefix the data with the message length that has already been received.
+                                 # The message length is part of BSONs message format
+
+        # Exit on empty message
+        if len(data) == 0:
+            return None
+
+        self.protocol.incoming(data)
+        return True
+
     def handle(self):
         """
         Listen for TCP messages
@@ -48,6 +84,12 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
         self.request.settimeout(cls.socket_timeout)
         while 1:
             try:
+              if self.bson_only_mode:
+                  if self.recv_bson() == None:
+                      break
+                  continue
+
+              # non-BSON handling
               data = self.request.recv(cls.incoming_buffer)
               # Exit on empty string
               if data.strip() == '':


### PR DESCRIPTION
Related to https://github.com/RobotWebTools/rosbridge_suite/issues/253

This commit allows users to switch to a full-duplex transmission of BSON messages and therefore eliminates the need for a base64 encoding of binary data when running in this mode. 
The new mode is **fully optional** and **is not activated by default**.
You can use the new mode by starting:
- roslaunch rosbridge_server rosbridge_tcp.launch bson_only_mode:=True

or
- rosbridge_tcp.py --bson_only_mode 

Your rosbridge_server will now only expect and transmit data in BSON.

This PR can also provide an improvement for problems like in https://github.com/RobotWebTools/roslibjs/issues/126, 
because the TCP handler can make some assumptions on the length of the message when using BSON. This is due to the length field that is located in the first four bytes of every BSON message.