### PR TITLE
Conversion between bytes and string

### DIFF
--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -59,7 +59,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
             packet = self.request.recv(n - len(data))
             if not packet:
                 return None
-            data += packet
+            data += packet.decode()
         return data
 
     def recv_bson(self):
@@ -103,7 +103,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
               if data.strip() == '':
                   break
               elif len(data.strip()) > 0:
-                  self.protocol.incoming(data.strip(''))
+                  self.protocol.incoming(data.decode().strip(''))
               else:
                   pass
             except Exception as e:
@@ -125,4 +125,4 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
         """
         Callback from rosbridge
         """
-        self.request.sendall(message)
+        self.request.sendall(message.encode())


### PR DESCRIPTION
As of python3 sockets will input and output byte strings instead of String objects.

This commits does the necessary coversions inside the tcp_handler, but it might
not be the most thoughtful solution but just what I did to make it work with
python3.

I tested this also on python2 and it also works there.