### PR TITLE
removing has_key for python3, keeping backwards compatibility

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -90,7 +90,7 @@ class Advertise(Capability):
         # Initialize class variables
         self._registrations = {}
 
-        if protocol.parameters and protocol.parameters.has_key("unregister_timeout"):
+        if protocol.parameters and "unregister_timeout" in protocol.parameters:
             manager.unregister_timeout = protocol.parameters.get("unregister_timeout")
 
     def advertise(self, message):

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -53,7 +53,7 @@ class Publish(Capability):
         # Save the topics that are published on for the purposes of unregistering
         self._published = {}
 
-        if protocol.parameters and protocol.parameters.has_key("unregister_timeout"):
+        if protocol.parameters and "unregister_timeout" in protocol.parameters:
             manager.unregister_timeout = protocol.parameters.get("unregister_timeout")
 
     def publish(self, message):

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -56,7 +56,7 @@ def has_binary(obj):
         return any(has_binary(item) for item in obj)
 
     if isinstance(obj, dict):
-        return any(has_binary(item) for item in obj.itervalues())
+        return any(has_binary(obj[item]) for item in obj)
 
     return isinstance(obj, bson.binary.Binary)
 


### PR DESCRIPTION
Pretty straight forward, remove has_key method for dict since it is removed in python 3. Changes are still backwards compatible with python 2.x.