### PR TITLE
Load message definitions from .msg files; exclude /msg/ and include builtin_interfaces in combined definitions

### DIFF
--- a/rosapi/src/rosapi/stringify_field_types.py
+++ b/rosapi/src/rosapi/stringify_field_types.py
@@ -1,9 +1,6 @@
-from rosbridge_library.internal import ros_loader
+from rosidl_runtime_py import get_interface_path
+from rosidl_adapter.parser import parse_message_string
 
-from rosidl_parser.definition import AbstractGenericString, AbstractSequence, AbstractType, AbstractWString, Array, BasicType, NamedType, NamespacedType
-from rosidl_adapter.msg import MSG_TYPE_TO_IDL
-
-IDL_TYPE_TO_MSG = {v: k for k, v in MSG_TYPE_TO_IDL.items()}
 
 def stringify_field_types(root_type):
     definition = ""
@@ -12,42 +9,27 @@ def stringify_field_types(root_type):
     is_root = True
     while deps:
         ty = deps.pop()
+        parts = ty.split("/")
         if not is_root:
             definition += "\n================================================================================\n"
             definition += f"MSG: {ty}\n"
         is_root = False
 
-        cls = ros_loader.get_message_class(ty)
-        prefix = ty.split("/")[:-1]
-        fields_and_types = zip(cls.get_fields_and_field_types().keys(), cls.SLOT_TYPES)
-        for name, field_type in fields_and_types:
-            type_str, dep = _stringify_type(field_type, prefix)
-            if dep is not None and dep not in seen_types:
-                deps.append(dep)
-                seen_types.add(dep)
-            definition += f"{type_str} {name}\n"
-    return definition
+        msg_name = parts[2] if len(parts) == 3 else parts[1]
+        interface_name = ty if len(parts) == 3 else f"{parts[0]}/msg/{parts[1]}"
+        with open(
+            get_interface_path(interface_name), "r", encoding="utf-8"
+        ) as msg_file:
+            msg_definition = msg_file.read()
+        definition += msg_definition
 
-def _stringify_type(ty: AbstractType, prefix: str):
-    if isinstance(ty, BasicType):
-        return IDL_TYPE_TO_MSG[ty.typename], None
-    elif isinstance(ty, NamedType):
-        return ty.name, f"{prefix}/{ty.name}"
-    elif isinstance(ty, NamespacedType):
-        namespaced_name = ty.namespaced_name()
-        full_name = "/".join(namespaced_name)
-        is_builtin = ty.namespaces[0] == "builtin_interfaces"
-        return full_name, None if is_builtin else full_name
-    elif isinstance(ty, AbstractGenericString):
-        typename = "wstring" if isinstance(ty, AbstractWString) else "string"
-        bound = f"<={ty.maximum_size}" if ty.has_maximum_size() else ""
-        return f"{typename}{bound}", None
-    elif isinstance(ty, Array):
-        name, dep = _stringify_type(ty.value_type, prefix)
-        return f"{name}[{ty.size}]", dep
-    elif isinstance(ty, AbstractSequence):
-        bound = f"[<={ty.maximum_size}]" if ty.has_maximum_size() else "[]"
-        name, dep = _stringify_type(ty.value_type, prefix)
-        return f"{name}{bound}", dep
-    else:
-        raise RuntimeError(f"Unhandled type {type(ty).__name__}")
+        spec = parse_message_string(parts[0], msg_name, msg_definition)
+        for field in spec.fields:
+            is_builtin = field.type.pkg_name is None
+            if not is_builtin:
+                field_ty = f"{field.type.pkg_name}/{field.type.type}"
+                if field_ty not in seen_types:
+                    deps.append(field_ty)
+                    seen_types.add(field_ty)
+
+    return definition

--- a/rosapi/test/test_stringify_field_types.py
+++ b/rosapi/test/test_stringify_field_types.py
@@ -11,12 +11,12 @@ class TestObjectUtils(unittest.TestCase):
 
         self.assertRegex(
             stringify_field_types("std_msgs/String"),
-            r"(?ms).+^string data",
+            r"(?ms)^string data",
         )
 
         self.assertRegex(
             stringify_field_types("std_msgs/msg/String"),
-            r"(?ms).+^string data",
+            r"(?ms)^string data",
         )
 
         self.assertRegex(

--- a/rosapi/test/test_stringify_field_types.py
+++ b/rosapi/test/test_stringify_field_types.py
@@ -9,80 +9,130 @@ class TestObjectUtils(unittest.TestCase):
     def test_stringify_field_types(self):
         self.maxDiff = None
 
-        self.assertEqual(stringify_field_types("std_msgs/String"), "string data\n")
+        self.assertRegex(
+            stringify_field_types("std_msgs/String"),
+            r"(?ms).+^string data",
+        )
 
-        self.assertEqual(stringify_field_types("std_msgs/msg/String"), "string data\n")
+        self.assertRegex(
+            stringify_field_types("std_msgs/msg/String"),
+            r"(?ms).+^string data",
+        )
 
-        self.assertEqual(
+        self.assertRegex(
             stringify_field_types("std_msgs/ByteMultiArray"),
-            """\
-std_msgs/msg/MultiArrayLayout layout
-byte[] data
+            r"""(?s)
+MultiArrayLayout  layout.*
+byte\[\]            data.*
 
 ================================================================================
-MSG: std_msgs/msg/MultiArrayLayout
-std_msgs/msg/MultiArrayDimension[] dim
-uint32 data_offset
+MSG: std_msgs/MultiArrayLayout
+.*
+MultiArrayDimension\[\] dim.*
+uint32 data_offset.*
 
 ================================================================================
-MSG: std_msgs/msg/MultiArrayDimension
-string label
-uint32 size
-uint32 stride
+MSG: std_msgs/MultiArrayDimension
+.*
+string label.*
+uint32 size.*
+uint32 stride.*
 """,
         )
-        self.assertEqual(
+        self.assertRegex(
             stringify_field_types("sensor_msgs/Image"),
-            """\
-std_msgs/msg/Header header
-uint32 height
-uint32 width
-string encoding
-uint8 is_bigendian
-uint32 step
-uint8[] data
+            r"""(?s)
+std_msgs/Header header.*
+.*
+uint32 height.*
+uint32 width.*
+.*
+string encoding.*
+.*
+uint8 is_bigendian.*
+uint32 step.*
+uint8\[\] data.*
 
 ================================================================================
-MSG: std_msgs/msg/Header
-builtin_interfaces/msg/Time stamp
+MSG: std_msgs/Header
+.*
+builtin_interfaces/Time stamp.*
 string frame_id
+
+================================================================================
+MSG: builtin_interfaces/Time
+.*
+int32 sec.*
+uint32 nanosec
 """,
         )
-        self.assertEqual(
+        self.assertRegex(
             stringify_field_types("sensor_msgs/CameraInfo"),
-            """\
-std_msgs/msg/Header header
-uint32 height
-uint32 width
-string distortion_model
-float64[] d
-float64[9] k
-float64[9] r
-float64[12] p
-uint32 binning_x
-uint32 binning_y
-sensor_msgs/msg/RegionOfInterest roi
+            r"""(?s)
+std_msgs/Header header.*
+uint32 height.*
+uint32 width.*
+string distortion_model.*
+float64\[\] d.*
+float64\[9\]  k.*
+float64\[9\]  r.*
+float64\[12\] p.*
+uint32 binning_x.*
+uint32 binning_y.*
+RegionOfInterest roi.*
 
 ================================================================================
-MSG: sensor_msgs/msg/RegionOfInterest
-uint32 x_offset
-uint32 y_offset
-uint32 height
-uint32 width
+MSG: sensor_msgs/RegionOfInterest
+.*
+uint32 x_offset.*
+uint32 y_offset.*
+uint32 height.*
+uint32 width.*
 bool do_rectify
 
 ================================================================================
-MSG: std_msgs/msg/Header
-builtin_interfaces/msg/Time stamp
+MSG: std_msgs/Header
+.*
+builtin_interfaces/Time stamp.*
 string frame_id
+
+================================================================================
+MSG: builtin_interfaces/Time
+.*
+int32 sec.*
+uint32 nanosec
+""",
+        )
+
+        self.assertRegex(
+            stringify_field_types("shape_msgs/SolidPrimitive"),
+            r"""(?s)
+uint8 BOX=1.*
+uint8 SPHERE=2.*
+uint8 CYLINDER=3.*
+uint8 CONE=4.*
+uint8 type.*
+float64\[<=3\] dimensions.*
+uint8 BOX_X=0.*
+uint8 BOX_Y=1.*
+uint8 BOX_Z=2.*
+uint8 SPHERE_RADIUS=0.*
+uint8 CYLINDER_HEIGHT=0.*
+uint8 CYLINDER_RADIUS=1.*
+uint8 CONE_HEIGHT=0.*
+uint8 CONE_RADIUS=1.*
 """,
         )
 
         self.assertEqual(
-            stringify_field_types("shape_msgs/SolidPrimitive"),
+            stringify_field_types("geometry_msgs/Quaternion"),
             """\
-uint8 type
-float64[<=3] dimensions
+# This represents an orientation in free space in quaternion form.
+
+float64 x 0
+float64 y 0
+float64 z 0
+float64 w 1
 """,
         )
 
@@ -92,12 +142,12 @@ float64[<=3] dimensions
                 """\
 string<=256 node_namespace
 string<=256 node_name
-rmw_dds_common/msg/Gid[] reader_gid_seq
-rmw_dds_common/msg/Gid[] writer_gid_seq
+Gid[] reader_gid_seq
+Gid[] writer_gid_seq
 
 ================================================================================
-MSG: rmw_dds_common/msg/Gid
-uint8[24] data
+MSG: rmw_dds_common/Gid
+char[24] data
 """,
             )
         except InvalidModuleException:


### PR DESCRIPTION
In #574, I implemented get_topics_and_raw_types by reconstructing message definitions from generated Python code. It recently came to my attention [via ROS Answers](https://answers.ros.org/question/321062/python-rosmsgrospack-in-ros2/?answer=354166#post-id-354166) that `ros2 interface show` and similar tooling actually access the **original** `.msg` files using a function called `rosidl_runtime_py.get_interface_path`. This seems to work reliably enough, and produces better fidelity message definitions (comments, constants, and default values are preserved), so it can be used instead of reconstructing definitions from the generated code.

This PR also removes `/msg/` again from the "raw types" response. In #584 and #591 I made sure `/msg/` was included in datatype names and definitions because it seemed more correct in ROS 2. But while writing this PR, I realized that `.msg` definition files actually do not and **cannot** include `/msg/` in their references to other message types — it is rejected by the [rosidl adapter](https://github.com/ros2/rosidl/blob/36ed120f43daeaab31fd9ba2bf8dfb58db05091d/rosidl_adapter/rosidl_adapter/parser.py#L188-L190) at build time — so I think it should be excluded from the combined definition which is meant to stay as close as possible to the original .msg sources. Still, the **datatype names** do seem to include `/msg/`, so I'm keeping them there. Unfortunately this means that the top-level datatype names don't match the contents of the definitions, but this isn't a big deal since the definitions are all self-contained.

Finally, this PR removes logic that excluded `builtin_interfaces/Time` and `builtin_interfaces/Duration` from the combined message definitions. While these are "builtin" interfaces, they are technically still messages, so it seems more correct to include their contents in the combined definitions: https://groups.google.com/g/ros-sig-ng-ros/c/f7OcEJBj9tU
> Time and Duration are now messages and not built-in types. This is a good thing, because it makes our builtin types more portable. For example, you don’t need to depend on rostime (a C++ library) to use our generated message code.


See also: https://github.com/ros2/ros2/issues/1159