### PR TITLE
[ROS 2] rosbridge_msgs: add missing build type

### DIFF
--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -17,4 +17,7 @@
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Fixes #431.