### PR TITLE
fix delete_param in rosapi

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -93,11 +93,10 @@ def delete_param(name, params_glob):
         return
     # If the glob list is empty (i.e. false) or the parameter matches
     # one of the glob strings, continue to delete the parameter.
-    with param_server_lock:
-        if has_param(name):
+    if has_param(name, params_glob):
+        with param_server_lock:
             rospy.delete_param(name)
-        
-        
+
 def search_param(name, params_glob):
     if params_glob and not any(fnmatch.fnmatch(str(v), glob) for glob in params_glob):
         # If the glob list is not empty and there are no glob matches,


### PR DESCRIPTION
To fix
```
[/rosapi ERROR 1498735222.314929]: Error processing request: has_param() takes exactly 2 arguments (1 given)
['Traceback (most recent call last):\n', '  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 625, in _handle_request\n    response = convert_return_to_response(self.handler(request), self.response_class)\n', '  File "/home/jihoonl/work/ros/webtools/src/rosbridge_suite/rosapi/scripts/rosapi_node", line 190, in delete_param\n    rosapi.params.delete_param(request.name, params_glob)\n', '  File "/home/jihoonl/work/ros/webtools/src/rosbridge_suite/rosapi/src/rosapi/params.py", line 97, in delete_param\n    if has_param(name):\n', 'TypeError: has_param() takes exactly 2 arguments (1 given)\n']
[/rosbridge_websocket ERROR 1498735222.315634]: [Client 1] [id: call_service:/rosapi/delete_param:6] call_service ServiceException: service [/rosapi/delete_param] responded with an error: error processing request: has_param() takes exactly 2 arguments (1 given)
```