### PR TITLE
fixed SyntaxWarning: "is not" with a literal

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -120,7 +120,7 @@ def get_param(node_name, name, default, params_glob):
         return
     # If the glob list is empty (i.e. false) or the parameter matches
     # one of the glob strings, continue to get the parameter.
-    if default is not "":
+    if not default:
         try:
             default = loads(default)
         except ValueError:


### PR DESCRIPTION
It compiles in ros2 foxy and ubuntu 20.04