### PR TITLE
Threadsafe capabilities

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
@@ -92,9 +92,6 @@ class AdvertiseService(Capability):
         # Register the operations that this capability provides
         protocol.register_operation("advertise_service", self.advertise_service)
 
-        # The list of services belongs to protocol, but we lock it on this side.
-        self._services_lock = Lock()
-
     def advertise_service(self, message):
         # Typecheck the args
         self.basic_type_check(message, self.advertise_service_msg_fields)
@@ -116,7 +113,7 @@ class AdvertiseService(Capability):
         else:
             self.protocol.log("debug", "No service security glob, not checking service advertisement.")
 
-        with self._services_lock:
+        with self.protocol.external_service_lock:
             # check for an existing entry
             if service_name in self.protocol.external_service_list.keys():
                 self.protocol.log("warn", "Duplicate service advertised. Overwriting %s." % service_name)

--- a/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
@@ -22,9 +22,13 @@ class ServiceResponse(Capability):
         self.basic_type_check(message, self.service_response_msg_fields)
 
         # check for the service
+        service_handler = None
         service_name = message["service"]
-        if service_name in self.protocol.external_service_list:
-            service_handler = self.protocol.external_service_list[service_name]
+        with self.protocol.external_service_lock:
+            if service_name in self.protocol.external_service_list:
+                service_handler = self.protocol.external_service_list[service_name]
+
+        if service_handler:
             # parse the message
             request_id = message["id"]
             values = message["values"]

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
@@ -33,11 +33,12 @@ class UnadvertiseService(Capability):
         else:
             self.protocol.log("debug", "No service security glob, not checking service unadvertisement...")
 
-        # unregister service in ROS
-        if service_name in self.protocol.external_service_list.keys():
-            self.protocol.external_service_list[service_name].graceful_shutdown(timeout=1.0)
-            self.protocol.external_service_list[service_name].service_handle.shutdown("Unadvertise request.")
-            del self.protocol.external_service_list[service_name]
-            self.protocol.log("info", "Unadvertised service %s." % service_name)
-        else:
-            self.protocol.log("error", "Service %s has not been advertised via rosbridge, can't unadvertise." % service_name)
+        with self.protocol.external_service_lock:
+            # unregister service in ROS
+            if service_name in self.protocol.external_service_list.keys():
+                self.protocol.external_service_list[service_name].graceful_shutdown(timeout=1.0)
+                self.protocol.external_service_list[service_name].service_handle.shutdown("Unadvertise request.")
+                del self.protocol.external_service_list[service_name]
+                self.protocol.log("info", "Unadvertised service %s." % service_name)
+            else:
+                self.protocol.log("error", "Service %s has not been advertised via rosbridge, can't unadvertise." % service_name)

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -31,6 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import rospy
+import threading
 import time
 
 from rosbridge_library.internal.exceptions import InvalidArgumentException
@@ -87,6 +88,7 @@ class Protocol:
     delay_between_messages = 0
     # global list of non-ros advertised services
     external_service_list = {}
+    external_service_lock = threading.Lock()
     # Use only BSON for the whole communication if the server has been started with bson_only_mode:=True
     bson_only_mode = False
 


### PR DESCRIPTION
#496 fixed deadlock issues by decoupling incoming message handling from the web socket server, but this opened the door to race conditions when interacting with capabilities.  These changes add thread safety at the top-level which should prevent state inconsistencies further down.