### PR TITLE
ROS2 - Add qos_durability (volatile or transient_local) option to subcriptions

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -92,7 +92,8 @@ class Subscription():
         self.clients.clear()
 
     def subscribe(self, sid=None, msg_type=None, throttle_rate=0,
-                  queue_length=0, fragment_size=None, compression="none"):
+                  queue_length=0, qos_durability="volatile", fragment_size=None, 
+                  compression="none"):
         """ Add another client's subscription request
 
         If there are multiple calls to subscribe, the values actually used for
@@ -106,6 +107,7 @@ class Subscription():
         being sent.  If multiple subscriptions, the lower of these is used
         queue_length    -- the number of messages that can be buffered.  If
         multiple subscriptions, the lower of these is used
+        qos_durability  -- the qos durability, 'volatile' or 'transient_local'
         fragment_size   -- None if no fragmentation, or the maximum length of
         allowed outgoing messages
         compression     -- "none" if no compression, or some other value if
@@ -116,6 +118,7 @@ class Subscription():
         client_details = {
             "throttle_rate": throttle_rate,
             "queue_length": queue_length,
+            "qos_durability": qos_durability,
             "fragment_size": fragment_size,
             "compression": compression
         }
@@ -128,7 +131,7 @@ class Subscription():
 
         # Subscribe with the manager. This will propagate any exceptions
         manager.subscribe(
-            self.client_id, self.topic, self.on_msg, self.node_handle, msg_type=msg_type, raw=raw)
+            self.client_id, self.topic, self.on_msg, self.node_handle, msg_type=msg_type, qos_durability=qos_durability, raw=raw)
 
     def unsubscribe(self, sid=None):
         """ Unsubscribe this particular client's subscription
@@ -203,7 +206,8 @@ class Subscribe(Capability):
 
     subscribe_msg_fields = [(True, "topic", string_types), (False, "type", string_types),
                             (False, "throttle_rate", int), (False, "fragment_size", int),
-                            (False, "queue_length", int), (False, "compression", string_types)]
+                            (False, "queue_length", int), (False, "qos_durability", str),
+                            (False, "compression", string_types)]
     unsubscribe_msg_fields = [(True, "topic", string_types)]
 
     topics_glob = None
@@ -254,6 +258,7 @@ class Subscribe(Capability):
           "throttle_rate": msg.get("throttle_rate", 0),
           "fragment_size": msg.get("fragment_size", None),
           "queue_length": msg.get("queue_length", 0),
+          "qos_durability": msg.get("qos_durability", "volatile"),
           "compression": msg.get("compression", "none")
         }
         self._subscriptions[topic].subscribe(**subscribe_args)

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -109,7 +109,7 @@ class MultiSubscriber():
             depth=1,
             durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL
         )
-        self.subscriber = node_handle.create_subscription(msg_class, topic, self.callback, 10, raw=raw, qos_profile=node_qos)
+        self.subscriber = node_handle.create_subscription(msg_class, topic, self.callback, raw=raw, qos_profile=node_qos)
         self.new_subscriber = None
         self.new_subscriptions = {}
 

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -38,6 +38,7 @@ from rosbridge_library.internal.message_conversion import msg_class_type_repr
 from rosbridge_library.internal.topics import TopicNotEstablishedException
 from rosbridge_library.internal.topics import TypeConflictException
 from rosbridge_library.internal.outgoing_message import OutgoingMessage
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy
 
 """ Manages and interfaces with ROS Subscriber objects.  A single subscriber
 is shared between multiple clients
@@ -104,8 +105,11 @@ class MultiSubscriber():
         self.topic = topic
         self.msg_class = msg_class
         self.node_handle = node_handle
-        # TODO(@jubeira): add support for other QoS.
-        self.subscriber = node_handle.create_subscription(msg_class, topic, self.callback, 10, raw=raw)
+        node_qos = QoSProfile(
+            depth=1,
+            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL
+        )
+        self.subscriber = node_handle.create_subscription(msg_class, topic, self.callback, 10, raw=raw, qos_profile=node_qos)
         self.new_subscriber = None
         self.new_subscriptions = {}
 

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -88,7 +88,7 @@ class RosbridgeWebsocketNode(Node):
             'delay_between_messages', RosbridgeWebSocket.delay_between_messages).value
 
         RosbridgeWebSocket.max_message_size = self.declare_parameter(
-            'max_message_size', RosbridgeWebSocket.max_message_size, ParameterDescriptor(dynamic_typing=True)).value
+            'max_message_size', RosbridgeWebSocket.max_message_size).value
 
         RosbridgeWebSocket.unregister_timeout = self.declare_parameter(
             'unregister_timeout', RosbridgeWebSocket.unregister_timeout).value


### PR DESCRIPTION
Inspired by https://github.com/RobotWebTools/rosbridge_suite/pull/557 This PR would break when a topic was being published as `volatile` but being subscribed as `transient_local` - as described [here](https://docs.ros.org/en/foxy/Concepts/About-Quality-of-Service-Settings.html#qos-compatibilities)

To resolve this, I have made this configurable using a `qos_durability` parameter.