### PR TITLE
Error initialization with tornado.

### DIFF
--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -79,7 +79,7 @@ class RosbridgeWebSocket(WebSocketHandler):
     fragment_timeout = 600                  # seconds
     # protocol.py:
     delay_between_messages = 0              # seconds
-    max_message_size = None                 # bytes
+    max_message_size = 10 * 1024 * 1024     # bytes
     unregister_timeout = 10.0               # seconds
     bson_only_mode = False
 


### PR DESCRIPTION
Using tornado version 6.0.4 when we try to initialize RosbridgeWebSocket from websocket_handler.py we get an error that says max_message_size has to be an Integer and not NoneType.

Also, if the max_message_size is too small, WebSocket closes without errors or explanation message.