### PR TITLE
Add cbor-raw compression

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -33,6 +33,7 @@ add_service_files(
   SetParam.srv
   Subscribers.srv
   Topics.srv
+  TopicsAndRawTypes.srv
   TopicsForType.srv
   TopicType.srv
 )

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -65,6 +65,7 @@ def register_services():
     rospy.Service('/rosapi/delete_param', DeleteParam, delete_param)
     rospy.Service('/rosapi/get_param_names', GetParamNames, get_param_names)
     rospy.Service('/rosapi/get_time', GetTime, get_time)
+    rospy.Service('/rosapi/topics_and_raw_types', TopicsAndRawTypes, get_topics_and_raw_types)
 
 def get_topics(request):
     """ Called by the rosapi/Topics service. Returns a list of all the topics being published. """
@@ -175,6 +176,12 @@ def get_param_names(request):
 
 def get_time(request):
     return GetTimeResponse(rospy.get_rostime())
+
+def get_topics_and_raw_types(request):
+    """ Called by the rosapi/topics_and_raw_types service. Returns a list of all the topics being published, and their
+    raw types, similar to `gendeps --cat`. """
+    topics, types = proxy.get_topics_and_types(rosapi.glob_helper.topics_glob)
+    return TopicsAndRawTypesResponse(topics, types, [objectutils.get_typedef_full_text(type) for type in types])
 
 def dict_to_typedef(typedefdict):
     typedef = TypeDef()

--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -95,6 +95,15 @@ def get_service_response_typedef_recursive(servicetype):
     # Return the list of sub-typedefs
     return _get_subtypedefs_recursive(typedef, [])
 
+def get_typedef_full_text(type):
+    """ Returns the full text (similar to `gendeps --cat`) for the specified message type """
+    # Get an instance of the service response class and get its typedef
+    try:
+        instance = ros_loader.get_message_instance(type)
+        return instance._full_text
+    except Exception:
+        return ""
+
 def _get_typedef(instance):
     """ Gets a typedef dict for the specified instance """
     if instance is None or not hasattr(instance, "__slots__") or not hasattr(instance, "_slot_types"):

--- a/rosapi/srv/TopicsAndRawTypes.srv
+++ b/rosapi/srv/TopicsAndRawTypes.srv
@@ -1,0 +1,5 @@
+
+---
+string[] topics
+string[] types
+string[] typedefs_full_text

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -38,6 +38,7 @@ from rosbridge_library.internal import ros_loader, message_conversion
 from rosbridge_library.internal.topics import TopicNotEstablishedException
 from rosbridge_library.internal.topics import TypeConflictException
 from rosbridge_library.internal.outgoing_message import OutgoingMessage
+from rospy.msg import AnyMsg
 
 """ Manages and interfaces with ROS Subscriber objects.  A single subscriber
 is shared between multiple clients
@@ -79,12 +80,15 @@ class MultiSubscriber():
         if msg_type is None:
             msg_type = topic_type
 
-        # Load the message class, propagating any exceptions from bad msg types
-        msg_class = ros_loader.get_message_class(msg_type)
+        if msg_type == "__AnyMsg":
+            msg_class = AnyMsg
+        else:
+            # Load the message class, propagating any exceptions from bad msg types
+            msg_class = ros_loader.get_message_class(msg_type)
 
-        # Make sure the specified msg type and established msg type are same
-        if topic_type is not None and topic_type != msg_class._type:
-            raise TypeConflictException(topic, topic_type, msg_class._type)
+            # Make sure the specified msg type and established msg type are same
+            if topic_type is not None and topic_type != msg_class._type:
+                raise TypeConflictException(topic, topic_type, msg_class._type)
 
         # Create the subscriber and associated member variables
         self.subscriptions = {}
@@ -110,6 +114,8 @@ class MultiSubscriber():
         this publisher
 
         """
+        if msg_type == "__AnyMsg":
+            return
         if not ros_loader.get_message_class(msg_type) is self.msg_class:
             raise TypeConflictException(self.topic,
                                         self.msg_class._type, msg_type)

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -27,4 +27,5 @@ install(FILES
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest(test/websocket/test_smoke.test)
+  add_rostest(test/websocket/test_cbor_raw.test)
 endif()

--- a/rosbridge_server/test/websocket/test_cbor_raw.py
+++ b/rosbridge_server/test/websocket/test_cbor_raw.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+import json
+import io
+import os
+import rostest
+import sys
+import threading
+import unittest
+
+import rospy
+from std_msgs.msg import String
+
+from twisted.internet import reactor
+from autobahn.twisted.websocket import (WebSocketClientProtocol,
+                                        WebSocketClientFactory)
+
+from rosbridge_library.util.cbor import loads as decode_cbor
+
+from twisted.python import log
+log.startLogging(sys.stderr)
+
+TOPIC = '/b_topic'
+STRING = 'B' * 10000
+WARMUP_DELAY = 1.0  # seconds
+TIME_LIMIT = 5.0  # seconds
+
+
+class TestWebsocketCborRaw(unittest.TestCase):
+    def test_cbor_raw(self):
+        test_client_received = []
+        class TestClientProtocol(WebSocketClientProtocol):
+            def onOpen(self):
+                self.sendMessage(json.dumps({
+                    'op': 'subscribe',
+                    'topic': TOPIC,
+                    'compression': 'cbor-raw',
+                }))
+
+            def onMessage(self, payload, binary):
+                test_client_received.append(payload)
+
+        protocol = os.environ.get('PROTOCOL')
+        port = rospy.get_param('/rosbridge_websocket/actual_port')
+        url = protocol + '://127.0.0.1:' + str(port)
+
+        factory = WebSocketClientFactory(url)
+        factory.protocol = TestClientProtocol
+        reactor.connectTCP('127.0.0.1', port, factory)
+
+        pub = rospy.Publisher(TOPIC, String, queue_size=1)
+        def publish_timer():
+            rospy.sleep(WARMUP_DELAY)
+            pub.publish(String(STRING))
+            rospy.sleep(TIME_LIMIT)
+            reactor.stop()
+        reactor.callInThread(publish_timer)
+        reactor.run()
+
+        self.assertEqual(len(test_client_received), 1)
+        websocket_message = decode_cbor(test_client_received[0])
+        self.assertEqual(websocket_message['topic'], TOPIC)
+        buff = io.BytesIO()
+        String(STRING).serialize(buff)
+        self.assertEqual(websocket_message['msg']['bytes'], buff.getvalue())
+
+
+PKG = 'rosbridge_server'
+NAME = 'test_websocket_cbor_raw'
+
+if __name__ == '__main__':
+    rospy.init_node(NAME)
+
+    while not rospy.is_shutdown() and not rospy.has_param('/rosbridge_websocket/actual_port'):
+        rospy.sleep(1.0)
+
+    rostest.rosrun(PKG, NAME, TestWebsocketCborRaw)

--- a/rosbridge_server/test/websocket/test_cbor_raw.test
+++ b/rosbridge_server/test/websocket/test_cbor_raw.test
@@ -1,0 +1,7 @@
+<launch>
+  <env name="PROTOCOL" value="ws" />
+  <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket.py">
+    <param name="port" value="0" />
+  </node>
+  <test test-name="test_cbor_raw" pkg="rosbridge_server" type="test_cbor_raw.py" />
+</launch>


### PR DESCRIPTION
The CBOR compression is already a huge win over JSON or PNG encoding, but it’s still suboptimal in some situations. This PR adds support for getting messages in their raw binary (ROS-serialized) format. This has benefits in the following cases:
- Your application already knows how to parse messages in bag files (e.g. using [rosbag.js](https://github.com/cruise-automation/rosbag.js)), which means that now you can use consistent code paths for both bags and live messages.
- You want to parse messages as late as possible, or in parallel, e.g. only in the thread or WebWorker that cares about the message. Delaying the parsing of the message means that moving or copying the message to the thread is cheaper when its in binary form, since no serialization between threads is necessary.
- You only care about part of the message, and don't need to parse the rest of it.
- You really care about performance; no conversion between the ROS binary format and CBOR is done in the rosbridge_sever.

For [Webviz](https://webviz.io) we care about all of these cases, and so we’d really like to be able to use raw binary ROS messages.

This seemed easy to support by extending the current CBOR-format. We simply encode the `outgoing_msg` (which contains stuff like the operation and the topic name) with CBOR, just like with the existing CBOR encoding. The only difference is that in the current CBOR encoding, the “msg” field is itself a CBOR structure that encodes the message, where in our encoding it’s a CBOR object that contains a “bytes” field, which is just a bytearray with the raw binary message.

Besides the “bytes” fields we also added “secs” and “nsecs” fields with the current time, which is useful when using `use_sim_time` set to true. Webviz needs this to properly show the simulated received time of messages.

Now that we have the raw messages, we need to be able to parse them on the client. Bags contain the raw message definitions as stored on the `._full_text` field on message instances, so we added a service call for accessing these raw message definitions for all topics in one call.

With both of these changes combined, you can now easily parse messages as late, parallel, partially, and fast as possible. In Webviz we intend to use this by either using [rosbag.js](https://github.com/cruise-automation/rosbag.js) or by parsing using the ROS deserializer compiled to WebAssembly, and by doing this in the WebWorker that actually controls the 3d canvas using the OffscreenCanvas API. This way we can have multiple rendering surfaces running from parallel threads. We already do this for some panels in Webviz, such as the Image panel, and we’ve seen substantial speedups with this method.

We also made a [companion PR to roslibjs](https://github.com/RobotWebTools/roslibjs/pull/351).

Documentation: we updated the ROSBRIDGE_PROTOCOL.md file with the new changes.

Test plan: we added a new test for the WebSocket server, modeled after the existing test. We also tested this end-to-end with our Webviz client, and it seems to work great.

Thanks to @vadimg for helping with this.