### PR TITLE
fix: remove json encoding before setting string params

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,3 +11,4 @@ Contributors
  * Brandon Alexander (baalexander@gmail.com)
  * David Bertram (davidbertram@gmx.de)
  * Matthias Gruhler (matthias.gruhler@ipa.fraunhofer.de)
+ * Travis Prosser (travisprosser@gmail.com) 

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -78,6 +78,7 @@ def set_param(node_name, name, value, params_glob):
     d = None
     try:
         d = loads(value)
+        value = d if isinstance(d, str) else value
     except ValueError:
         raise Exception("Due to the type flexibility of the ROS parameter server, the value argument to set_param must be a JSON-formatted string.")
 


### PR DESCRIPTION
Since porting to ROS2, it was previously impossible to use `Param.set_param()` to set string-type parameters.

The input argument `value` must be JSON-serialized, however, unlike the case of other data types, the later call to `get_parameter_value()` inside of `Param._set_param()` does not strip the JSON encoding from the string. This means that the message is constructed with a double-encoded JSON string before being sent to the appropriate node. All string type parameters previously set by `rosapi` were therefore wrapped with unnecessary quotes.

As the `get_parameter_value()` method belongs to the `ros2` project, it feels appropriate for this to be handled on the `rosapi` side. This simple fix allows for the proper decoding of strings when passed as the `value` argument. 

No changes appear to be necessary for the `Param.get_param()` function to work as expected after this modification. Tested with ROS Eloquent on Ubuntu 18.04.

