### PR TITLE
Fix missing find_package() on rosauth

### DIFF
--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosbridge_server)
 
-find_package(catkin REQUIRED COMPONENTS rosbridge_library rosapi rospy)
+find_package(catkin REQUIRED COMPONENTS rosbridge_library rosapi rospy rosauth)
 
 catkin_python_setup()
 


### PR DESCRIPTION
Fixes #260 
CMake now complains about the missing package. This is much better than a run-time failure;

```bash
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "rosauth" with any
  of the following names:

    rosauthConfig.cmake
    rosauth-config.cmake

  Add the installation prefix of "rosauth" to CMAKE_PREFIX_PATH or set
  "rosauth_DIR" to a directory containing one of the above files.  If
  "rosauth" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  rosbridge_suite/rosbridge_server/CMakeLists.txt:4 (find_package)


-- Could not find the required component 'rosauth'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "rosauth" with any
  of the following names:

    rosauthConfig.cmake
    rosauth-config.cmake

  Add the installation prefix of "rosauth" to CMAKE_PREFIX_PATH or set
  "rosauth_DIR" to a directory containing one of the above files.  If
  "rosauth" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  rosbridge_suite/rosbridge_server/CMakeLists.txt:4 (find_package)


-- Configuring incomplete, errors occurred!
```