### PR TITLE
Make unregister_timeout configurable

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -90,6 +90,9 @@ class Advertise(Capability):
         # Initialize class variables
         self._registrations = {}
 
+        if protocol.parameters and protocol.parameters.has_key("unregister_timeout"):
+            manager.unregister_timeout = protocol.parameters.get("unregister_timeout")
+
     def advertise(self, message):
         # Pull out the ID
         aid = message.get("id", None)

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -53,6 +53,9 @@ class Publish(Capability):
         # Save the topics that are published on for the purposes of unregistering
         self._published = {}
 
+        if protocol.parameters and protocol.parameters.has_key("unregister_timeout"):
+            manager.unregister_timeout = protocol.parameters.get("unregister_timeout")
+
     def publish(self, message):
         # Do basic type checking
         self.basic_type_check(message, self.publish_msg_fields)

--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -40,7 +40,6 @@ from rostopic import get_topic_type
 from rosbridge_library.internal import ros_loader, message_conversion
 from rosbridge_library.internal.topics import TopicNotEstablishedException, TypeConflictException
 
-UNREGISTER_TIMEOUT = 10.0
 
 class PublisherConsistencyListener(SubscribeListener):
     """ This class is used to solve the problem that sometimes we create a
@@ -255,6 +254,7 @@ class PublisherManager():
     def __init__(self):
         self._publishers = {}
         self.unregister_timers = {}
+        self.unregister_timeout = 10.0
 
     def register(self, client_id, topic, msg_type=None, latch=False, queue_size=100):
         """ Register a publisher on the specified topic.
@@ -314,7 +314,7 @@ class PublisherManager():
         if topic in self.unregister_timers:
             self.unregister_timers[topic].cancel()
             del self.unregister_timers[topic]
-        self.unregister_timers[topic] = Timer(UNREGISTER_TIMEOUT, self._unregister_impl,
+        self.unregister_timers[topic] = Timer(self.unregister_timeout, self._unregister_impl,
                                               [topic])
         self.unregister_timers[topic].start()
 

--- a/rosbridge_library/test/capabilities/test_advertise.py
+++ b/rosbridge_library/test/capabilities/test_advertise.py
@@ -10,7 +10,7 @@ from std_msgs.msg import *
 from rosbridge_library.protocol import Protocol
 from rosbridge_library.protocol import InvalidArgumentException, MissingArgumentException
 from rosbridge_library.capabilities.advertise import Registration, Advertise
-from rosbridge_library.internal.publishers import manager, UNREGISTER_TIMEOUT
+from rosbridge_library.internal.publishers import manager
 from rosbridge_library.internal import ros_loader
 
 from json import loads, dumps
@@ -20,7 +20,7 @@ class TestAdvertise(unittest.TestCase):
 
     def setUp(self):
         rospy.init_node("test_advertise")
-        UNREGISTER_TIMEOUT = 1.0
+        manager.unregister_timeout = 1.0
 
     def is_topic_published(self, topicname):
         return topicname in dict(rospy.get_published_topics()).keys()
@@ -131,7 +131,7 @@ class TestAdvertise(unittest.TestCase):
         self.assertTrue(self.is_topic_published(topic))
         adv.unadvertise(loads(dumps(msg)))
         self.assertTrue(self.is_topic_published(topic))
-        sleep(UNREGISTER_TIMEOUT*1.1)
+        sleep(manager.unregister_timeout * 1.1)
         self.assertFalse(self.is_topic_published(topic))
 
 

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -16,7 +16,7 @@ class TestPublisherManager(unittest.TestCase):
 
     def setUp(self):
         rospy.init_node("test_publisher_manager")
-        UNREGISTER_TIMEOUT = 1.0
+        manager.unregister_timeout = 1.0
 
     def is_topic_published(self, topicname):
         return topicname in dict(rospy.get_published_topics()).keys()
@@ -37,7 +37,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertTrue(topic in manager.unregister_timers)
         self.assertTrue(topic in manager._publishers)
         self.assertTrue(self.is_topic_published(topic))
-        sleep(UNREGISTER_TIMEOUT*1.1)
+        sleep(manager.unregister_timeout*1.1)
         self.assertFalse(topic in manager._publishers)
         self.assertFalse(self.is_topic_published(topic))
         self.assertFalse(topic in manager.unregister_timers)
@@ -63,7 +63,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertTrue(topic in manager.unregister_timers)
         self.assertTrue(topic in manager._publishers)
         self.assertTrue(self.is_topic_published(topic))
-        sleep(UNREGISTER_TIMEOUT*1.1)
+        sleep(manager.unregister_timeout*1.1)
         self.assertFalse(topic in manager._publishers)
         self.assertFalse(self.is_topic_published(topic))
         self.assertFalse(topic in manager.unregister_timers)
@@ -112,7 +112,7 @@ class TestPublisherManager(unittest.TestCase):
         manager.unregister(client, topic2)
         self.assertTrue(topic2 in manager.unregister_timers)
         self.assertTrue(self.is_topic_published(topic2))
-        sleep(UNREGISTER_TIMEOUT*1.1)
+        sleep(manager.unregister_timeout*1.1)
         self.assertFalse(topic1 in manager._publishers)
         self.assertFalse(self.is_topic_published(topic1))
         self.assertFalse(topic2 in manager._publishers)
@@ -168,7 +168,7 @@ class TestPublisherManager(unittest.TestCase):
         manager.unregister(client2, topic)
         self.assertTrue(topic in manager.unregister_timers)
         self.assertTrue(topic in manager._publishers)
-        sleep(UNREGISTER_TIMEOUT*1.1)
+        sleep(manager.unregister_timeout*1.1)
         self.assertFalse(topic in manager._publishers)
         self.assertFalse(topic in manager.unregister_timers)
         self.assertFalse(self.is_topic_published(topic))

--- a/rosbridge_server/launch/rosbridge_tcp.launch
+++ b/rosbridge_server/launch/rosbridge_tcp.launch
@@ -9,6 +9,7 @@
   <arg name="fragment_timeout" default="600" />
   <arg name="delay_between_messages" default="0" />
   <arg name="max_message_size" default="None" />
+  <arg name="unregister_timeout" default="10" />
 
   <arg name="authenticate" default="false" />
 
@@ -28,7 +29,8 @@
     <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
     <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
     <param name="max_message_size" value="$(arg max_message_size)"/>
-    
+    <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+
     <param name="topics_glob" value="$(arg topics_glob)"/>
     <param name="services_glob" value="$(arg services_glob)"/>
     <param name="params_glob" value="$(arg params_glob)"/>

--- a/rosbridge_server/launch/rosbridge_udp.launch
+++ b/rosbridge_server/launch/rosbridge_udp.launch
@@ -5,6 +5,7 @@
   <arg name="fragment_timeout" default="600" />
   <arg name="delay_between_messages" default="0" />
   <arg name="max_message_size" default="None" />
+  <arg name="unregister_timeout" default="10" />
 
   <arg name="authenticate" default="false" />
 
@@ -20,7 +21,8 @@
     <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
     <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
     <param name="max_message_size" value="$(arg max_message_size)"/>
-    
+    <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+
     <param name="topics_glob" value="$(arg topics_glob)"/>
     <param name="services_glob" value="$(arg services_glob)"/>
     <param name="params_glob" value="$(arg params_glob)"/>

--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -10,6 +10,7 @@
   <arg name="fragment_timeout" default="600" />
   <arg name="delay_between_messages" default="0" />
   <arg name="max_message_size" default="None" />
+  <arg name="unregister_timeout" default="10" />
 
   <arg name="authenticate" default="false" />
 
@@ -32,6 +33,7 @@
       <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
       <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
       <param name="max_message_size" value="$(arg max_message_size)"/>
+      <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
 
       <param name="topics_glob" value="$(arg topics_glob)"/>
       <param name="services_glob" value="$(arg services_glob)"/>
@@ -47,7 +49,8 @@
       <param name="fragment_timeout" value="$(arg fragment_timeout)"/>
       <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
       <param name="max_message_size" value="$(arg max_message_size)"/>
-      
+      <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+
       <param name="topics_glob" value="$(arg topics_glob)"/>
       <param name="services_glob" value="$(arg services_glob)"/>
       <param name="params_glob" value="$(arg params_glob)"/>

--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
             fragment_timeout = get_param('~fragment_timeout', RosbridgeTcpSocket.fragment_timeout)
             delay_between_messages = get_param('~delay_between_messages', RosbridgeTcpSocket.delay_between_messages)
             max_message_size = get_param('~max_message_size', RosbridgeTcpSocket.max_message_size)
+            unregister_timeout = get_param('~unregister_timeout', RosbridgeTcpSocket.unregister_timeout)
             bson_only_mode = get_param('~bson_only_mode', False)
 
             if max_message_size == "None":
@@ -150,12 +151,21 @@ if __name__ == "__main__":
                     print("--max_message_size argument provided without a value. (can be None or <Integer>)")
                     sys.exit(-1)
 
+            if "--unregister_timeout" in sys.argv:
+                idx = sys.argv.index("--unregister_timeout") + 1
+                if idx < len(sys.argv):
+                    unregister_timeout = float(sys.argv[idx])
+                else:
+                    print("--unregister_timeout argument provided without a value.")
+                    sys.exit(-1)
+
             # export parameters to handler class
             RosbridgeTcpSocket.incoming_buffer = incoming_buffer
             RosbridgeTcpSocket.socket_timeout = socket_timeout
             RosbridgeTcpSocket.fragment_timeout = fragment_timeout
             RosbridgeTcpSocket.delay_between_messages = delay_between_messages
             RosbridgeTcpSocket.max_message_size = max_message_size
+            RosbridgeTcpSocket.unregister_timeout = unregister_timeout
             RosbridgeTcpSocket.bson_only_mode = bson_only_mode
 
 

--- a/rosbridge_server/scripts/rosbridge_udp.py
+++ b/rosbridge_server/scripts/rosbridge_udp.py
@@ -63,6 +63,8 @@ if __name__ == "__main__":
                                                                 RosbridgeUdpSocket.delay_between_messages)
     RosbridgeUdpSocket.max_message_size = rospy.get_param('~max_message_size',
                                                           RosbridgeUdpSocket.max_message_size)
+    RosbridgeUdpSocket.unregister_timeout = rospy.get_param('~unregister_timeout',
+                                                          RosbridgeUdpSocket.unregister_timeout)
     if RosbridgeUdpSocket.max_message_size == "None":
         RosbridgeUdpSocket.max_message_size = None
 
@@ -127,6 +129,14 @@ if __name__ == "__main__":
                 RosbridgeUdpSocket.max_message_size = int(value)
         else:
             print("--max_message_size argument provided without a value. (can be None or <Integer>)")
+            sys.exit(-1)
+
+    if "--unregister_timeout" in sys.argv:
+        idx = sys.argv.index("--unregister_timeout") + 1
+        if idx < len(sys.argv):
+            unregister_timeout = float(sys.argv[idx])
+        else:
+            print("--unregister_timeout argument provided without a value.")
             sys.exit(-1)
 
     if "--topics_glob" in sys.argv:

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -69,6 +69,8 @@ if __name__ == "__main__":
                                                                 RosbridgeWebSocket.delay_between_messages)
     RosbridgeWebSocket.max_message_size = rospy.get_param('~max_message_size',
                                                           RosbridgeWebSocket.max_message_size)
+    RosbridgeWebSocket.unregister_timeout = rospy.get_param('~unregister_timeout',
+                                                          RosbridgeWebSocket.unregister_timeout)
     bson_only_mode = rospy.get_param('~bson_only_mode', False)
 
     if RosbridgeWebSocket.max_message_size == "None":
@@ -146,6 +148,14 @@ if __name__ == "__main__":
                 RosbridgeWebSocket.max_message_size = int(value)
         else:
             print("--max_message_size argument provided without a value. (can be None or <Integer>)")
+            sys.exit(-1)
+
+    if "--unregister_timeout" in sys.argv:
+        idx = sys.argv.index("--unregister_timeout") + 1
+        if idx < len(sys.argv):
+            unregister_timeout = float(sys.argv[idx])
+        else:
+            print("--unregister_timeout argument provided without a value.")
             sys.exit(-1)
 
     if "--topics_glob" in sys.argv:

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -26,6 +26,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     # protocol.py:
     delay_between_messages = 0              # seconds
     max_message_size = None                 # bytes
+    unregister_timeout = 10.0               # seconds
     bson_only_mode = False
 
     def setup(self):
@@ -34,6 +35,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
             "fragment_timeout": cls.fragment_timeout,
             "delay_between_messages": cls.delay_between_messages,
             "max_message_size": cls.max_message_size,
+            "unregister_timeout": cls.unregister_timeout,
             "bson_only_mode": cls.bson_only_mode
         }
 

--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -29,6 +29,7 @@ class RosbridgeUdpSocket:
     # protocol.py:
     delay_between_messages = 0              # seconds
     max_message_size = None                 # bytes
+    unregister_timeout = 10.0               # seconds
 
     def __init__(self,write):
         self.write = write
@@ -39,7 +40,8 @@ class RosbridgeUdpSocket:
         parameters = {
             "fragment_timeout": cls.fragment_timeout,
             "delay_between_messages": cls.delay_between_messages,
-            "max_message_size": cls.max_message_size
+            "max_message_size": cls.max_message_size,
+            "unregister_timeout": cls.unregister_timeout
         }
         try:
             self.protocol = RosbridgeProtocol(cls.client_id_seed, parameters=parameters)

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -53,6 +53,7 @@ class RosbridgeWebSocket(WebSocketHandler):
     # protocol.py:
     delay_between_messages = 0              # seconds
     max_message_size = None                 # bytes
+    unregister_timeout = 10.0               # seconds
     bson_only_mode = False
 
     def open(self):
@@ -61,6 +62,7 @@ class RosbridgeWebSocket(WebSocketHandler):
             "fragment_timeout": cls.fragment_timeout,
             "delay_between_messages": cls.delay_between_messages,
             "max_message_size": cls.max_message_size,
+            "unregister_timeout": cls.unregister_timeout,
             "bson_only_mode": cls.bson_only_mode
         }
         try:


### PR DESCRIPTION
Pull request #247 introduces a 10 second delay to mitigate issue #138.
This change makes this delay configurable by passing an argument either
on the command line or when including a launch file.

Usage example:
```xml
<launch>
  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
    <arg name="unregister_timeout" value="5.0"/>
  </include>
</launch>
```

Closes #320