### PR TITLE
Fixes #418: WebSocketClosedError Spam

### DIFF
--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -172,6 +172,7 @@ class RosbridgeWebSocket(WebSocketHandler):
 
                 # When closing, self.write_message() return None even if it's an undocument output.
                 # Consider it as WebSocketClosedError
+                # For tornado versions <4.3.0 self.write_message() does not have a return value
                 if future is None and tornado_version_info >= (4,3,0,0):
                     raise WebSocketClosedError
 

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -172,7 +172,7 @@ class RosbridgeWebSocket(WebSocketHandler):
 
                 # When closing, self.write_message() return None even if it's an undocument output.
                 # Consider it as WebSocketClosedError
-                if future is None:
+                if future is None and tornado_version_info >= (4,3,0,0):
                     raise WebSocketClosedError
 
                 yield future


### PR DESCRIPTION
#413 added a check for the result of tornados WebSocketHandler.write_message and is throwing WebSocketClosedError if its None.
WebSocketHandler.write_message does return a Future since version 4.3.0. ([tornado write_message doc](https://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler.write_message))
I added a check to only raisie the Error when version is >4.3.0, to prevent anyone using a tornado version <4.3.0 to have a WebSockedClosedError for every message (see #418).