### PR TITLE
Add settings for websocket timeout

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -79,6 +79,11 @@ if __name__ == "__main__":
     if RosbridgeWebSocket.max_message_size == "None":
         RosbridgeWebSocket.max_message_size = None
 
+    # get tornado application parameters
+    tornado_settings = {}
+    tornado_settings['websocket_ping_interval'] = float(rospy.get_param('~websocket_ping_interval', 0))
+    tornado_settings['websocket_ping_timeout'] = float(rospy.get_param('~websocket_ping_timeout', 30))
+
     # SSL options
     certfile = rospy.get_param('~certfile', None)
     keyfile = rospy.get_param('~keyfile', None)
@@ -202,6 +207,22 @@ if __name__ == "__main__":
     if ("--bson_only_mode" in sys.argv) or bson_only_mode:
         RosbridgeWebSocket.bson_only_mode = bson_only_mode
 
+    if "--websocket_ping_interval" in sys.argv:
+        idx = sys.argv.index("--websocket_ping_interval") + 1
+        if idx < len(sys.argv):
+            tornado_settings['websocket_ping_interval'] = float(sys.argv[idx])
+        else:
+            print("--websocket_ping_interval argument provided without a value.")
+            sys.exit(-1)
+
+    if "--websocket_ping_timeout" in sys.argv:
+        idx = sys.argv.index("--websocket_ping_timeout") + 1
+        if idx < len(sys.argv):
+            tornado_settings['websocket_ping_timeout'] = float(sys.argv[idx])
+        else:
+            print("--websocket_ping_timeout argument provided without a value.")
+            sys.exit(-1)
+
     # To be able to access the list of topics and services, you must be able to access the rosapi services.
     if RosbridgeWebSocket.services_glob:
         RosbridgeWebSocket.services_glob.append("/rosapi/*")
@@ -217,7 +238,7 @@ if __name__ == "__main__":
     # Done with parameter handling                   #
     ##################################################
 
-    application = Application([(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)])
+    application = Application([(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)], **tornado_settings)
 
     connected = False
     while not connected and not rospy.is_shutdown():

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -42,6 +42,7 @@ from functools import partial, wraps
 
 from tornado import version_info as tornado_version_info
 from tornado.ioloop import IOLoop
+from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketHandler, WebSocketClosedError
 from tornado.gen import coroutine, BadYieldError
 
@@ -169,7 +170,10 @@ class RosbridgeWebSocket(WebSocketHandler):
             with self._write_lock:
                 yield self.write_message(message, binary)
         except WebSocketClosedError:
-            rospy.logwarn('WebSocketClosedError: Tried to write to a closed websocket')
+            rospy.logwarn_throttle(1, 'WebSocketClosedError: Tried to write to a closed websocket')
+            raise
+        except StreamClosedError:
+            rospy.logwarn_throttle(1, 'StreamClosedError: Tried to write to a closed stream')
             raise
         except BadYieldError:
             # Tornado <4.5.0 doesn't like its own yield and raises BadYieldError.


### PR DESCRIPTION
I've noticed that if the connection between websocket client and server is closed unexpectedly, a client can be marked as connected forever on the server. With only one client I managed to make the `client_count` topic grow higher than 3 by disabling wifi while rosbridge was connected.

Tornado has parameters to enable the keep-alive ping which is integrated into [websocket protocol](https://tools.ietf.org/html/rfc6455#section-5.5.2). I exposed `websocket_ping_interval` and `websocket_ping_timeout` as ROS and CLI parameters. [Tornado documentation of those parameters](https://www.tornadoweb.org/en/stable/web.html#tornado.web.Application.settings).

I've set `websocket_ping_interval` to 0, to let this feature disabled by default. Because if someone use rosbridge with a buggy websocket client, it might not answer to the ping. So, it can be a breaking change in some case if we enable it by default. I let you decide if you want to enable it by default.