### PR TITLE
fix python-future dependency

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.0.19
+        uses: ros-tooling/action-ros-ci@0.1.0
         with:
          package-name: rosbridge_suite
          target-ros1-distro: ${{ matrix.ros_distribution }}

--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: ros_ws/src
       - name: setup ROS environment
-        uses: ros-tooling/setup-ros@0.0.25
+        uses: ros-tooling/setup-ros@0.1.0
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - name: build and test

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -35,6 +35,7 @@
   <exec_depend>rosservice</exec_depend>
   <exec_depend>rostopic</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-future</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-imaging</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pil</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>


### PR DESCRIPTION
This was not fixed with fadffa09b1b572e4dc11848c31bb6ebab4a3e95d
The dependency was added with #541

Python doesn't have build dependencies, only exec dependencies

Also bump ros-tooling/action-ros-ci and ros-tooling/setup-ros to get upstream fixes:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/