### PR TITLE
Access to constants of messages/services via rosbridge 

### DIFF
--- a/rosapi/msg/TypeDef.msg
+++ b/rosapi/msg/TypeDef.msg
@@ -3,3 +3,5 @@ string[] fieldnames
 string[] fieldtypes
 int32[] fieldarraylen
 string[] examples
+string[] constnames
+string[] constvalues

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -97,6 +97,7 @@ def get_action_servers(request):
     topics = proxy.get_topics(rosapi.glob_helper.topics_glob)
     action_servers = proxy.filter_action_servers(topics)
     return GetActionServersResponse(action_servers)
+    
 def get_topic_type(request):
     """ Called by the rosapi/TopicType service.  Given the name of a topic, returns the name of the type of that topic.
     Request class has one field, 'topic', which is a string value (the name of the topic)
@@ -182,6 +183,8 @@ def dict_to_typedef(typedefdict):
     typedef.fieldtypes = typedefdict["fieldtypes"]
     typedef.fieldarraylen = typedefdict["fieldarraylen"]
     typedef.examples = typedefdict["examples"]
+    typedef.constnames = typedefdict["constnames"]
+    typedef.constvalues = typedefdict["constvalues"]
     return typedef
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is currently no access to the constants of messages/services via rosbridge.

These new lines added to the current project permit us to get an access to these values and use them if needed. `constnames` and `constvalues` variables are added to TypeDef.msg.