### PR TITLE
Fixed filter_globs for noetic

### DIFF
--- a/rosapi/src/rosapi/glob_helper.py
+++ b/rosapi/src/rosapi/glob_helper.py
@@ -2,9 +2,7 @@
 
 import rospy
 import fnmatch
-import sys
 
-PYTHON2 = sys.version_info < (3, 0)
 topics_glob = []
 services_glob = []
 params_glob = []
@@ -32,14 +30,10 @@ def get_globs():
 def filter_globs(globs, full_list):
     # If the globs are empty (weren't defined in the params), return the full list
     if globs is not None and len(globs) > 0:
-        if PYTHON2:
-            return filter(lambda x: any_match(x, globs), full_list)
-        else:
-            return [i for i in filter(lambda x: any_match(x, globs), full_list)]
+        return [i for i in filter(lambda x: any_match(x, globs), full_list)]
     else:
         return full_list
 
 
 def any_match(query, globs):
     return globs is None or len(globs) == 0 or any(fnmatch.fnmatch(str(query), glob) for glob in globs)
-

--- a/rosapi/src/rosapi/glob_helper.py
+++ b/rosapi/src/rosapi/glob_helper.py
@@ -2,7 +2,9 @@
 
 import rospy
 import fnmatch
+import sys
 
+PYTHON2 = sys.version_info < (3, 0)
 topics_glob = []
 services_glob = []
 params_glob = []
@@ -30,7 +32,10 @@ def get_globs():
 def filter_globs(globs, full_list):
     # If the globs are empty (weren't defined in the params), return the full list
     if globs is not None and len(globs) > 0:
-        return filter(lambda x: any_match(x, globs), full_list)
+        if PYTHON2:
+            return filter(lambda x: any_match(x, globs), full_list)
+        else:
+            return [i for i in filter(lambda x: any_match(x, globs), full_list)]
     else:
         return full_list
 


### PR DESCRIPTION
Service calls with non empty requests (e.g. /rosapi/topics_for_type) were crashing due to filter's return type in python 3.