### PR TITLE
Update subscribers.py

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -204,7 +204,7 @@ class MultiSubscriber():
         subscriptors.
         """
         with self.lock:
-            self.callback(msg, [self.new_subscriptions.values()])
+            self.callback(msg, self.new_subscriptions.values())
             self.subscriptions.update(self.new_subscriptions)
             self.new_subscriptions = {}
             self.node_handle.destroy_subscription(self.new_subscriber)


### PR DESCRIPTION
`.values()` should return an iterable. Wrapping with another iterable (list) leads to this error.

```
[ERROR] Exception calling subscribe callback: 'dict_values' object is not callable
```