### PR TITLE
Add script for dockerized development shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+ARG DOCKER_ROS_DISTRO=melodic
+FROM ros:${DOCKER_ROS_DISTRO}
+
+# Booststrap workspace.
+ENV CATKIN_DIR=/catkin_ws
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+ && mkdir -p $CATKIN_DIR/src \
+ && cd $CATKIN_DIR/src \
+ && catkin_init_workspace
+WORKDIR $CATKIN_DIR
+
+# Install dependencies first.
+COPY rosbridge_suite/package.xml $CATKIN_DIR/src/rosbridge_suite/
+COPY rosbridge_library/package.xml $CATKIN_DIR/src/rosbridge_library/
+COPY rosbridge_server/package.xml $CATKIN_DIR/src/rosbridge_server/
+COPY rosbridge_msgs/package.xml $CATKIN_DIR/src/rosbridge_msgs/
+COPY rosapi/package.xml $CATKIN_DIR/src/rosapi/
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+ && apt-get update \
+ && rosdep update \
+ && rosdep install \
+    --from-paths src \
+    --ignore-src \
+    --rosdistro $ROS_DISTRO \
+    -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# Build rosbridge packages.
+COPY rosbridge_suite $CATKIN_DIR/src/rosbridge_suite
+COPY rosbridge_library $CATKIN_DIR/src/rosbridge_library
+COPY rosbridge_server $CATKIN_DIR/src/rosbridge_server
+COPY rosbridge_msgs $CATKIN_DIR/src/rosbridge_msgs
+COPY rosapi $CATKIN_DIR/src/rosapi
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+ && catkin_make
+
+# We want the development workspace active all the time.
+RUN echo "#!/bin/bash\n\
+set -e\n\
+source \"${CATKIN_DIR}/devel/setup.bash\"\n\
+exec \"\$@\"" > /startup.sh \
+ && chmod a+x /startup.sh \
+ && echo "source ${CATKIN_DIR}/devel/setup.bash" >> /root/.bashrc
+ENTRYPOINT ["/startup.sh"]
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ A rosbridge client is a program that communicates with rosbridge using its JSON 
  * [jrosbridge](https://github.com/WPI-RAIL/jrosbridge) - A Java API, which communicates with rosbridge over WebSockets.
  * [roslibpy](https://github.com/gramaziokohler/roslibpy) - A Python API, which communicates with rosbridge over WebSockets.
 
+### Development
+
+You can use the `run_docker.sh` script to get an interactive shell in a container with rosbridge in a catkin workspace. The sources will be mounted read-only in the container, so any changes you make outside the container will be reflected inside. Host networking will be used so you can run interact with ROS nodes and access the server from outside the container. You can use this to quickly iterate without having to rebuild the image for most changes.
+
 ### License
 rosbridge_suite is released with a BSD license. For full terms and conditions, see the [LICENSE](LICENSE) file.
 

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -95,6 +95,9 @@ class TestMessageHandlers(unittest.TestCase):
         handler = handler.set_queue_length(queue_length)
         self.assertIsInstance(handler, subscribe.QueueMessageHandler)
 
+        # yield the thread to let QueueMessageHandler reach wait().
+        time.sleep(0.001)
+
         # send all messages at once.
         # only the first and the last queue_length should get through,
         # because the callbacks are blocked.
@@ -102,7 +105,7 @@ class TestMessageHandlers(unittest.TestCase):
             handler.handle_message(x)
             # yield the thread so the first callback can append,
             # otherwise the first handled value is non-deterministic.
-            time.sleep(0)
+            time.sleep(0.001)
 
         # wait long enough for all the callbacks, and then some.
         time.sleep(queue_length + 3)

--- a/rosbridge_library/test/internal/test_internal.test
+++ b/rosbridge_library/test/internal/test_internal.test
@@ -8,7 +8,7 @@
   <test test-name="test_multi_unregistering" pkg="rosbridge_library" type="test_multi_unregistering.py" />
   <test test-name="test_multi_subscriber" pkg="rosbridge_library" type="test_multi_subscriber.py" />
   <test test-name="test_subscriber_manager" pkg="rosbridge_library" type="test_subscriber_manager.py" />
-  <test test-name="test_subscription_modifiers" pkg="rosbridge_library" type="test_subscription_modifiers.py" />
+  <test test-name="test_subscription_modifiers" pkg="rosbridge_library" type="test_subscription_modifiers.py" time-limit="90" />
   <test test-name="test_cbor_conversion" pkg="rosbridge_library" type="test_cbor_conversion.py" />
   <test test-name="test_outgoing_message" pkg="rosbridge_library" type="test_outgoing_message.py" />
 </launch>

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# This script will build a Docker image with rosbridge in a catkin workspace,
+# then run it with host networking and the sources mounted read-only.
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+docker build -t rosbridge_dev .
+docker run -it --rm --net=host \
+  -v "$(pwd)/rosbridge_suite:${CATKIN_DIR}/src/rosbridge_suite:ro" \
+  -v "$(pwd)/rosbridge_library:${CATKIN_DIR}/src/rosbridge_library:ro" \
+  -v "$(pwd)/rosbridge_server:${CATKIN_DIR}/src/rosbridge_server:ro" \
+  -v "$(pwd)/rosbridge_msgs:${CATKIN_DIR}/src/rosbridge_msgs:ro" \
+  -v "$(pwd)/rosapi:${CATKIN_DIR}/src/rosapi:ro" \
+  rosbridge_dev $@

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -4,6 +4,8 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+CATKIN_DIR=/catkin_ws
+
 docker build -t rosbridge_dev .
 docker run -it --rm --net=host \
   -v "$(pwd)/rosbridge_suite:${CATKIN_DIR}/src/rosbridge_suite:ro" \


### PR DESCRIPTION
This script spins up a docker container with all rosbridge packages in a catkin workspace with sources mounted read-only and host networking.  Have been using something like it for a while, and thought the community might find it useful for quickly testing and iterating rosbridge.