### PR TITLE
Fixing wrong header/stamp in published ROS-messsages

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -280,7 +280,10 @@ def _to_object_inst(msg, rostype, roottype, inst, stack):
     # Substitute the correct time if we're an std_msgs/Header
     try:
         if rostype in ros_header_types:
-            inst.stamp = rospy.get_rostime()
+            cur_time = rospy.get_rostime()
+            # copy attributes of global Time obj to inst.stamp
+            inst.stamp.secs = cur_time.secs
+            inst.stamp.nsecs = cur_time.nsecs
     except rospy.exceptions.ROSInitException as e:
         rospy.logdebug("Not substituting the correct header time: %s" % e)
 


### PR DESCRIPTION
When publishing a message to ROS (i.e. incoming from rosbridge_server's perspective), timestamps in the Header attributes all point to the same Time object iff the message contains multiple Header attributes (typically the case if a ROS message contains other ROS messages, e.g. ...Array-types) and rosparam use_sim_time is true. 

This commit fixes the issue. 