### PR TITLE
removed symbolic links from scripts directory and changed launch file to start python scripts

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -310,7 +310,7 @@ class PublisherManager():
         if not topic in self._publishers:
             return
 
-        self._publishers[topic].unregister_client(client_id)
+        #self._publishers[topic].unregister_client(client_id)
         if topic in self.unregister_timers:
             self.unregister_timers[topic].cancel()
             del self.unregister_timers[topic]
@@ -319,9 +319,9 @@ class PublisherManager():
         self.unregister_timers[topic].start()
 
     def _unregister_impl(self, topic):
-        if not self._publishers[topic].has_clients():
-            self._publishers[topic].unregister()
-            del self._publishers[topic]
+        #if not self._publishers[topic].has_clients():
+        #    self._publishers[topic].unregister()
+        #    del self._publishers[topic]
         del self.unregister_timers[topic]
 
     def unregister_all(self, client_id):

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -9,10 +9,7 @@ catkin_package()
 
 install(PROGRAMS
   scripts/rosbridge_websocket.py
-  scripts/rosbridge_websocket
   scripts/rosbridge_tcp.py
-  scripts/rosbridge_tcp
-  scripts/rosbridge_udp
   scripts/rosbridge_udp.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/rosbridge_server/launch/rosbridge_tcp.launch
+++ b/rosbridge_server/launch/rosbridge_tcp.launch
@@ -18,7 +18,7 @@
   <arg name="params_glob" default="[*]" />
   <arg name="bson_only_mode" default="false" />
 
-  <node name="rosbridge_tcp" pkg="rosbridge_server" type="rosbridge_tcp" output="screen">
+  <node name="rosbridge_tcp" pkg="rosbridge_server" type="rosbridge_tcp.py" output="screen">
     <param name="authenticate" value="$(arg authenticate)" />
 
     <param name="port" value="$(arg port)"/>

--- a/rosbridge_server/launch/rosbridge_udp.launch
+++ b/rosbridge_server/launch/rosbridge_udp.launch
@@ -13,7 +13,7 @@
   <arg name="services_glob" default="[*]" />
   <arg name="params_glob" default="[*]" />
 
-  <node name="rosbridge_udp" pkg="rosbridge_server" type="rosbridge_udp" output="screen">
+  <node name="rosbridge_udp" pkg="rosbridge_server" type="rosbridge_udp.py" output="screen">
     <param name="authenticate" value="$(arg authenticate)" />
 
     <param name="port" value="$(arg port)"/>

--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -23,7 +23,7 @@
   <arg unless="$(arg bson_only_mode)" name="binary_encoder" default="default"/>
 
   <group if="$(arg ssl)">
-    <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket" output="screen">
+    <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket.py" output="screen">
       <param name="certfile" value="$(arg certfile)" />
       <param name="keyfile" value="$(arg keyfile)" />
       <param name="authenticate" value="$(arg authenticate)" />
@@ -41,7 +41,7 @@
     </node>
   </group>
   <group unless="$(arg ssl)">
-    <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket" output="screen">
+    <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket.py" output="screen">
       <param name="authenticate" value="$(arg authenticate)" />
       <param name="port" value="$(arg port)"/>
       <param name="address" value="$(arg address)"/>

--- a/rosbridge_server/scripts/rosbridge_tcp
+++ b/rosbridge_server/scripts/rosbridge_tcp
@@ -1,1 +1,0 @@
-./rosbridge_tcp.py

--- a/rosbridge_server/scripts/rosbridge_udp
+++ b/rosbridge_server/scripts/rosbridge_udp
@@ -1,1 +1,0 @@
-rosbridge_udp.py

--- a/rosbridge_server/scripts/rosbridge_websocket
+++ b/rosbridge_server/scripts/rosbridge_websocket
@@ -1,1 +1,0 @@
-rosbridge_websocket.py


### PR DESCRIPTION
The launch files refer to the symbolic links in the scripts directory of rsobridge_server (e.g. rosbridge_websocket), not rosbridge_websocket.py.
The symbolic links in the scripts folder can cause problems when a dpkg package is generated from the package. As a result the files in the dpkg package (e.g. rosbridge_websocket) only contain the text rosbridge_websocket.py. In the case of rosbridge_tcp the link is set to ./rosbridge_tcp what results in a file that contains ./rosbridge_tcp and bascially works as a link. Unfortunately this only works for ./rosbridge_tcp not for rosbridge_websocket and rosbridge_udp, because here the links are set directly to rosbridge_websocket, etc.

solution: remove the symbolic links and call the py-files directly in the launch file
