### PR TITLE
Allow topic directionality control in rosbridge

### DIFF
--- a/rosapi/src/rosapi/glob_helper.py
+++ b/rosapi/src/rosapi/glob_helper.py
@@ -18,7 +18,7 @@ def get_globs():
         param = rospy.get_param(param_name, '')
         # strips array delimiters in case of an array style value
         return [
-            element.strip().strip("'")
+            element.strip().strip("'").lstrip("<>")
             for element in param.strip('[').strip(']').split(',')
             if len(element.strip().strip("'")) > 0]
 

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -27,4 +27,5 @@ install(FILES
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest(test/websocket/test_smoke.test)
+  add_rostest(test/websocket/test_direction.test)
 endif()

--- a/rosbridge_server/src/rosbridge_server/util.py
+++ b/rosbridge_server/src/rosbridge_server/util.py
@@ -10,3 +10,34 @@ def get_ephemeral_port(sock_family=socket.AF_INET, sock_type=socket.SOCK_STREAM)
     port = s.getsockname()[1]
     s.close()
     return port
+
+
+def directional_topics_globs(topics_glob):
+    """
+        Return a filtered set of topic globs, specifying which topics are allowed
+        in incoming (from websocket to ros), outgoing (from ros to websocket) or
+        in both directions.
+
+        By default topic communication is allowed in both directions.
+        Topics prefixed with `>` are only allowed in outgoing (to the websocket).
+        Topics prefixed with `<` are only allowed in ingoing (from the websocket).
+    """
+    incoming = set()
+    outgoing = set()
+    for t in topics_glob:
+        if t.startswith(">"):
+            # Allow to websocket only, not publishing from the websocket.
+            topic_path = t[1:]
+            outgoing.add(topic_path)
+        elif t.startswith("<"):
+            # Allow publishing from the websocket only, not subscribing to the messages.
+            topic_path = t[1:]
+            incoming.add(topic_path)
+        else:
+            # Allow both subscription and advertise / subscribe.
+            incoming.add(t)
+            outgoing.add(t)
+    return {"incoming": list(incoming),
+            "outgoing": list(outgoing),
+            "bidirectional": list(incoming & outgoing),
+            "all": list(incoming | outgoing)}

--- a/rosbridge_server/src/rosbridge_server/util.py
+++ b/rosbridge_server/src/rosbridge_server/util.py
@@ -21,6 +21,14 @@ def directional_topics_globs(topics_glob):
         By default topic communication is allowed in both directions.
         Topics prefixed with `>` are only allowed in outgoing (to the websocket).
         Topics prefixed with `<` are only allowed in ingoing (from the websocket).
+
+        If the input topics_glob is empty, it returns empty lists and everything
+        is allowed.
+
+        If the input topics_glob is not empty, it will ensure that the output
+        topics_globs contain at least one element (an empty string) that will
+        ensure that capabilities don't assume everything is allowed because the
+        topics_glob list was empty.
     """
     incoming = set()
     outgoing = set()
@@ -30,14 +38,25 @@ def directional_topics_globs(topics_glob):
             topic_path = t[1:]
             outgoing.add(topic_path)
         elif t.startswith("<"):
-            # Allow publishing from the websocket only, not subscribing to the messages.
+            # Allow publishing from the websocket only, not subscribing.
             topic_path = t[1:]
             incoming.add(topic_path)
         else:
             # Allow both subscription and advertise / subscribe.
             incoming.add(t)
             outgoing.add(t)
-    return {"incoming": list(incoming),
-            "outgoing": list(outgoing),
-            "bidirectional": list(incoming & outgoing),
-            "all": list(incoming | outgoing)}
+
+    # The topics_globs assume that empty lists means allow anything. So we
+    # need to insert a dummy value to prevent the list from being empty
+    # while at the same time preserving backwards compatilibity in case
+    # the input topics_glob is really empty and we want to allow everything.
+    if len(topics_glob) == 0:
+        return {"incoming": [], "outgoing": [], "bidirectional": [], "all": []}
+
+    # Some topic was specified, in this case none of the returns may be empty lists.
+    # we insert `""`, this can only ever match the empty string itself, which is an
+    # invalid topic name.
+    return {"incoming": list(incoming | set([""])),
+            "outgoing": list(outgoing | set([""])),
+            "bidirectional": list((incoming & outgoing) | set([""])),
+            "all": list(incoming | outgoing | set([""]))}

--- a/rosbridge_server/test/websocket/test_direction.py
+++ b/rosbridge_server/test/websocket/test_direction.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+import json
+import os
+import rostest
+import sys
+import threading
+import unittest
+
+import rospy
+from std_msgs.msg import String
+
+from twisted.internet import reactor
+from autobahn.twisted.websocket import (WebSocketClientProtocol,
+                                        WebSocketClientFactory)
+
+from twisted.python import log
+log.startLogging(sys.stderr)
+
+# This unit test tests whether the messages are appropriately gated.
+# The client attempts to publish on the OUTGOING_TOPIC topic. This should not go through.
+# The client attempts to receive on the  INGOING_TOPIC topic. This should not go through.
+# The client attempts to publish on the  INGOING_TOPIC topic. This should go through.
+# The client attempts to receive on the OUTGOING_TOPIC topic. This should go through.
+
+
+# For consistency, the number of messages must not exceed the the protocol
+# Subscriber queue_size.
+NUM_MSGS = 10
+OUTGOING_TOPIC = '/outgoing_only'
+INGOING_TOPIC = '/ingoing_only'
+
+CLIENT_PUB_TO_OUTGOING = "CLIENT_PUB_TO_OUTGOING"
+SERVER_PUB_TO_OUTGOING = "SERVER_PUB_TO_OUTGOING"
+CLIENT_PUB_TO_INGOING = "CLIENT_PUB_TO_INGOING"
+SERVER_PUB_TO_INGOING = "SERVER_PUB_TO_INGOING"
+# Client should only receive SERVER_PUB_TO_OUTGOING
+# Server should only receive CLIENT_PUB_TO_INGOING and SERVER_PUB_TO_INGOING (loopback)
+
+# The bidirectional topics are tested by the test_smoke.py
+WARMUP_DELAY = 1.0  # seconds
+TIME_LIMIT = 5.0  # seconds
+
+class TestClientProtocol(WebSocketClientProtocol):
+    def onOpen(self):
+        # client attempt to publish on outgoing.
+        self._sendDict({
+            'op': 'advertise',
+            'topic': OUTGOING_TOPIC,
+            'type': 'std_msgs/String',
+        })
+        self._sendDict({
+            'op': 'publish',
+            'topic': OUTGOING_TOPIC,
+            'msg': {
+                'data': CLIENT_PUB_TO_OUTGOING,
+            },
+        }, NUM_MSGS)
+
+        # client attempt to subscribe to outgoing.
+        self._sendDict({
+            'op': 'subscribe',
+            'topic': OUTGOING_TOPIC,
+            'type': 'std_msgs/String',
+            'queue_length': 0,
+        })
+
+        # client attempt to subscribe on outgoing.
+        self._sendDict({
+            'op': 'subscribe',
+            'topic': INGOING_TOPIC,
+            'type': 'std_msgs/String',
+            'queue_length': 0,
+        })
+        # Client attempt to publish on the ingoing topic.
+        self._sendDict({
+            'op': 'advertise',
+            'topic': INGOING_TOPIC,
+            'type': 'std_msgs/String',
+        })
+        self._sendDict({
+            'op': 'publish',
+            'topic': INGOING_TOPIC,
+            'msg': {
+                'data': CLIENT_PUB_TO_INGOING,
+            },
+        }, NUM_MSGS)
+
+
+    def _sendDict(self, msg_dict, times=1):
+        msg = json.dumps(msg_dict).encode('utf-8')
+        for _ in range(times):
+            self.sendMessage(msg)
+
+    def onMessage(self, payload, binary):
+        self.__class__.received.append(payload)
+
+
+class TestWebsocketDirection(unittest.TestCase):
+    def test_smoke(self):
+        protocol = os.environ.get('PROTOCOL')
+        port = rospy.get_param('/rosbridge_websocket/actual_port')
+        url = protocol + '://127.0.0.1:' + str(port)
+
+        factory = WebSocketClientFactory(url)
+        factory.protocol = TestClientProtocol
+        reactor.connectTCP('127.0.0.1', port, factory)
+
+        ros_received = []
+        TestClientProtocol.received = []
+        rospy.Subscriber(INGOING_TOPIC, String, ros_received.append)
+        pub_outgoing = rospy.Publisher(OUTGOING_TOPIC, String, queue_size=NUM_MSGS)
+        pub_ingoing = rospy.Publisher(INGOING_TOPIC, String, queue_size=NUM_MSGS)
+        
+
+        def publish_outgoing_timer():
+            rospy.sleep(WARMUP_DELAY)
+            msg = String(SERVER_PUB_TO_OUTGOING)
+            for _ in range(NUM_MSGS):
+                pub_outgoing.publish(msg)
+
+        def publish_ingoing_timer():
+            rospy.sleep(WARMUP_DELAY)
+            msg = String(SERVER_PUB_TO_INGOING)
+            for _ in range(NUM_MSGS):
+                pub_ingoing.publish(msg)
+
+        def shutdown_timer():
+            rospy.sleep(WARMUP_DELAY + TIME_LIMIT)
+            reactor.stop()
+
+        reactor.callInThread(publish_outgoing_timer)
+        reactor.callInThread(publish_ingoing_timer)
+        reactor.callInThread(shutdown_timer)
+        reactor.run()
+
+        # Done sending all the messages and receiving them, lets see if
+        # the client and server obtained the right ones.
+
+        # The client should have obtained NUM_MSGS only, namely the ones sent   
+        # by the server on the outgoing topic.
+        self.assertEqual(NUM_MSGS, len(TestClientProtocol.received))
+        for received in TestClientProtocol.received:
+            msg = json.loads(received)
+            self.assertEqual('publish', msg['op'])
+            self.assertEqual(OUTGOING_TOPIC, msg['topic'])
+            self.assertEqual(SERVER_PUB_TO_OUTGOING, msg['msg']['data'])        
+
+
+        # Confirm that the server only obtained NUM_MSGS, on the server side
+        # we have a loopback, since what we publish also ends up in the
+        # subscription.
+        self.assertEqual(NUM_MSGS * 2, len(ros_received))
+        for msg in ros_received:
+            allowed_receipt = {CLIENT_PUB_TO_INGOING, SERVER_PUB_TO_INGOING}
+            self.assertTrue(msg.data in allowed_receipt)
+
+
+PKG = 'rosbridge_server'
+NAME = 'test_websocket_direction'
+
+if __name__ == '__main__':
+    rospy.init_node(NAME)
+
+    while not rospy.is_shutdown() and not rospy.has_param('/rosbridge_websocket/actual_port'):
+        rospy.sleep(1.0)
+
+    rostest.rosrun(PKG, NAME, TestWebsocketDirection)

--- a/rosbridge_server/test/websocket/test_direction.test
+++ b/rosbridge_server/test/websocket/test_direction.test
@@ -1,0 +1,10 @@
+<launch>
+  <env name="PROTOCOL" value="ws" />
+  <node name="rosbridge_websocket" pkg="rosbridge_server" type="rosbridge_websocket.py">
+    <param name="port" value="0" />
+    <param name="topics_glob" value="[/a_topic,/b_topic,&gt;/outgoing_only,&lt;/ingoing_only]" />
+  </node>
+  <test test-name="test_smoke" pkg="rosbridge_server" type="test_smoke.py" />
+  <test test-name="test_cbor_raw" pkg="rosbridge_server" type="test_cbor_raw.py" />
+  <test test-name="test_direction" pkg="rosbridge_server" type="test_direction.py" />
+</launch>


### PR DESCRIPTION
This PR provides a simple way to specify whether topics are read only, write only or both.

The `topics_glob` entries are used to specify the directionality. Globs that are prefixed with `>` are outgoing only, prefixed with `<` are incoming only, topics that aren't prefixed with anything are bidirectional, preserving current behaviour and making the change backwards compatible.

The topic information from the `rosapi` is always available such that clients can still see the topic type.

Commits are split out, with the first one adding the core logic, the second one unit test support, and the third one a fix to ensure that if any topic is specified the incoming or outgoing globs don't end up empty because of the filtering, because empty globs results in everything allowed, which is obviously not desired when any filter is specified.

Fyi @jasonimercer @jscharlach 