### PR TITLE
Evaluate filter() generator before returning in get_param_names()

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -110,7 +110,7 @@ def get_param_names(params_glob):
     with param_server_lock:
         if params_glob:
             # If there is a parameter glob, filter by it.
-            return filter(lambda x: any(fnmatch.fnmatch(str(x), glob) for glob in params_glob), rospy.get_param_names())
+            return list(filter(lambda x: any(fnmatch.fnmatch(str(x), glob) for glob in params_glob), rospy.get_param_names()))
         else:
             # If there is no parameter glob, don't filter.
             return rospy.get_param_names()


### PR DESCRIPTION
See issue #527.

This patch was needed when running rosapi under ROS Noetic which uses python3 due to the difference in in the return type of the `filter()` function between python2 and python3. In python2, a list is returned directly, but in python 3 a generator is returned which needs to be evaluated into a list to match the expected return type of the `get_param_names()` function in `params.py`.

Also tested using the ros-melodic docker container which uses python2 and it seems to work fine.

Please let me know if this is the wrong place to submit pull requests to, or if the python3/noetic migration work is being done elsewhere?