### PR TITLE
rosbridge_udp now encodes msg before sending

### DIFF
--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -14,7 +14,7 @@ class RosbridgeUdpFactory(DatagramProtocol):
         if endpoint in self.socks:
             self.socks[endpoint].datagramReceived(message)
         else:
-            writefunc = lambda msg: self.transport.write(msg, (host,port))
+            writefunc = lambda msg: self.transport.write(msg.encode(), (host,port))
             self.socks[endpoint] = RosbridgeUdpSocket(writefunc)
             self.socks[endpoint].startProtocol()
             self.socks[endpoint].datagramReceived(message)


### PR DESCRIPTION
This is required to work with python3 socket library

Similar fix to #534 

Tested with ROS noetic (python3) and melodic (python2), seemed to be functional in both of them.