### PR TITLE
Use slice replacement for glob lists

### DIFF
--- a/rosapi/src/rosapi/glob_helper.py
+++ b/rosapi/src/rosapi/glob_helper.py
@@ -22,9 +22,9 @@ def get_globs():
             for element in param.strip('[').strip(']').split(',')
             if len(element.strip().strip("'")) > 0]
 
-    topics_glob = get_param('~topics_glob')
-    services_glob = get_param('~services_glob')
-    params_glob = get_param('~params_glob')
+    topics_glob[:] = get_param('~topics_glob')
+    services_glob[:] = get_param('~services_glob')
+    params_glob[:] = get_param('~params_glob')
 
 
 def filter_globs(globs, full_list):


### PR DESCRIPTION
This commit fixes a bug introduced in 76a9bc449b2be7a7c2ffad2ee4e37b45974c7e9e .

The variables `topics_glob`, `services_glob` and `params_glob`, plus some other methods, were moved to a separate file. This caused the `get_globs` function to replace only the local reference of these collections. 

Using a slice replacement avoids creating a new list and keeps using the same instances as external sources. Of course this is far from optimal, but at least it fixes the issue of not getting the value of the params from outside once imported.