### PR TITLE
use package format 2, remove unnecessary dependencies

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosapi)
 
-find_package(catkin REQUIRED COMPONENTS rospy message_generation)
+find_package(catkin REQUIRED COMPONENTS message_generation)
 catkin_python_setup()
 
 add_message_files(

--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rosapi</name>
   <version>0.9.0</version>
   <description>
@@ -19,12 +19,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rospy</build_depend>
   <build_depend>message_generation</build_depend>
 
-  <run_depend>rosbridge_library</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>rosnode</run_depend>
-  <run_depend>rosgraph</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <exec_depend>rosbridge_library</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosnode</exec_depend>
+  <exec_depend>rosgraph</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 </package>

--- a/rosbridge_library/CMakeLists.txt
+++ b/rosbridge_library/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosbridge_library)
 
-find_package(catkin REQUIRED COMPONENTS message_generation rospy std_msgs geometry_msgs)
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs geometry_msgs)
 
 # Generate messages for testing (NOINSTALL)
 add_message_files(

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rosbridge_library</name>
   <version>0.9.0</version>
   <description>
@@ -20,23 +20,22 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>python-imaging</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>python-bson</build_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rosgraph</run_depend>
-  <run_depend>rosservice</run_depend>
-  <run_depend>rostopic</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>python-imaging</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>python-bson</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rosgraph</exec_depend>
+  <exec_depend>rosservice</exec_depend>
+  <exec_depend>rostopic</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>python-imaging</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>python-bson</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>actionlib_msgs</test_depend>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rosbridge_server</name>
   <version>0.9.0</version>
   <description>A WebSocket interface to rosbridge.</description>
@@ -15,11 +15,11 @@
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>python-backports.ssl-match-hostname</run_depend>
-  <run_depend>python-tornado</run_depend>
-  <run_depend>python-twisted-core</run_depend>
-  <run_depend>rosbridge_library</run_depend>
-  <run_depend>rosapi</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>rosauth</run_depend>
+  <exec_depend>python-backports.ssl-match-hostname</exec_depend>
+  <exec_depend>python-tornado</exec_depend>
+  <exec_depend>python-twisted-core</exec_depend>
+  <exec_depend>rosbridge_library</exec_depend>
+  <exec_depend>rosapi</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosauth</exec_depend>
 </package>

--- a/rosbridge_suite/package.xml
+++ b/rosbridge_suite/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rosbridge_suite</name>
   <version>0.9.0</version>
   <description>
@@ -23,9 +23,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rosbridge_library</run_depend>
-  <run_depend>rosbridge_server</run_depend>
-  <run_depend>rosapi</run_depend>
+  <exec_depend>rosbridge_library</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>rosapi</exec_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
This uses format 2 for the package manifest files. Additionally I removed the build dependency on `rospy` which isn't necessary.