### PR TITLE
Fixed action_servers filter to allow more than one namespace

### DIFF
--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -160,7 +160,8 @@ def filter_action_servers(topics):
     for topic in sorted(topics):
         split = topic.split('/')
         if(len(split) >= 3):
-            [empty, namespace, topic] = split[-3:]
+            topic = split.pop()
+            namespace = '/'.join(split)
             if(possible_action_server != namespace):
                 possible_action_server = namespace
                 possibility = [0, 0, 0, 0, 0]

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -158,8 +158,9 @@ def filter_action_servers(topics):
 
     action_topics = ['cancel', 'feedback', 'goal', 'result', 'status']
     for topic in sorted(topics):
-        if (len(topic.split('/')) == 3):
-            [empty, namespace, topic] = topic.split('/')
+        split = topic.split('/')
+        if(len(split) >= 3):
+            [empty, namespace, topic] = split[-3:]
             if(possible_action_server != namespace):
                 possible_action_server = namespace
                 possibility = [0, 0, 0, 0, 0]


### PR DESCRIPTION
### Context
The service `/rosapi/action_servers` uses a filter function on topic names to detect action servers.

### Problem
This function worked only with topics of type `/namespace/goal`, with only one namespace.

### Fix
It is now capable of detecting for example `/ns1/ns2/server/goal` (when all goal, success, cancel, feedback and status topics are alive, of course).
The service returns an array of the full namespaces, `/ns1/ns2/server` being one of them here for example