### PR TITLE
Install scripts with catkin_install_python.

### DIFF
--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_python_setup()
 
 catkin_package()
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/rosbridge_websocket.py
   scripts/rosbridge_websocket
   scripts/rosbridge_tcp.py


### PR DESCRIPTION
This is friendlier to using alternative pythons, and the recommended approach:

http://docs.ros.org/melodic/api/catkin/html/howto/format2/installing_python.html#scripts