### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # This config file for Travis CI utilizes ros-industrial/industrial_ci package.
 # For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
 
-dist: trusty
-sudo: required
 services:
   - docker
 language: generic


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

Also, do not hard-code __Trusty__ because it reaches its end-of-support this month.
https://wiki.ubuntu.com/Releases