### PR TITLE
Fix globs in launch xml

### DIFF
--- a/rosbridge_server/launch/rosbridge_tcp_launch.xml
+++ b/rosbridge_server/launch/rosbridge_tcp_launch.xml
@@ -11,16 +11,12 @@
   <arg name="max_message_size" default="None" />
   <arg name="unregister_timeout" default="10" />
 
-  <arg name="authenticate" default="false" />
-
-  <arg name="topics_glob" default="''[*]''" />
-  <arg name="services_glob" default="''[*]''" />
-  <arg name="params_glob" default="''[*]''" />
+  <arg name="topics_glob" default="" />
+  <arg name="services_glob" default="" />
+  <arg name="params_glob" default="" />
   <arg name="bson_only_mode" default="false" />
 
   <node name="rosbridge_tcp" pkg="rosbridge_server" exec="rosbridge_tcp" output="screen">
-    <param name="authenticate" value="$(var authenticate)" />
-
     <param name="port" value="$(var port)"/>
     <param name="host" value="$(var host)"/>
     <param name="incoming_buffer" value="$(var incoming_buffer)"/>

--- a/rosbridge_server/launch/rosbridge_udp_launch.xml
+++ b/rosbridge_server/launch/rosbridge_udp_launch.xml
@@ -7,15 +7,11 @@
   <arg name="max_message_size" default="None" />
   <arg name="unregister_timeout" default="10" />
 
-  <arg name="authenticate" default="false" />
-
-  <arg name="topics_glob" default="''[*]''" />
-  <arg name="services_glob" default="''[*]''" />
-  <arg name="params_glob" default="''[*]''" />
+  <arg name="topics_glob" default="" />
+  <arg name="services_glob" default="" />
+  <arg name="params_glob" default="" />
 
   <node name="rosbridge_udp" pkg="rosbridge_server" exec="rosbridge_udp" output="screen">
-    <param name="authenticate" value="$(var authenticate)" />
-
     <param name="port" value="$(var port)"/>
     <param name="interface" value="$(var interface)"/>
     <param name="fragment_timeout" value="$(var fragment_timeout)"/>

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -14,11 +14,9 @@
 
   <arg name="use_compression" default="false" />
 
-  <arg name="authenticate" default="false" />
-
-  <arg name="topics_glob" default="'[*]'" />
-  <arg name="services_glob" default="'[*]'" />
-  <arg name="params_glob" default="'[*]'" />
+  <arg name="topics_glob" default="" />
+  <arg name="services_glob" default="" />
+  <arg name="params_glob" default="" />
   <arg name="bson_only_mode" default="false" />
 
   <arg unless="$(var bson_only_mode)" name="binary_encoder" default="default"/>
@@ -27,7 +25,6 @@
     <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen">
       <param name="certfile" value="$(var certfile)" />
       <param name="keyfile" value="$(var keyfile)" />
-      <param name="authenticate" value="$(var authenticate)" />
       <param name="port" value="$(var port)"/>
       <param name="address" value="$(var address)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>
@@ -44,7 +41,6 @@
   </group>
   <group unless="$(var ssl)">
     <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen">
-      <param name="authenticate" value="$(var authenticate)" />
       <param name="port" value="$(var port)"/>
       <param name="address" value="$(var address)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>


### PR DESCRIPTION
Fixes https://github.com/RobotWebTools/rosbridge_suite/issues/588 by removing the default value of `[*]` from the launch XML files. An empty string is treated as matching all topics, which was the intended default behavior anyway.

Also cleans up some launch params I forgot in #586.