### PR TITLE
Use getTopicTypes() in /rosapi/get_topics for increased performance

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -68,8 +68,7 @@ def register_services():
 
 def get_topics(request):
     """ Called by the rosapi/Topics service. Returns a list of all the topics being published. """
-    topics = proxy.get_topics(rosapi.glob_helper.topics_glob)
-    types = proxy.get_topics_types(topics, rosapi.glob_helper.topics_glob)
+    topics, types = proxy.get_topics_and_types(rosapi.glob_helper.topics_glob)
     return TopicsResponse(topics, types)
 
 def get_topics_for_type(request):

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -48,25 +48,26 @@ from rosapi.msg import TypeDef
 from .glob_helper import filter_globs, any_match
 
 
-def get_topics(topics_glob):
+def get_topics_and_types(topics_glob):
     """ Returns a list of all the active topics in the ROS system """
     try:
-        publishers, subscribers, services = Master('/rosbridge').getSystemState()
-        # Filter the list of topics by whether they are public before returning.
-        return filter_globs(topics_glob,
-                            list(set([x for x, _ in publishers] + [x for x, _, in subscribers])))
+        # Function getTopicTypes also returns inactive topics and does not
+        # return topics with unknown message types, so it must be compared
+        # to results from getSystemState.
+        master = Master('/rosbridge')
+        topic_types = master.getTopicTypes()
+        publishers, subscribers, services = master.getSystemState()
+        topics = set([x for x, _ in publishers] + [x for x, _ in subscribers])
+
+        # Filter the list of topics by whether they are public.
+        topics = set(filter_globs(topics_glob, topics))
+        topic_types = [x for x in topic_types if x[0] in topics]
+
+        # Add topics with unknown type messages.
+        unknown_type = topics.difference([x for x, _ in topic_types])
+        return zip(* topic_types + [[x,''] for x in unknown_type])
     except:
         return []
-
-
-def get_topics_types(topics, topics_glob):
-    try:
-        types = []
-        for i in topics:
-            types.append(get_topic_type(i, topics_glob))
-        return types
-    except:
-        return[]
 
 
 def get_topics_for_type(type, topics_glob):


### PR DESCRIPTION
Hello,

When using `rosapi` in the development of web applications for the PR2 robot, I was facing the problem that the call for the `/rosapi/topics` service was extremely slow (operating with over 1200 topics).

Looking into the problem, it seems that getting the types was taking a lot of time:

```python
In [3]: time topics = get_topics(['*'])
CPU times: user 152 ms, sys: 0 ns, total: 152 ms
Wall time: 183 ms

In [4]: time types = get_topics_types(topics, ['*'])
CPU times: user 1min 18s, sys: 428 ms, total: 1min 18s
Wall time: 2min 6s
```

By using the `Master.getTopicTypes()` we can get equivalent results (the order changes) with better performance:
```python
In [5]: time new_topics, new_types = get_topics_and_types(['*'])
CPU times: user 244 ms, sys: 0 ns, total: 244 ms
Wall time: 297 ms

In [6]: set(new_topics) == set(topics) and set(types) == set(new_types)
Out[6]: True
```

Note that differently from `Master.getSystemState()`, `Master.getTopicTypes()` also includes inactive topics and does not include topics with unknown messages.

Related to: https://github.com/ros/ros_comm/issues/53