### PR TITLE
Fix invalid conversion bug in time and duration

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -33,6 +33,12 @@ TAGGED_ARRAY_FORMATS = {
     'float64[]': (86, '<{}d'),
 }
 
+SECS_KEY = 'secs'
+NSECS_KEY = 'nsecs'
+if PYTHON2:
+    SECS_KEY = u'secs'
+    NSECS_KEY = u'nsecs'
+
 
 def extract_cbor_values(msg):
     """Extract a dictionary of CBOR-friendly values from a ROS message.
@@ -67,8 +73,8 @@ def extract_cbor_values(msg):
         # time/duration
         elif slot_type in TIME_TYPES:
             out[slot] = {
-                'secs': int(val.secs),
-                'nsecs': int(val.nsecs),
+                SECS_KEY: int(val.secs),
+                NSECS_KEY: int(val.nsecs),
             }
 
         # byte array

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -75,9 +75,11 @@ class TestCBORConversion(unittest.TestCase):
             msg = msg_type()
             extracted = extract_cbor_values(msg)
 
-            if PYTHON2:
-                for key in extracted['data'].keys():
-                    self.assertEqual(type(key), unicode, 'type={}'.format(msg_type))
+            for key in extracted['data'].keys():
+                if PYTHON2:
+                    self.assertEqual(type(key), unicode, 'type={}'.format(msg_type))  # noqa: F821
+                else:
+                    self.assertEqual(type(key), str, 'type={}'.format(msg_type))
             self.assertEqual(extracted['data']['secs'], msg.data.secs, 'type={}'.format(msg_type))
             self.assertEqual(extracted['data']['nsecs'], msg.data.nsecs, 'type={}'.format(msg_type))
             self.assertEqual(type(extracted['data']['secs']), int, 'type={}'.format(msg_type))

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -75,6 +75,9 @@ class TestCBORConversion(unittest.TestCase):
             msg = msg_type()
             extracted = extract_cbor_values(msg)
 
+            if PYTHON2:
+                for key in extracted['data'].keys():
+                    self.assertEqual(type(key), unicode, 'type={}'.format(msg_type))
             self.assertEqual(extracted['data']['secs'], msg.data.secs, 'type={}'.format(msg_type))
             self.assertEqual(extracted['data']['nsecs'], msg.data.nsecs, 'type={}'.format(msg_type))
             self.assertEqual(type(extracted['data']['secs']), int, 'type={}'.format(msg_type))


### PR DESCRIPTION
There is a invalid conversion bug in time and duration. While I use roslibjs, the `sec` and `nsecs` keys become `'115,101,99,115'` and `'110,115,101,99,115'`. This pr fixes the problem. 