### PR TITLE
Python 3 fix for dict::values

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -162,7 +162,7 @@ class MultiSubscriber():
         # Get the callbacks to call
         if not callbacks:
             with self.lock:
-                callbacks = self.subscriptions.values()
+                callbacks = list(self.subscriptions.values())
 
         # Pass the JSON to each of the callbacks
         for callback in callbacks:


### PR DESCRIPTION
Under Python 3, values() returns a `dict_values` iterator, and because that object is used outside the mutex, we were getting `RuntimeError: dictionary changed size during iteration` under some circumstances. This creates a copy of the values, restoring the Python 2 behaviour and fixing the problem.