### PR TITLE
Fixes error when sending binary data

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -136,7 +136,7 @@ def _from_inst(inst, rostype):
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
             encoded = get_encoder()(inst)
-            return encoded if python2 else encoded.decode('ascii')
+            return encoded
 
     # Check for time or duration
     if rostype in ros_time_types:


### PR DESCRIPTION
uint8[] is no necessarily a string, raw data like images is normally sent as uint8[]

For example I get this eror when sending images
```
call_service UnicodeDecodeError: 'ascii' codec can't decode byte 0x8a in position 2: ordinal not in range(128)
```