### PR TITLE
Fix typo in function call

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -56,7 +56,7 @@ def has_binary(obj):
         return any(has_binary(item) for item in obj)
 
     if isinstance(obj, dict):
-        return any(as_binary(item) for item in obj.itervalues())
+        return any(has_binary(item) for item in obj.itervalues())
 
     return isinstance(obj, bson.binary.Binary)
 


### PR DESCRIPTION
The problem for me was that after subscribing, rosbridge didn't send messages back to client with no errors.

Code failed silently, because has_binary was called out in try catch block.