### PR TITLE
Automatically warn and close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: "This issue has been marked as stale because it has been open for 180 days with no activity. Please remove the stale label or add a comment to keep it open."
+          stale-issue-label: stale
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
+
+          stale-pr-message: "This PR has been marked as stale because it has been open for 90 days with no activity. Please remove the stale label or add a comment to keep it open. Thank you for your contribution."
+          stale-pr-label: stale
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          delete-branch: true


### PR DESCRIPTION
This repo has many stale issues dating back years. Many are not actionable or reproducible.

Proposing an automated bot which will comment on stale issues and PRs.

For issues:
- A comment will be made if there is no activity for 180 days
- If no further activity, the issue will be closed after 30 days

For PRs:
- A comment will be made if there is no activity for 90 days
- If no further activity, the issue will be closed after 14 days

