### PR TITLE
Include /msg/ in type definitions for TopicsAndRawTypes

### DIFF
--- a/rosapi/src/rosapi/stringify_field_types.py
+++ b/rosapi/src/rosapi/stringify_field_types.py
@@ -18,30 +18,24 @@ def stringify_field_types(root_type):
         is_root = False
 
         cls = ros_loader.get_message_class(ty)
-        pkg = ty.split("/")[0]
+        prefix = ty.split("/")[:-1]
         fields_and_types = zip(cls.get_fields_and_field_types().keys(), cls.SLOT_TYPES)
-        for name, ty in fields_and_types:
-            type_str, dep = _stringify_type(ty, pkg)
+        for name, field_type in fields_and_types:
+            type_str, dep = _stringify_type(field_type, prefix)
             if dep is not None and dep not in seen_types:
                 deps.append(dep)
                 seen_types.add(dep)
             definition += f"{type_str} {name}\n"
     return definition
 
-def _stringify_type(ty: AbstractType, pkg: str):
+def _stringify_type(ty: AbstractType, prefix: str):
     if isinstance(ty, BasicType):
         return IDL_TYPE_TO_MSG[ty.typename], None
     elif isinstance(ty, NamedType):
-        return ty.name, f"{pkg}/{ty.name}"
+        return ty.name, f"{prefix}/{ty.name}"
     elif isinstance(ty, NamespacedType):
         namespaced_name = ty.namespaced_name()
-        if len(namespaced_name) == 3:
-            full_name = f"{namespaced_name[0]}/{namespaced_name[2]}"
-        elif len(namespaced_name) == 2:
-            full_name = f"{namespaced_name[0]}/{namespaced_name[1]}"
-        else:
-            full_name = "/".join(namespaced_name)
-            raise RuntimeError(f"Unsupported namespaced type: f{full_name}")
+        full_name = "/".join(namespaced_name)
         is_builtin = ty.namespaces[0] == "builtin_interfaces"
         return full_name, None if is_builtin else full_name
     elif isinstance(ty, AbstractGenericString):
@@ -49,11 +43,11 @@ def _stringify_type(ty: AbstractType, pkg: str):
         bound = f"<={ty.maximum_size}" if ty.has_maximum_size() else ""
         return f"{typename}{bound}", None
     elif isinstance(ty, Array):
-        name, dep = _stringify_type(ty.value_type, pkg)
+        name, dep = _stringify_type(ty.value_type, prefix)
         return f"{name}[{ty.size}]", dep
     elif isinstance(ty, AbstractSequence):
         bound = f"[<={ty.maximum_size}]" if ty.has_maximum_size() else "[]"
-        name, dep = _stringify_type(ty.value_type, pkg)
+        name, dep = _stringify_type(ty.value_type, prefix)
         return f"{name}{bound}", dep
     else:
         raise RuntimeError(f"Unhandled type {type(ty).__name__}")

--- a/rosapi/test/test_stringify_field_types.py
+++ b/rosapi/test/test_stringify_field_types.py
@@ -16,16 +16,16 @@ class TestObjectUtils(unittest.TestCase):
         self.assertEqual(
             stringify_field_types("std_msgs/ByteMultiArray"),
             """\
-std_msgs/MultiArrayLayout layout
+std_msgs/msg/MultiArrayLayout layout
 byte[] data
 
 ================================================================================
-MSG: std_msgs/MultiArrayLayout
-std_msgs/MultiArrayDimension[] dim
+MSG: std_msgs/msg/MultiArrayLayout
+std_msgs/msg/MultiArrayDimension[] dim
 uint32 data_offset
 
 ================================================================================
-MSG: std_msgs/MultiArrayDimension
+MSG: std_msgs/msg/MultiArrayDimension
 string label
 uint32 size
 uint32 stride
@@ -34,7 +34,7 @@ uint32 stride
         self.assertEqual(
             stringify_field_types("sensor_msgs/Image"),
             """\
-std_msgs/Header header
+std_msgs/msg/Header header
 uint32 height
 uint32 width
 string encoding
@@ -43,15 +43,15 @@ uint32 step
 uint8[] data
 
 ================================================================================
-MSG: std_msgs/Header
-builtin_interfaces/Time stamp
+MSG: std_msgs/msg/Header
+builtin_interfaces/msg/Time stamp
 string frame_id
 """,
         )
         self.assertEqual(
             stringify_field_types("sensor_msgs/CameraInfo"),
             """\
-std_msgs/Header header
+std_msgs/msg/Header header
 uint32 height
 uint32 width
 string distortion_model
@@ -61,10 +61,10 @@ float64[9] r
 float64[12] p
 uint32 binning_x
 uint32 binning_y
-sensor_msgs/RegionOfInterest roi
+sensor_msgs/msg/RegionOfInterest roi
 
 ================================================================================
-MSG: sensor_msgs/RegionOfInterest
+MSG: sensor_msgs/msg/RegionOfInterest
 uint32 x_offset
 uint32 y_offset
 uint32 height
@@ -72,8 +72,8 @@ uint32 width
 bool do_rectify
 
 ================================================================================
-MSG: std_msgs/Header
-builtin_interfaces/Time stamp
+MSG: std_msgs/msg/Header
+builtin_interfaces/msg/Time stamp
 string frame_id
 """,
         )
@@ -92,11 +92,11 @@ float64[<=3] dimensions
                 """\
 string<=256 node_namespace
 string<=256 node_name
-rmw_dds_common/Gid[] reader_gid_seq
-rmw_dds_common/Gid[] writer_gid_seq
+rmw_dds_common/msg/Gid[] reader_gid_seq
+rmw_dds_common/msg/Gid[] writer_gid_seq
 
 ================================================================================
-MSG: rmw_dds_common/Gid
+MSG: rmw_dds_common/msg/Gid
 uint8[24] data
 """,
             )


### PR DESCRIPTION
It's more canonical for ROS 2 type names to be of the form `foo_msgs/msg/Bar` rather than just `foo_msgs/Bar`. This is occasionally reflected in documentation and command line tooling: https://docs.ros.org/en/galactic/Tutorials/Topics/Understanding-ROS2-Topics.html#ros2-interface-show

So rather than stripping out `/msg/`, we include it in the type definitions.

See also: https://github.com/foxglove/rosmsg/pull/12