### PR TITLE
autobahn_websocket.py: Convert BSON to bytes before call to sendMessage

### DIFF
--- a/rosbridge_server/src/rosbridge_server/autobahn_websocket.py
+++ b/rosbridge_server/src/rosbridge_server/autobahn_websocket.py
@@ -182,6 +182,7 @@ class RosbridgeWebSocket(WebSocketServerProtocol):
     def outgoing(self, message):
         if type(message) == bson.BSON:
             binary = True
+            message = bytes(message)
         elif type(message) == bytearray:
             binary = True
             message = bytes(message)


### PR DESCRIPTION
Fixes a crash when sending data from rosbridge_server to client when running server with bson_only_mode=True 

autobahn.websocket.WebSocketServerProtocol.sendMessage asserts whether message is of type bytes, which fails for message of type bson.BSON. Hence a conversion is required. 

