### PR TITLE
Set default for bson_only_mode in websocket handler and launch file.

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -16,6 +16,7 @@
   <arg name="topics_glob" default="[*]" />
   <arg name="services_glob" default="[*]" />
   <arg name="params_glob" default="[*]" />
+  <arg name="bson_only_mode" default="false" />
 
   <group if="$(arg ssl)">
     <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket" output="screen">
@@ -47,6 +48,8 @@
       <param name="topics_glob" value="$(arg topics_glob)"/>
       <param name="services_glob" value="$(arg services_glob)"/>
       <param name="params_glob" value="$(arg params_glob)"/>
+
+      <param name="bson_only_mode" value="$(arg bson_only_mode)"/>
     </node>
   </group>
 

--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             fragment_timeout = get_param('~fragment_timeout', RosbridgeTcpSocket.fragment_timeout)
             delay_between_messages = get_param('~delay_between_messages', RosbridgeTcpSocket.delay_between_messages)
             max_message_size = get_param('~max_message_size', RosbridgeTcpSocket.max_message_size)
-            bson_only_mode = get_param('~bson_only_mode', "false")
+            bson_only_mode = get_param('~bson_only_mode', False)
 
             if max_message_size == "None":
                 max_message_size = None

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -68,6 +68,8 @@ if __name__ == "__main__":
                                                                 RosbridgeWebSocket.delay_between_messages)
     RosbridgeWebSocket.max_message_size = rospy.get_param('~max_message_size',
                                                           RosbridgeWebSocket.max_message_size)
+    bson_only_mode = rospy.get_param('~bson_only_mode', False)
+
     if RosbridgeWebSocket.max_message_size == "None":
         RosbridgeWebSocket.max_message_size = None
 
@@ -180,6 +182,9 @@ if __name__ == "__main__":
         else:
             print "--params_glob argument provided without a value. (can be None or a list)"
             sys.exit(-1)
+
+    if ("--bson_only_mode" in sys.argv) or bson_only_mode:
+        print "bson_only_mode is only supported in the TCP Version of Rosbridge currently. Ignoring bson_only_mode argument..."
 
     # To be able to access the list of topics and services, you must be able to access the rosapi services.
     if RosbridgeWebSocket.services_glob:

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -54,13 +54,15 @@ class RosbridgeWebSocket(WebSocketHandler):
     # protocol.py:
     delay_between_messages = 0              # seconds
     max_message_size = None                 # bytes
+    bson_only_mode = False
 
     def open(self):
         cls = self.__class__
         parameters = {
             "fragment_timeout": cls.fragment_timeout,
             "delay_between_messages": cls.delay_between_messages,
-            "max_message_size": cls.max_message_size
+            "max_message_size": cls.max_message_size,
+            "bson_only_mode": cls.bson_only_mode
         }
         try:
             self.protocol = RosbridgeProtocol(cls.client_id_seed, parameters=parameters)


### PR DESCRIPTION
This PR shall prevent bson_only_mode to be undefined at any time when using the websocket version of ROSBridge. This PR targets the problem described in https://github.com/RobotWebTools/rosbridge_suite/issues/271 .

When this change seems fine, i could also apply it on the udp version of ROSBridge.
Is there any UDP testclient?