### PR TITLE
Add param to enable ws per-message deflate

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -12,6 +12,8 @@
   <arg name="max_message_size" default="None" />
   <arg name="unregister_timeout" default="10" />
 
+  <arg name="use_compression" default="false" />
+
   <arg name="authenticate" default="false" />
 
   <arg name="topics_glob" default="[*]" />
@@ -34,6 +36,7 @@
       <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
       <param name="max_message_size" value="$(arg max_message_size)"/>
       <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+      <param name="use_compression" value="$(arg use_compression)"/>
 
       <param name="topics_glob" value="$(arg topics_glob)"/>
       <param name="services_glob" value="$(arg services_glob)"/>
@@ -50,6 +53,7 @@
       <param name="delay_between_messages" value="$(arg delay_between_messages)"/>
       <param name="max_message_size" value="$(arg max_message_size)"/>
       <param name="unregister_timeout" value="$(arg unregister_timeout)"/>
+      <param name="use_compression" value="$(arg use_compression)"/>
 
       <param name="topics_glob" value="$(arg topics_glob)"/>
       <param name="services_glob" value="$(arg services_glob)"/>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -64,6 +64,8 @@ if __name__ == "__main__":
     ##################################################
     retry_startup_delay = rospy.get_param('~retry_startup_delay', 2.0)  # seconds
 
+    RosbridgeWebSocket.use_compression = rospy.get_param('~use_compression', False)
+
     # get RosbridgeProtocol parameters
     RosbridgeWebSocket.fragment_timeout = rospy.get_param('~fragment_timeout',
                                                           RosbridgeWebSocket.fragment_timeout)

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -47,6 +47,7 @@ class RosbridgeWebSocket(WebSocketHandler):
     clients_connected = 0
     client_count_pub = None
     authenticate = False
+    use_compression = False
 
     # The following are passed on to RosbridgeProtocol
     # defragmentation.py:
@@ -126,3 +127,11 @@ class RosbridgeWebSocket(WebSocketHandler):
 
     def check_origin(self, origin):
         return True
+
+    def get_compression_options(self):
+        cls = self.__class__
+
+        if not cls.use_compression:
+            return None
+
+        return {}

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -129,6 +129,8 @@ class RosbridgeWebSocket(WebSocketHandler):
         return True
 
     def get_compression_options(self):
+        # If this method returns None (the default), compression will be disabled.
+        # If it returns a dict (even an empty one), it will be enabled.
         cls = self.__class__
 
         if not cls.use_compression:


### PR DESCRIPTION
Tornado has its own per-message deflate compression option, which
compresses each WebSocket message.  The compression level should be
roughly equivalent to PNG compression, depending on whether the message is
JSON or binary (CBOR).  The encoding/decoding time will be much faster
than protocol PNG compression.

This param should be enabled when wire size is important, e.g. not
connecting to localhost.