### PR TITLE
Fix for type error caused by appending byte arrays to empty string

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -118,7 +118,10 @@ class Protocol:
         message_string -- the wire-level message sent by the client
 
         """
-        self.buffer = self.buffer + message_string
+        if(len(self.buffer) > 0):
+            self.buffer = self.buffer + message_string
+        else:
+            self.buffer = message_string
         msg = None
 
         # take care of having multiple JSON-objects in receiving buffer


### PR DESCRIPTION
Fixes a TypeError caused when clients send incoming message as byte arrays. This error is introduced in ROS 2 due to Python 3's introduction of byte arrays distinct from strings.