### PR TITLE
Porting rosbridge library (capabilities and internal) to ROS2.

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -44,15 +44,20 @@ from rosapi.msg import *
 
 class Rosapi(Node):
 
+    NAME = 'rosapi'
+
     def __init__(self):
-        super().__init__('rosapi')
+        super().__init__(self.NAME)
+        self.declare_parameter('topics_glob', '[*]')
+        self.declare_parameter('services_glob', '[*]')
+        self.declare_parameter('params_glob', '[*]')
         self.globs = self.get_globs()
         self.register_services()
 
     # Initialises the ROS node
     def register_services(self):
         proxy.init(self)
-        params.init()
+        params.init(self.NAME)
         self.create_service(Topics, '/rosapi/topics', self.get_topics)
         self.create_service(TopicsForType, '/rosapi/topics_for_type', self.get_topics_for_type)
         self.create_service(Services, '/rosapi/services', self.get_services)
@@ -180,15 +185,27 @@ class Rosapi(Node):
         return response
 
     def set_param(self, request, response):
-        params.set_param(request.node_name, request.name, request.value, self.globs.params)
+        try:
+            node_name, param_name = self._get_node_and_param_name(request.name)
+            params.set_param(node_name, param_name, request.value, self.globs.params)
+        except ValueError:
+            self._print_malformed_param_name_warning(request.name)
         return response
 
     def get_param(self, request, response):
-        response.value = params.get_param(request.node_name, request.name, request.default_value, self.globs.params)
+        try:
+            node_name, param_name = self._get_node_and_param_name(request.name)
+            response.value = params.get_param(node_name, param_name, request.default_value, self.globs.params)
+        except ValueError:
+            self._print_malformed_param_name_warning(request.name)
         return response
 
     def has_param(self, request, response):
-        response.exists = params.has_param(request.node_name, request.name, self.globs.params)
+        try:
+            node_name, param_name = self._get_node_and_param_name(request.name)
+            response.exists = params.has_param(node_name, param_name, self.globs.params)
+        except ValueError:
+            self._print_malformed_param_name_warning(request.name)
         return response
 
     def delete_param(self, request, response):
@@ -196,13 +213,18 @@ class Rosapi(Node):
         return response
 
     def get_param_names(self, request, response):
-        response.names = params.get_param_names(request.node_name, self.globs.params)
+        response.names = params.get_param_names(self.globs.params)
         return response
 
     def get_time(self, request, response):
         response.time = Clock(clock_type=ClockType.ROS_TIME).now().to_msg()
         return response
 
+    def _get_node_and_param_name(self, param):
+        return tuple(param.split(':'))
+
+    def _print_malformed_param_name_warning(self, param_name):
+        self.get_logger().warn('Malformed parameter name: {}; expecting <node_name>:<param_name>'.format(param_name))
 
 # TODO(@jubeira): make all of these methods of the node and port them.
 

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -57,7 +57,11 @@ class Rosapi(Node):
     # Initialises the ROS node
     def register_services(self):
         proxy.init(self)
-        params.init(self.NAME)
+        if self.get_namespace() == '/':
+            full_name = self.get_namespace() + self.get_name()
+        else:
+            full_name = self.get_namespace() + '/' + self.get_name()
+        params.init(full_name)
         self.create_service(Topics, '/rosapi/topics', self.get_topics)
         self.create_service(TopicsForType, '/rosapi/topics_for_type', self.get_topics_for_type)
         self.create_service(Services, '/rosapi/services', self.get_services)

--- a/rosapi/src/rosapi/glob_helper.py
+++ b/rosapi/src/rosapi/glob_helper.py
@@ -21,9 +21,9 @@ def get_globs(node):
             for element in parameter_value.strip('[').strip(']').split(',')
             if len(element.strip().strip("'")) > 0]
 
-    topics_glob = get_param('/topics_glob')
-    services_glob = get_param('/services_glob')
-    params_glob = get_param('/params_glob')
+    topics_glob = get_param('topics_glob')
+    services_glob = get_param('services_glob')
+    params_glob = get_param('params_glob')
     return Globs(topics_glob, services_glob, params_glob)
 
 

--- a/rosapi/srv/DeleteParam.srv
+++ b/rosapi/srv/DeleteParam.srv
@@ -1,3 +1,2 @@
-string node_name
 string name
 ---

--- a/rosapi/srv/GetParam.srv
+++ b/rosapi/srv/GetParam.srv
@@ -1,4 +1,3 @@
-string node_name
 string name
 string default_value
 ---

--- a/rosapi/srv/GetParamNames.srv
+++ b/rosapi/srv/GetParamNames.srv
@@ -1,3 +1,2 @@
-string node_name
 ---
 string[] names

--- a/rosapi/srv/HasParam.srv
+++ b/rosapi/srv/HasParam.srv
@@ -1,4 +1,3 @@
-string node_name
 string name
 ---
 bool exists

--- a/rosapi/srv/SetParam.srv
+++ b/rosapi/srv/SetParam.srv
@@ -1,4 +1,3 @@
-string node_name
 string name
 string value
 ---

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -47,18 +47,20 @@ class Registration():
 
     """
 
-    def __init__(self, client_id, topic):
+    def __init__(self, client_id, topic, node_handle):
         # Initialise variables
         self.client_id = client_id
         self.topic = topic
         self.clients = {}
+        self.node_handle = node_handle
 
     def unregister(self):
         manager.unregister(self.client_id, self.topic)
 
     def register_advertisement(self, msg_type, adv_id=None, latch=False, queue_size=100):
         # Register with the publisher manager, propagating any exception
-        manager.register(self.client_id, self.topic, msg_type, latch=latch, queue_size=queue_size)
+        manager.register(
+            self.client_id, self.topic, self.node_handle, msg_type=msg_type, latch=latch, queue_size=queue_size)
 
         self.clients[adv_id] = True
 
@@ -120,7 +122,7 @@ class Advertise(Capability):
         # Create the Registration if one doesn't yet exist
         if not topic in self._registrations:
             client_id = self.protocol.client_id
-            self._registrations[topic] = Registration(client_id, topic)
+            self._registrations[topic] = Registration(client_id, topic, self.protocol.node_handle)
 
         # Register, propagating any exceptions
         self._registrations[topic].register_advertisement(msg_type, aid, latch, queue_size)

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
@@ -7,7 +7,6 @@ from rosbridge_library.internal import message_conversion
 from rosbridge_library.capability import Capability
 from rosbridge_library.util import string_types
 
-import rospy
 
 class AdvertisedServiceHandler():
 
@@ -22,7 +21,7 @@ class AdvertisedServiceHandler():
         self.service_type = service_type
         self.protocol = protocol
         # setup the service
-        self.service_handle = rospy.Service(service_name, get_service_class(service_type), self.handle_request)
+        self.service_handle = protocol.node_handle.create_service(get_service_class(service_type), service_name, self.handle_request)
 
     def next_id(self):
         id = self.id_counter
@@ -69,7 +68,7 @@ class AdvertisedServiceHandler():
         """
         Signal the AdvertisedServiceHandler to shutdown
 
-        Using this, rather than just rospy.Service.shutdown(), allows us
+        Using this, rather than just node_handle.destroy_service, allows us
         time to stop any active service requests, ending their busy wait
         loops.
         """
@@ -78,6 +77,7 @@ class AdvertisedServiceHandler():
         start_time = time.clock()
         while time.clock() - start_time < timeout:
             time.sleep(0)
+        self.protocol.node_handle.destroy_service(self.service_handle)
 
 class AdvertiseService(Capability):
     services_glob = None

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -86,8 +86,8 @@ class CallService(Capability):
         s_cb = partial(self._success, cid, service, fragment_size, compression)
         e_cb = partial(self._failure, cid, service)
 
-        # Kick off the service caller thread
-        ServiceCaller(trim_servicename(service), args, s_cb, e_cb).start()
+        # Run service caller in the same thread.
+        ServiceCaller(trim_servicename(service), args, s_cb, e_cb, self.protocol.node_handle).run()
 
     def _success(self, cid, service, fragment_size, compression, message):
         outgoing_message = {

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -79,14 +79,14 @@ class Publish(Capability):
 
         # Register as a publishing client, propagating any exceptions
         client_id = self.protocol.client_id
-        manager.register(client_id, topic, latch=latch, queue_size=queue_size)
+        manager.register(client_id, topic, self.protocol.node_handle, latch=latch, queue_size=queue_size)
         self._published[topic] = True
 
         # Get the message if one was provided
         msg = message.get("msg", {})
 
         # Publish the message
-        manager.publish(client_id, topic, msg, latch=latch, queue_size=queue_size)
+        manager.publish(client_id, topic, msg, self.protocol.node_handle, latch=latch, queue_size=queue_size)
 
     def finish(self):
         client_id = self.protocol.client_id

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -87,7 +87,6 @@ class Subscription():
     def unregister(self):
         """ Unsubscribes this subscription and cleans up resources """
         manager.unsubscribe(self.client_id, self.topic)
-
         with self.handler_lock:
             self.handler.finish()
         self.clients.clear()

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -36,7 +36,6 @@ PYTHON2 = sys.version_info < (3, 0)
 import fnmatch
 from threading import Lock
 from functools import partial
-from rospy import loginfo
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.subscribers import manager
 from rosbridge_library.internal.subscription_modifiers import MessageHandler
@@ -63,7 +62,7 @@ class Subscription():
 
     Chooses the most appropriate settings to send messages """
 
-    def __init__(self, client_id, topic, publish):
+    def __init__(self, client_id, topic, publish, node_handle):
         """ Create a subscription for the specified client on the specified
         topic, with callback publish
 
@@ -71,11 +70,13 @@ class Subscription():
         client_id -- the ID of the client making this subscription
         topic     -- the name of the topic to subscribe to
         publish   -- the callback function for incoming messages
+        node_handle -- Handle to a rclpy node to create the publisher.
 
         """
         self.client_id = client_id
         self.topic = topic
         self.publish = publish
+        self.node_handle = node_handle
 
         self.clients = {}
 
@@ -86,6 +87,7 @@ class Subscription():
     def unregister(self):
         """ Unsubscribes this subscription and cleans up resources """
         manager.unsubscribe(self.client_id, self.topic)
+
         with self.handler_lock:
             self.handler.finish()
         self.clients.clear()
@@ -124,7 +126,8 @@ class Subscription():
         self.update_params()
 
         # Subscribe with the manager. This will propagate any exceptions
-        manager.subscribe(self.client_id, self.topic, self.on_msg, msg_type)
+        manager.subscribe(
+            self.client_id, self.topic, self.on_msg, self.node_handle, msg_type=msg_type)
 
     def unsubscribe(self, sid=None):
         """ Unsubscribe this particular client's subscription
@@ -239,7 +242,7 @@ class Subscribe(Capability):
         if not topic in self._subscriptions:
             client_id = self.protocol.client_id
             cb = partial(self.publish, topic)
-            self._subscriptions[topic] = Subscription(client_id, topic, cb)
+            self._subscriptions[topic] = Subscription(client_id, topic, cb, self.protocol.node_handle)
 
         # Register the subscriber
         subscribe_args = {

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -179,7 +179,7 @@ def _from_inst(inst, rostype):
     # Check for primitive types
     if rostype in ros_primitive_types:
         #JSON does not support Inf and NaN. They are mapped to None and encoded as null
-        if (not bson_only_mode) and (rostype in ["float32", "float64"]):
+        if (not bson_only_mode) and (rostype in type_map.get('float')):
             if math.isnan(inst) or math.isinf(inst):
                 return None
         return inst
@@ -201,7 +201,7 @@ def _from_list_inst(inst, rostype):
     rostype = re.search(list_tokens, rostype).group(1)
 
     # Shortcut for primitives
-    if rostype in ros_primitive_types and not rostype in ["float32", "float64"]:
+    if rostype in ros_primitive_types and not rostype in type_map.get('float'):
         return list(inst)
 
     # Call to _to_inst for every element of the list

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -32,8 +32,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
-import roslib
-import rospy
+import rclpy
+from rclpy.clock import ROSClock
 
 from rosbridge_library.internal import ros_loader
 
@@ -51,7 +51,7 @@ if sys.version_info >= (3, 0):
     "int":     ["int8", "byte", "uint8", "char",
                 "int16", "uint16", "int32", "uint32",
                 "int64", "uint64", "float32", "float64"],
-    "float":   ["float32", "float64"],
+    "float":   ["float32", "float64", "double"],
     "str":     ["string"]
     }
     primitive_types = [bool, int, float]
@@ -71,25 +71,32 @@ else:
     python2 = True
 
 list_types = [list, tuple]
-ros_time_types = ["time", "duration"]
+ros_time_types = ["builtin_interfaces/Time", "builtin_interfaces/Duration"]
 ros_primitive_types = ["bool", "byte", "char", "int8", "uint8", "int16",
                        "uint16", "int32", "uint32", "int64", "uint64",
-                       "float32", "float64", "string"]
+                       "float32", "float64", "double", "string"]
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
 ros_binary_types = ["uint8[]", "char[]"]
-list_braces = re.compile(r'\[[^\]]*\]')
+list_tokens = re.compile('<(.+?)>')
 ros_binary_types_list_braces = [("uint8[]", re.compile(r'uint8\[[^\]]*\]')),
                                 ("char[]", re.compile(r'char\[[^\]]*\]'))]
 
 binary_encoder = None
-bson_only_mode = None
+binary_encoder_type = 'default'
+bson_only_mode = False
 
-def get_encoder():
-    global binary_encoder,bson_only_mode
+# TODO(@jubeira): configure module with a node handle.
+# The original code doesn't seem to actually use these parameters.
+def configure(node_handle=None):
+    global binary_encoder, binary_encoder_type, bson_only_mode
+
+    if node_handle is not None:
+        binary_encoder_type = node_handler.get_parameter_or('binary_encoder',
+            Parameter('', value='default')).value
+        bson_only_mode = node_handler.get_parameter_or('bson_only_mode',
+            Parameter('', value=False)).value
+
     if binary_encoder is None:
-        binary_encoder_type = rospy.get_param('~binary_encoder', 'default')
-        bson_only_mode = rospy.get_param('~bson_only_mode', False)
-
         if binary_encoder_type == 'bson' or bson_only_mode:
             binary_encoder = bson.Binary
         elif binary_encoder_type == 'default' or binary_encoder_type == 'b64':
@@ -97,6 +104,9 @@ def get_encoder():
         else:
             print("Unknown encoder type '%s'"%binary_encoder_type)
             exit(0)
+
+def get_encoder():
+    configure()
     return binary_encoder
 
 class InvalidMessageException(Exception):
@@ -118,7 +128,7 @@ class FieldTypeMismatchException(Exception):
 
 
 def extract_values(inst):
-    rostype = getattr(inst, "_type", None)
+    rostype = msg_instance_type_repr(inst)
     if rostype is None:
         raise InvalidMessageException(inst=inst)
     return _from_inst(inst, rostype)
@@ -127,7 +137,30 @@ def extract_values(inst):
 def populate_instance(msg, inst):
     """ Returns an instance of the provided class, with its fields populated
     according to the values in msg """
-    return _to_inst(msg, inst._type, inst._type, inst)
+    inst_type = msg_instance_type_repr(inst)
+
+    return _to_inst(msg, inst_type, inst_type, inst)
+
+
+def msg_instance_type_repr(msg_inst):
+    """Returns a string representation of a ROS2 message type from a message instance"""
+    # Message representation: '{package}.msg.{message_name}({fields})'.
+    # A representation like '_type' member in ROS1 messages is needed: '{package}/{message_name}'.
+    # E.g: 'std_msgs/Header'
+    msg_type = type(msg_inst)
+    if msg_type in primitive_types or msg_type in list_types:
+        return str(type(inst))
+    inst_repr = str(msg_inst).split('.')
+    return '{}/{}'.format(inst_repr[0], inst_repr[2].split('(')[0])
+
+
+def msg_class_type_repr(msg_class):
+    """Returns a string representation of a ROS2 message type from a class representation."""
+    # The string representation of the class is <class '{package}.msg._{message}.{Message}'>
+    # (e.g. <class 'std_msgs.msg._string.String'>).
+    # This has to be converted to {package}/msg/{Message} (e.g. std_msgs/msg/String).
+    class_repr = str(msg_class).split('\'')[1].split('.')
+    return '{}/{}/{}'.format(class_repr[0], class_repr[1], class_repr[3])
 
 
 def _from_inst(inst, rostype):
@@ -165,7 +198,7 @@ def _from_list_inst(inst, rostype):
         return []
 
     # Remove the list indicators from the rostype
-    rostype = list_braces.sub("", rostype)
+    rostype = re.search(list_tokens, rostype).group(1)
 
     # Shortcut for primitives
     if rostype in ros_primitive_types and not rostype in ["float32", "float64"]:
@@ -178,7 +211,8 @@ def _from_list_inst(inst, rostype):
 def _from_object_inst(inst, rostype):
     # Create an empty dict then populate with values from the inst
     msg = {}
-    for field_name, field_rostype in zip(inst.__slots__, inst._slot_types):
+    # Equivalent for zip(inst.__slots__, inst._slot_types) in ROS1:
+    for field_name, field_rostype in inst.get_fields_and_field_types().items():
         field_inst = getattr(inst, field_name)
         msg[field_name] = _from_inst(field_inst, field_rostype)
     return msg
@@ -224,14 +258,15 @@ def _to_binary_inst(msg):
 
 def _to_time_inst(msg, rostype, inst=None):
     # Create an instance if we haven't been provided with one
+
     if rostype == "time" and msg == "now":
-        return rospy.get_rostime()
+        return ROSClock().now().to_msg()
 
     if inst is None:
         if rostype == "time":
-            inst = rospy.rostime.Time()
+            inst = rclpy.time.Time().to_msg()
         elif rostype == "duration":
-            inst = rospy.rostime.Duration()
+            inst = rclpy.duration.Duration().to_msg()
         else:
             return None
 
@@ -266,7 +301,7 @@ def _to_list_inst(msg, rostype, roottype, inst, stack):
         return []
 
     # Remove the list indicators from the rostype
-    rostype = list_braces.sub("", rostype)
+    rostype = re.search(list_tokens, rostype).group(1)
 
     # Call to _to_inst for every element of the list
     return [_to_inst(x, rostype, roottype, None, stack) for x in msg]
@@ -278,13 +313,10 @@ def _to_object_inst(msg, rostype, roottype, inst, stack):
         raise FieldTypeMismatchException(roottype, stack, rostype, type(msg))
 
     # Substitute the correct time if we're an std_msgs/Header
-    try:
-        if rostype in ros_header_types:
-            inst.stamp = rospy.get_rostime()
-    except rospy.exceptions.ROSInitException as e:
-        rospy.logdebug("Not substituting the correct header time: %s" % e)
+    if rostype in ros_header_types:
+        inst.stamp = ROSClock().now().to_msg()
 
-    inst_fields = dict(zip(inst.__slots__, inst._slot_types))
+    inst_fields = inst.get_fields_and_field_types()
 
     for field_name in msg:
         # Add this field to the field stack

--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -199,6 +199,8 @@ def _splittype(typestring):
     splits = [x for x in typestring.split("/") if x]
     if len(splits) == 2:
         return splits
+    elif len(splits) == 3:
+        return (splits[0], splits[2])
     raise InvalidTypeStringException(typestring)
 
 

--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -197,9 +197,7 @@ def _splittype(typestring):
     more forgiving about excess slashes
     """
     splits = [x for x in typestring.split("/") if x]
-    if len(splits) == 2:
-        return splits
-    elif len(splits) == 3:
+    if len(splits) == 3:
         return (splits[0], splits[2])
     raise InvalidTypeStringException(typestring)
 

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -30,7 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import rospy
 import time
 
 from rosbridge_library.internal.exceptions import InvalidArgumentException
@@ -92,16 +91,18 @@ class Protocol:
 
     parameters = None
 
-    def __init__(self, client_id):
+    def __init__(self, client_id, node_handle):
         """ Keyword arguments:
         client_id -- a unique ID for this client to take.  Uniqueness is
         important otherwise there will be conflicts between multiple clients
         with shared resources
+        node_handle -- a ROS2 node handle.
 
         """
         self.client_id = client_id
         self.capabilities = []
         self.operations = {}
+        self.node_handle = node_handle
 
         if self.parameters:
             self.fragment_size = self.parameters["max_message_size"]
@@ -383,10 +384,10 @@ class Protocol:
             stdout_formatted_msg = "[Client %s] %s" % (self.client_id, message)
 
         if level == "error" or level == "err":
-            rospy.logerr(stdout_formatted_msg)
+            self.node_handle.get_logger().error(stdout_formatted_msg)
         elif level == "warning" or level == "warn":
-            rospy.logwarn(stdout_formatted_msg)
+            self.node_handle.get_logger().warn(stdout_formatted_msg)
         elif level == "info" or level == "information":
-            rospy.loginfo(stdout_formatted_msg)
+            self.node_handle.get_logger().info(stdout_formatted_msg)
         else:
-            rospy.logdebug(stdout_formatted_msg)
+            self.node_handle.get_logger().debug(stdout_formatted_msg)

--- a/rosbridge_library/src/rosbridge_library/rosbridge_protocol.py
+++ b/rosbridge_library/src/rosbridge_library/rosbridge_protocol.py
@@ -55,8 +55,8 @@ class RosbridgeProtocol(Protocol):
 
     parameters = None
 
-    def __init__(self, client_id, parameters = None):
+    def __init__(self, client_id, node_handle, parameters = None):
         self.parameters = parameters
-        Protocol.__init__(self, client_id)
+        Protocol.__init__(self, client_id, node_handle)
         for capability_class in self.rosbridge_capabilities:
             self.add_capability(capability_class)

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,21 +1,20 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(rosbridge_msgs)
 
-find_package(catkin REQUIRED COMPONENTS
-  message_generation std_msgs
+find_package(ament_cmake_ros REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  msg/ConnectedClient.msg
+  msg/ConnectedClients.msg
+  DEPENDENCIES builtin_interfaces
 )
 
-add_message_files(
-  FILES
-  ConnectedClient.msg
-  ConnectedClients.msg
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-generate_messages(
-  DEPENDENCIES
-  std_msgs
-)
-
-catkin_package(
-  CATKIN_DEPENDS message_runtime std_msgs
-)
+ament_package()

--- a/rosbridge_msgs/msg/ConnectedClient.msg
+++ b/rosbridge_msgs/msg/ConnectedClient.msg
@@ -1,2 +1,2 @@
 string ip_address
-time connection_time
+builtin_interfaces/Time connection_time

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>rosbridge_msgs</name>
   <version>0.11.3</version>
   <description>Package containing message files</description>
@@ -9,11 +9,14 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>std_msgs</depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
 </package>

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -10,11 +10,9 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
+  <build_depend>builtin_interfaces</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rosbridge_server/src/rosbridge_server/__init__.py
+++ b/rosbridge_server/src/rosbridge_server/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from .websocket_handler import RosbridgeWebSocket
-from .tcp_handler import RosbridgeTcpSocket
-from .udp_handler import RosbridgeUdpSocket,RosbridgeUdpFactory
 from .client_mananger import ClientManager
+
+# TODO(@jubeira): add imports again once the modules are ported to ROS2.
+# from .tcp_handler import RosbridgeTcpSocket
+# from .udp_handler import RosbridgeUdpSocket,RosbridgeUdpFactory

--- a/rosbridge_server/src/rosbridge_server/client_mananger.py
+++ b/rosbridge_server/src/rosbridge_server/client_mananger.py
@@ -41,7 +41,7 @@ from std_msgs.msg import Int32
 
 class ClientManager:
     def __init__(self, node_handle):
-        qos = QoSProfile(depth=10,
+        qos = QoSProfile(depth=1,
             durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
 
         # Publisher for number of connected clients


### PR DESCRIPTION
See https://github.com/ros2/rosbridge_suite/issues/3.

With this patch, all the code from the entrypoint (`Websocket server`) up to the internal libraries should be ROS2-compatible, and no references to `rclpy` or ROS1 code should remain.

<details><summary>Details</summary>

- All the ROS1 code that involves publishers, subscribers and services now need a `rclpy.node.Node` handle to work.
- `RosbridgeWebsocketNode` in `rosbridge_websocket` module was converted to a ROS2 node because it's near the entry point of the application. A reference to it shall be used to generate publishers, subscribers and service clients where necessary.
- Besides routing the node handle to all the points of the program where it was required (the deepest point from the entrypoint is the `internal` package), there were a few features from ROS1 that changed a bit, so workarounds had to be found:
  - In `publishers` module inside `internal`, a ROS1 `SubscriberListener` was used to prevent late-joining subscribers from missing messages. This is now achieved using transient local QoS with a lifespan.
  - At the same time, there was support for latched topics. This now applies for publishers and subscribers, so transient local is the QoS of choice for subscribers as well.
  - In `subscribers` module, additional subscriber callbacks were used to send latched messages to new (web) subscribers using only one ROS subscriber. Since this is not available in ROS2 (at least not that I know of), a workaround was implemented and tested in a minimal example. 
- In `message_conversion`, the parameters don't seem to be used in the original code. For a first iteration, using defaults should work.
</details>