### PR TITLE
Fix bson support for python3

### DIFF
--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -129,3 +129,6 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
             self.request.sendall(message)
         elif message is not None:
             self.request.sendall(message.encode())
+        else:
+            rospy.logerr("send_message called with no message or message is None, not sending")
+

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -125,4 +125,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
         """
         Callback from rosbridge
         """
-        self.request.sendall(message.encode())
+        if self.bson_only_mode:
+            self.request.sendall(message)
+        elif message is not None:
+            self.request.sendall(message.encode())

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -54,12 +54,12 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     def recvall(self,n):
         # http://stackoverflow.com/questions/17667903/python-socket-receive-large-amount-of-data
         # Helper function to recv n bytes or return None if EOF is hit
-        data = ''
+        data = bytearray()
         while len(data) < n:
             packet = self.request.recv(n - len(data))
             if not packet:
                 return None
-            data += packet.decode()
+            data.extend(packet)
         return data
 
     def recv_bson(self):


### PR DESCRIPTION
When running in BSON only mode with python3, the bridge silently fails and does not publish any messages. 

An exception is caught on [line 109 of tcp_handler.py](https://github.com/RobotWebTools/rosbridge_suite/blob/a09a964fb5956321aca3b296da367e21d3d2e044/rosbridge_server/src/rosbridge_server/tcp_handler.py#L109) and ignored. Re-raising the exception gives the following error:

```
[INFO] [1607978704.270194]: Rosbridge TCP server started on port 9090
[INFO] [1607978704.671599]: [Client 0] connected. 1 client total.
[INFO] [1607978704.672726]: [Client 0] disconnected. 0 client total.
----------------------------------------
Exception happened during processing of request from ('10.0.0.14', 53436)
Traceback (most recent call last):
  File "/usr/lib/python3.8/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.8/socketserver.py", line 720, in __init__
    self.handle()
  File "/home/nick/ws/src/isolate/rosbridge_suite/rosbridge_server/src/rosbridge_server/tcp_handler.py", line 110, in handle
    raise e
  File "/home/nick/ws/src/isolate/rosbridge_suite/rosbridge_server/src/rosbridge_server/tcp_handler.py", line 96, in handle
    if self.recv_bson() == None:
  File "/home/nick/ws/src/isolate/rosbridge_suite/rosbridge_server/src/rosbridge_server/tcp_handler.py", line 68, in recv_bson
    raw_msglen = self.recvall(BSON_LENGTH_IN_BYTES)
  File "/home/nick/ws/src/isolate/rosbridge_suite/rosbridge_server/src/rosbridge_server/tcp_handler.py", line 62, in recvall
    data += packet.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc9 in position 0: invalid continuation byte
----------------------------------------
```

Code was added in #534 which causes the BSON handling code to decode the message bytes before the data gets to the BSON constructor. This causes decode errors since the [raw_msglen](https://github.com/RobotWebTools/rosbridge_suite/blob/a09a964fb5956321aca3b296da367e21d3d2e044/rosbridge_server/src/rosbridge_server/tcp_handler.py#L68) is not always utf-8 compatible but is required when passing to the BSON constructor.

The data was also failing to be decoded on [line 123 of protocol.py](https://github.com/RobotWebTools/rosbridge_suite/blob/a09a964fb5956321aca3b296da367e21d3d2e044/rosbridge_library/src/rosbridge_library/protocol.py#L123) so checks were added to use bytearray for bson only mode here as well

This PR uses bytearrays instead of `str` and delays any str conversions when in bson_only_mode to avoid decoding errors.

Ran unit tests using python3 and all tests passed.