### PR TITLE
Default to supporting local files as we had before Autobahn.

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket.launch
+++ b/rosbridge_server/launch/rosbridge_websocket.launch
@@ -19,6 +19,7 @@
   <arg name="websocket_ping_interval" default="0" />
   <arg name="websocket_ping_timeout" default="30" />
   <arg name="websocket_external_port" default="None" />
+  <arg name="websocket_null_origin" default="true" />
 
   <arg name="topics_glob" default="[*]" />
   <arg name="services_glob" default="[*]" />
@@ -45,6 +46,7 @@
       <param name="websocket_ping_interval" value="$(arg websocket_ping_interval)" />
       <param name="websocket_ping_timeout" value="$(arg websocket_ping_timeout)" />
       <param name="websocket_external_port" value="$(arg websocket_external_port)" />
+      <param name="websocket_null_origin" value="$(arg websocket_null_origin)" />
 
       <param name="topics_glob" value="$(arg topics_glob)"/>
       <param name="services_glob" value="$(arg services_glob)"/>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -38,6 +38,7 @@ import sys
 from twisted.python import log
 from twisted.internet import reactor, ssl
 from twisted.internet.error import CannotListenError, ReactorNotRunning
+from distutils.version import LooseVersion
 import autobahn #to check version
 from autobahn.twisted.websocket import WebSocketServerFactory, listenWS
 from autobahn.websocket.compress import (PerMessageDeflateOffer,
@@ -274,7 +275,8 @@ if __name__ == "__main__":
     uri = '{}://{}:{}'.format(protocol, address, port)
     factory = WebSocketServerFactory(uri)
     factory.protocol = RosbridgeWebSocket
-    if autobahn.__version__ == '0.10.3':
+    # https://github.com/crossbario/autobahn-python/commit/2ef13a6804054de74eb36455b58a64a3c701f889
+    if LooseVersion(autobahn.__version__) < LooseVersion("0.15.0"):
         factory.setProtocolOptions(
             perMessageCompressionAccept=handle_compression_offers,
             autoPingInterval=ping_interval,


### PR DESCRIPTION
For Kinetic 0.10.3 version don't add the allowNullOrigin option.
For everything else add it and default to True because that is
consistent with the original behaviour of this package.