### PR TITLE
Fix some but not all Python undefined names

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -37,10 +37,12 @@ import threading
 from rcl_interfaces.msg import Parameter, ParameterType, ParameterValue
 from rcl_interfaces.srv import ListParameters
 import rclpy
+import rospy
 from ros2node.api import get_absolute_node_name
 from ros2param.api import call_get_parameters, call_set_parameters, get_parameter_value
 
 from rosapi.proxy import get_nodes
+
 
 """ Methods to interact with the param server.  Values have to be passed
 as JSON in order to facilitate dynamically typed SRV messages """

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -30,9 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import sys
-PYTHON2 = sys.version_info < (3, 0)
-
 import fnmatch
 from threading import Lock
 from functools import partial
@@ -317,9 +314,6 @@ class Subscribe(Capability):
                 return
         else:
             self.protocol.log("debug", "No topic security glob, not checking topic publish.")
-
-        if PYTHON2:
-            topic = unicode(topic)
 
         outgoing_msg = {u"op": u"publish", u"topic": topic}
         if compression=="png":

--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -1,7 +1,4 @@
 import struct
-import sys
-
-PYTHON2 = sys.version_info < (3, 0)
 
 try:
     from cbor import Tag
@@ -45,12 +42,9 @@ def extract_cbor_values(msg):
     for slot, slot_type in zip(msg.__slots__, msg._slot_types):
         val = getattr(msg, slot)
 
-        if PYTHON2:
-            slot = unicode(slot)
-
         # string
         if slot_type in STRING_TYPES:
-            out[slot] = unicode(val) if PYTHON2 else str(val)
+            out[slot] = str(val)
 
         # bool
         elif slot_type in BOOL_TYPES:
@@ -73,10 +67,7 @@ def extract_cbor_values(msg):
 
         # byte array
         elif slot_type in BYTESTREAM_TYPES:
-            if PYTHON2:
-                out[slot] = bytes(bytearray(val))
-            else:
-                out[slot] = bytes(val)
+            out[slot] = bytes(val)
 
         # bool array
         elif slot_type in BOOL_ARRAY_TYPES:

--- a/rosbridge_library/src/rosbridge_library/util/__init__.py
+++ b/rosbridge_library/src/rosbridge_library/util/__init__.py
@@ -7,14 +7,8 @@ except ImportError:
     except ImportError:
         import json
 
-# Differing string types for Python 2 and 3
-import sys
-if sys.version_info >= (3, 0):
-    string_types = (str,)
-    from io import StringIO
-else:
-    string_types = (str, unicode)
-    from StringIO import StringIO
+string_types = (str,)
+from io import StringIO
 
 import bson
 try:

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -1,9 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import rostest
-import sys
 import unittest
-
-PYTHON2 = sys.version_info < (3, 0)
 
 import struct
 from rosbridge_library.internal.cbor_conversion import extract_cbor_values, TAGGED_ARRAY_FORMATS
@@ -35,10 +32,7 @@ class TestCBORConversion(unittest.TestCase):
         extracted = extract_cbor_values(msg)
 
         self.assertEqual(extracted['data'], msg.data)
-        if PYTHON2:
-            self.assertEqual(type(extracted['data']), unicode)
-        else:
-            self.assertEqual(type(extracted['data']), str)
+        self.assertEqual(type(extracted['data']), str)
 
     def test_bool(self):
         for val in [True, False]:
@@ -87,10 +81,7 @@ class TestCBORConversion(unittest.TestCase):
         data = extracted['data']
         self.assertEqual(type(data), bytes)
         for i, val in enumerate(msg.data):
-            if PYTHON2:
-                self.assertEqual(ord(data[i]), val)
-            else:
-                self.assertEqual(data[i], val)
+            self.assertEqual(data[i], val)
 
     def test_numeric_array(self):
         for msg_type in [Int8MultiArray, Int16MultiArray, Int32MultiArray, Int64MultiArray,
@@ -148,10 +139,7 @@ class TestCBORConversion(unittest.TestCase):
 
         keys = extracted.keys()
         for key in keys:
-            if PYTHON2:
-                self.assertEqual(type(key), unicode)
-            else:
-                self.assertEqual(type(key), str)
+            self.assertEqual(type(key), str)
 
 
 PKG = 'rosbridge_library'

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -1,24 +1,14 @@
-#!/usr/bin/env python
-from __future__ import print_function
-import sys
+#!/usr/bin/env python3
 import rospy
 import rostest
 import unittest
 from json import loads, dumps
 
-try:
-    from cStringIO import StringIO  # Python 2.x
-except ImportError:
-    from io import BytesIO as StringIO  # Python 3.x
+from io import BytesIO
 
 from rosbridge_library.internal import message_conversion as c
 from rosbridge_library.internal import ros_loader
-from base64 import standard_b64encode, standard_b64decode
-
-if sys.version_info >= (3, 0):
-    string_types = (str,)
-else:
-    string_types = (str, unicode)
+from base64 import standard_b64encode
 
 
 class TestMessageConversion(unittest.TestCase):
@@ -30,7 +20,7 @@ class TestMessageConversion(unittest.TestCase):
         """ Serializes and deserializes the inst to typecheck and ensure that
         instances are correct """
         inst1._check_types()
-        buff = StringIO()
+        buff = BytesIO()
         inst1.serialize(buff)
         inst2 = type(inst1)()
         inst2.deserialize(buff.getvalue())
@@ -38,7 +28,7 @@ class TestMessageConversion(unittest.TestCase):
         inst2._check_types()
 
     def msgs_equal(self, msg1, msg2):
-        if type(msg1) in string_types and type(msg2) in string_types:
+        if isinstance(msg1, str) and isinstance(msg2, str):
             pass
         else:
             self.assertEqual(type(msg1), type(msg2))

--- a/rosbridge_library/test/internal/test_services.py
+++ b/rosbridge_library/test/internal/test_services.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
-import sys
 import rospy
 import rostest
 import unittest
@@ -13,11 +12,6 @@ from rosbridge_library.internal.message_conversion import FieldTypeMismatchExcep
 
 from roscpp.srv import GetLoggers
 
-if sys.version_info >= (3, 0):
-    string_types = (str,)
-else:
-    string_types = (str, unicode)
-
 
 def populate_random_args(d):
     # Given a dictionary d, replaces primitives with random values
@@ -27,8 +21,6 @@ def populate_random_args(d):
         return d
     elif isinstance(d, str):
         return str(random.random())
-    elif sys.version_info < (3,0) and isinstance(d, unicode):
-        return unicode(random.random())
     elif isinstance(d, bool):
         return True
     elif isinstance(d, int):
@@ -91,7 +83,7 @@ class TestServices(unittest.TestCase):
         rospy.init_node("test_services")
 
     def msgs_equal(self, msg1, msg2):
-        if type(msg1) in string_types and type(msg2) in string_types:
+        if isinstance(msg1, str) and isinstance(msg2, str):
             pass
         else:
             self.assertEqual(type(msg1), type(msg2))


### PR DESCRIPTION
Use the test `flake8 --select=F82` to find and fix _undefined names_ in Python code like [we used to do in Travis CI](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/.travis.yml#L35).  Several of these changes are about removing Python 2 data types that were dropped in Python 3 (basestring, long, unicode).  Other fixes were about missing imports or local variable naming.  This PR fixes 24 of 26 _undefined name_ but was unable to resolve the issues in the two excluded files.   #604

## After:
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./rosapi/src/rosapi/proxy.py:240:11: F821 undefined name 'get_service_uri'
    uri = get_service_uri(service)
          ^
./rosbridge_server/scripts/rosbridge_websocket.py:304:5: F821 undefined name 'node'
    node.destroy_node()
    ^
2     F821 undefined name 'get_service_uri'
2
```

## Before:
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./rosbridge_library/test/internal/test_services.py:19:26: F821 undefined name 'unicode'
    string_types = (str, unicode)
                         ^
./rosbridge_library/test/internal/test_services.py:30:53: F821 undefined name 'unicode'
    elif sys.version_info < (3,0) and isinstance(d, unicode):
                                                    ^
./rosbridge_library/test/internal/test_services.py:31:16: F821 undefined name 'unicode'
        return unicode(random.random())
               ^
./rosbridge_library/test/internal/test_message_conversion.py:21:26: F821 undefined name 'unicode'
    string_types = (str, unicode)
                         ^
./rosbridge_library/test/internal/test_cbor_conversion.py:39:55: F821 undefined name 'unicode'
            self.assertEqual(type(extracted['data']), unicode)
                                                      ^
./rosbridge_library/test/internal/test_cbor_conversion.py:152:45: F821 undefined name 'unicode'
                self.assertEqual(type(key), unicode)
                                            ^
./rosbridge_library/src/rosbridge_library/capabilities/subscribe.py:322:21: F821 undefined name 'unicode'
            topic = unicode(topic)
                    ^
./rosbridge_library/src/rosbridge_library/util/__init__.py:16:26: F821 undefined name 'unicode'
    string_types = (str, unicode)
                         ^
./rosbridge_library/src/rosbridge_library/util/cbor.py:152:32: F821 undefined name 'unicode'
        return isinstance(val, unicode)
                               ^
./rosbridge_library/src/rosbridge_library/util/cbor.py:218:36: F821 undefined name 'basestring'
        return isinstance(x, (str, basestring, bytes, unicode))
                                   ^
./rosbridge_library/src/rosbridge_library/util/cbor.py:218:55: F821 undefined name 'unicode'
        return isinstance(x, (str, basestring, bytes, unicode))
                                                      ^
./rosbridge_library/src/rosbridge_library/util/cbor.py:220:36: F821 undefined name 'long'
        return isinstance(x, (int, long))
                                   ^
./rosbridge_library/src/rosbridge_library/util/cbor.py:371:18: F821 undefined name 'xrange'
        for i in xrange(aux):
                 ^
./rosbridge_library/src/rosbridge_library/util/cbor.py:378:18: F821 undefined name 'xrange'
        for i in xrange(aux):
                 ^
./rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py:49:20: F821 undefined name 'unicode'
            slot = unicode(slot)
                   ^
./rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py:53:25: F821 undefined name 'unicode'
            out[slot] = unicode(val) if PYTHON2 else str(val)
                        ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:72:35: F821 undefined name 'long'
    primitive_types = [bool, int, long, float]
                                  ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:99:31: F821 undefined name 'node_handler'
        binary_encoder_type = node_handler.get_parameter_or('binary_encoder',
                              ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:100:13: F821 undefined name 'Parameter'
            Parameter('', value='default')).value
            ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:101:26: F821 undefined name 'node_handler'
        bson_only_mode = node_handler.get_parameter_or('bson_only_mode',
                         ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:102:13: F821 undefined name 'Parameter'
            Parameter('', value=False)).value
            ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:155:25: F821 undefined name 'inst'
        return str(type(inst))
                        ^
./rosbridge_library/src/rosbridge_library/internal/message_conversion.py:185:49: F821 undefined name 'rospy'
    if(bson_only_mode is None):bson_only_mode = rospy.get_param('~bson_only_mode', False)
                                                ^
./rosapi/src/rosapi/params.py:239:12: F821 undefined name 'rospy'
    return rospy.search_param(name)
           ^
./rosapi/src/rosapi/proxy.py:240:11: F821 undefined name 'get_service_uri'
    uri = get_service_uri(service)
          ^
./rosbridge_server/scripts/rosbridge_websocket.py:304:5: F821 undefined name 'node'
    node.destroy_node()
    ^
26    F821 undefined name 'rospy'
26
```