### PR TITLE
Additional client information websocket

### DIFF
--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rosbridge_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  genmsg std_msgs
+)
+
+add_message_files(
+  FILES
+  ConnectedClient.msg
+  ConnectedClients.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
+catkin_package(
+ CATKIN_DEPENDS std_msgs
+)

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rosbridge_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-  genmsg std_msgs
+  message_generation std_msgs
 )
 
 add_message_files(
@@ -17,5 +17,5 @@ generate_messages(
 )
 
 catkin_package(
- CATKIN_DEPENDS std_msgs
+  CATKIN_DEPENDS message_runtime std_msgs
 )

--- a/rosbridge_msgs/msg/ConnectedClient.msg
+++ b/rosbridge_msgs/msg/ConnectedClient.msg
@@ -1,0 +1,2 @@
+string ip_address
+time connection_time

--- a/rosbridge_msgs/msg/ConnectedClients.msg
+++ b/rosbridge_msgs/msg/ConnectedClients.msg
@@ -1,0 +1,1 @@
+ConnectedClient[] clients

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>rosbridge_msgs</name>
+  <version>0.9.0</version>
+  <description>Package containing message files</description>
+
+  <maintainer email="achim@intermodalics.eu">Hans-Joachim Krauch</maintainer>
+  <author email="achim@intermodalics.eu">Hans-Joachim Krauch</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+</package>

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -11,8 +11,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+
+  <depend>std_msgs</depend>
+
 </package>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>python-tornado</exec_depend>
   <exec_depend>python-twisted-core</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
+  <exec_depend>rosbridge_msgs</exec_depend>
   <exec_depend>rosapi</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosauth</exec_depend>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -41,7 +41,7 @@ from tornado.ioloop import IOLoop
 from tornado.ioloop import PeriodicCallback
 from tornado.web import Application
 
-from rosbridge_server import RosbridgeWebSocket
+from rosbridge_server import RosbridgeWebSocket, ClientManager
 
 from rosbridge_library.capabilities.advertise import Advertise
 from rosbridge_library.capabilities.publish import Publish
@@ -50,7 +50,6 @@ from rosbridge_library.capabilities.advertise_service import AdvertiseService
 from rosbridge_library.capabilities.unadvertise_service import UnadvertiseService
 from rosbridge_library.capabilities.call_service import CallService
 
-from std_msgs.msg import Int32
 
 def shutdown_hook():
     IOLoop.instance().stop()
@@ -85,9 +84,8 @@ if __name__ == "__main__":
     RosbridgeWebSocket.authenticate = rospy.get_param('~authenticate', False)
     port = rospy.get_param('~port', 9090)
     address = rospy.get_param('~address', "")
-    # Publisher for number of connected clients
-    RosbridgeWebSocket.client_count_pub = rospy.Publisher('client_count', Int32, queue_size=10, latch=True)
-    RosbridgeWebSocket.client_count_pub.publish(0)
+
+    RosbridgeWebSocket.client_manager = ClientManager()
 
     # Get the glob strings and parse them as arrays.
     RosbridgeWebSocket.topics_glob = [

--- a/rosbridge_server/src/rosbridge_server/__init__.py
+++ b/rosbridge_server/src/rosbridge_server/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 from .websocket_handler import RosbridgeWebSocket
 from .tcp_handler import RosbridgeTcpSocket
 from .udp_handler import RosbridgeUdpSocket,RosbridgeUdpFactory
+from .client_mananger import ClientManager

--- a/rosbridge_server/src/rosbridge_server/client_mananger.py
+++ b/rosbridge_server/src/rosbridge_server/client_mananger.py
@@ -41,7 +41,6 @@ class ClientManager:
         # Publisher for number of connected clients
         self._client_count_pub = rospy.Publisher(
           'client_count', Int32, queue_size=10, latch=True)
-        self._client_count_pub.publish(0)
         # Publisher for connected clients
         self._conn_clients_pub = rospy.Publisher(
           'connected_clients', ConnectedClients, queue_size=10, latch=True)
@@ -53,7 +52,7 @@ class ClientManager:
     def __publish(self):
         msg = ConnectedClients()
         msg.clients = list(self._clients.values())
-        self._conn_clients_pub.publish(msg.clients)
+        self._conn_clients_pub.publish(msg)
         self._client_count_pub.publish(len(msg.clients))
 
     def add_client(self, client_id, ip_address):

--- a/rosbridge_server/src/rosbridge_server/client_mananger.py
+++ b/rosbridge_server/src/rosbridge_server/client_mananger.py
@@ -58,13 +58,13 @@ class ClientManager:
 
     def add_client(self, client_id, ip_address):
         with self._lock:
-          client = ConnectedClient()
-          client.ip_address = ip_address
-          client.connection_time = rospy.Time.now()
-          self._clients[client_id] = client
-          self.__publish()
+            client = ConnectedClient()
+            client.ip_address = ip_address
+            client.connection_time = rospy.Time.now()
+            self._clients[client_id] = client
+            self.__publish()
 
     def remove_client(self, client_id, ip_address):
         with self._lock:
-          self._clients.pop(client_id, None)
-          self.__publish()
+            self._clients.pop(client_id, None)
+            self.__publish()

--- a/rosbridge_server/src/rosbridge_server/client_mananger.py
+++ b/rosbridge_server/src/rosbridge_server/client_mananger.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, Intermodalics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Intermodalics nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import rospy
+from rosbridge_msgs.msg import ConnectedClient, ConnectedClients
+from std_msgs.msg import Int32
+
+
+class ClientManager:
+    def __init__(self):
+        # Publisher for number of connected clients
+        self._client_count_pub = rospy.Publisher(
+          'client_count', Int32, queue_size=10, latch=True)
+        self._client_count_pub.publish(0)
+        # Publisher for connected clients
+        self._conn_clients_pub = rospy.Publisher(
+          'connected_clients', ConnectedClients, queue_size=10, latch=True)
+        self._client_count = 0
+        self._clients = {}
+        self.__publish()
+
+    def __publish(self):
+        msg = ConnectedClients()
+        msg.clients = list(self._clients.values())
+        self._conn_clients_pub.publish(msg.clients)
+        self._client_count_pub.publish(len(msg.clients))
+
+    def add_client(self, client_id, ip_address):
+        client = ConnectedClient()
+        client.ip_address = ip_address
+        client.connection_time = rospy.Time.now()
+        self._clients[client_id] = client
+        self.__publish()
+
+    def remove_client(self, client_id, ip_address):
+        self._clients.pop(client_id, None)
+        self.__publish()


### PR DESCRIPTION
Latches a list of all connected clients, where each client is described by
- the client's IP address
- the time the client connected

This only works for the websocket server for now. Let me know if this is something useful. If so, then I will look into adding this functionality also to the other backends.