### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ DEVEL
 
 2014-03-14 - **0.5.2**
  * Added error messages on result=False When call_service returns False as result, values contains the error message. (Pro)
- * Specific IP adress binding using roslaunch (Steffel Fenix)
+ * Specific IP address binding using roslaunch (Steffel Fenix)
  * support publishing non-ascii letters (furushchev)
  * Fixed wrong unicode encoding (Pro)
  * adding missing dependency in rosbridge_library (jihoonl)

--- a/ROSBRIDGE_PROTOCOL.md
+++ b/ROSBRIDGE_PROTOCOL.md
@@ -330,8 +330,8 @@ the advertise command.
      is sent and this message is dropped.
    * If the topic already exists with the same type, the sender of this message
      is registered as another publisher.
-   * If the topic doesnt already exist but the type cannot be resolved, then an
-     error status message is sent and this message is dropped.
+   * If the topic doesn't already exist but the type cannot be resolved, then
+     an error status message is sent and this message is dropped.
 
 #### 3.4.2 Unadvertise ( _unadvertise_ )
 

--- a/rosapi/CHANGELOG.rst
+++ b/rosapi/CHANGELOG.rst
@@ -144,7 +144,7 @@ Changelog for package rosapi
 * correct default values for security globs
   also accept empty list as the default "do not check globs" value in addition to None.
   Finally, append rosapi service glob after processing command line input so it's not overwritten
-* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellanous fixes.
+* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellaneous fixes.
 * As per the suggestions of @T045T, fixed several typos, improved logging, and made some style fixes.
 * Fixed time object field definitions to match documentation.
 * Two minor fixes.

--- a/rosbridge_library/CHANGELOG.rst
+++ b/rosbridge_library/CHANGELOG.rst
@@ -202,7 +202,7 @@ Changelog for package rosbridge_library
 * correct default values for security globs
   also accept empty list as the default "do not check globs" value in addition to None.
   Finally, append rosapi service glob after processing command line input so it's not overwritten
-* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellanous fixes.
+* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellaneous fixes.
 * As per the suggestions of @T045T, fixed several typos, improved logging, and made some style fixes.
 * Added new parameters for topic and service security.
   Added 3 new parameters to rosapi and rosbridge_server which filter the
@@ -401,7 +401,7 @@ Changelog for package rosbridge_library
 ------------------
 * removing wrong import
 * test case for fixed size of uint8 array
-* uses regular expresion to match uint8 array and char array.
+* uses regular expression to match uint8 array and char array.
 * logerr when it fails while message_conversion
 * Contributors: Jihoon Lee
 
@@ -444,7 +444,7 @@ Changelog for package rosbridge_library
 * updated websocket test service server script to use websocket
 * added files to test new caps with websocket server
 * feierabend.. morgen weiter mit server & client JSON-decoder, see notes
-* fixed parsing of incomplete/multiple JSON in incoming buffer; so clients do not need to use an intervall when sending to rosbridge
+* fixed parsing of incomplete/multiple JSON in incoming buffer; so clients do not need to use an interval when sending to rosbridge
 * only current changes; not yet done..
 * code cleanup, not yet finished..; rosbridge logging much cleaner now
 * fixed test_server_defragment - recodegit status
@@ -455,7 +455,7 @@ Changelog for package rosbridge_library
 * blocking behavior for service requests to non-ros; test-scripts use get-ip4 helper function; ..needs a lot cleanup before next steps..
 * need to implement server side blocking of multiple requests, to keep implementation of service provider as easy and simple as possible
 * not finished
-* some changes.. still needs serveral fixes
+* some changes.. still needs several fixes
 * unique request_ids
 * fixed deserialization of multiple fragments in incoming-data; was caused by too short delay between socket-sends (<0.2 seconds); maybe only temp. fixed
 * added fragment sorting to test-client and test-server
@@ -542,7 +542,7 @@ Changelog for package rosbridge_library
 * Adds BSD license header to code files.
   See Issue `#13 <https://github.com/RobotWebTools/rosbridge_suite/issues/13>`_.
 * Removing ultrajson from rosbridge.
-  If JSON parsing becomes a performance bottle neck, we can readd it.
+  If JSON parsing becomes a performance bottle neck, we can re-add it.
 * Catkinizing rosbridge_library and server.
 * PNG compression now creates a square RGB image padded with new-line characters
 * Add stack dependencies and rosdeps.

--- a/rosbridge_library/CMakeLists.txt
+++ b/rosbridge_library/CMakeLists.txt
@@ -40,7 +40,7 @@ ament_export_dependencies(rosidl_default_runtime)
 ament_package()
 
 if (BUILD_TESTING)
-  # TODO reenable rostests
+  # TODO re-enable rostests
   # find_package(rostest REQUIRED)
   # add_rostest(test/capabilities/test_capabilities.test)
   # add_rostest(test/internal/test_internal.test)

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -3,7 +3,7 @@
   <name>rosbridge_library</name>
   <version>1.0.6</version>
   <description>
-    The core rosbridge package, repsonsible for interpreting JSON andperforming
+    The core rosbridge package, responsible for interpreting JSON andperforming
     the appropriate ROS action, like subscribe, publish, call service, and
     interact with params.
   </description>

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -293,7 +293,7 @@ def _to_time_inst(msg, rostype, inst=None):
 def _to_primitive_inst(msg, rostype, roottype, stack):
     # Typecheck the msg
     if type(msg) == int and rostype in type_map['float']:
-        # propably wrong parsing,
+        # probably wrong parsing,
         # fix that by casting the int to the expected float
         msg = float(msg)
 

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -149,7 +149,7 @@ class Protocol:
                 # .. check for "op"-field. i can still imagine cases where a nested message ( e.g. complete service_response fits into the data field of a fragment..)
                 # .. would cause trouble, but if a response fits as a whole into a fragment, simply do not pack it into a fragment.
                 #
-                # --> from that follows current limitiation:
+                # --> from that follows current limitation:
                 #     fragment data must NOT (!) contain a complete json-object that has an "op-field"
                 #
                 # an alternative solution would be to only check from first opening bracket and have a time out on data in input buffer.. (to handle broken data)
@@ -169,7 +169,7 @@ class Protocol:
                             # debug json-decode errors with this line
                             #print e
                             pass
-                    # if load was successfull --> break outer loop, too.. -> no need to check if json begins at a "later" opening bracket..
+                    # if load was successful --> break outer loop, too.. -> no need to check if json begins at a "later" opening bracket..
                     if msg != None:
                         break
 
@@ -328,7 +328,7 @@ class Protocol:
 
             # TODO: implement a way to have a final Exception when nothing works out to decode (multiple/broken/partial JSON..)
 
-            # supressed logging of exception on json-decode to keep rosbridge-logs "clean", otherwise console logs would get spammed for every failed json-decode try
+            # suppressed logging of exception on json-decode to keep rosbridge-logs "clean", otherwise console logs would get spammed for every failed json-decode try
 #            if msg != self.buffer:
 #                error_msg = "Unable to deserialize message from client: %s"  % msg
 #                error_msg += "\nException was: " +str(e)

--- a/rosbridge_library/src/rosbridge_library/util/cbor.py
+++ b/rosbridge_library/src/rosbridge_library/util/cbor.py
@@ -449,7 +449,7 @@ def _loads_tb(fp, tb, limit=None, depth=0, returntags=False):
             # Don't interpret the tag, return it and the tagged object.
             ob = Tag(aux, ob)
         else:
-            # attempt to interpet the tag and the value into a Python object.
+            # attempt to interpret the tag and the value into a Python object.
             ob = tagify(ob, aux)
         return ob, bytes_read
     elif tag == CBOR_7:

--- a/rosbridge_server/CHANGELOG.rst
+++ b/rosbridge_server/CHANGELOG.rst
@@ -199,7 +199,7 @@ Changelog for package rosbridge_server
   also accept empty list as the default "do not check globs" value in addition to None.
   Finally, append rosapi service glob after processing command line input so it's not overwritten
 * add missing imports and correct default values for glob parameters
-* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellanous fixes.
+* Added services_glob to CallServices, added globs to rosbridge_tcp and rosbridge_udp, and other miscellaneous fixes.
 * Two minor fixes.
 * Added new parameters for topic and service security.
   Added 3 new parameters to rosapi and rosbridge_server which filter the
@@ -305,7 +305,7 @@ Changelog for package rosbridge_server
 * update changelog
 * Merge pull request #147 from RobotWebTools/migrate_third_parties
   separate tornado and backports from rosbridge_server
-* seprate out third party library and ros related script
+* separate out third party library and ros related script
 * remove setup.py
 * add rosbridge_tools as rosbridge_server dependency
 * remove python-imaging dependency. it is used in rosbridge_library
@@ -336,7 +336,7 @@ Changelog for package rosbridge_server
 * update changelog
 * Merge pull request #147 from RobotWebTools/migrate_third_parties
   separate tornado and backports from rosbridge_server
-* seprate out third party library and ros related script
+* separate out third party library and ros related script
 * remove setup.py
 * add rosbridge_tools as rosbridge_server dependency
 * remove python-imaging dependency. it is used in rosbridge_library
@@ -346,7 +346,7 @@ Changelog for package rosbridge_server
 ------------------
 * Merge pull request `#147 <https://github.com/RobotWebTools/rosbridge_suite/issues/147>`_ from RobotWebTools/migrate_third_parties
   separate tornado and backports from rosbridge_server
-* seprate out third party library and ros related script
+* separate out third party library and ros related script
 * remove setup.py
 * add rosbridge_tools as rosbridge_server dependency
 * remove python-imaging dependency. it is used in rosbridge_library
@@ -421,7 +421,7 @@ Changelog for package rosbridge_server
 * move global param into local param to address issue `#25 <https://github.com/RobotWebTools/rosbridge_suite/issues/25>`_
 * moving global parameter into local parameter to address issue `#25 <https://github.com/RobotWebTools/rosbridge_suite/issues/25>`_
 * merging changes of groovy-devel into hydro-devel
-* Specific IP adress binding using roslauch
+* Specific IP address binding using roslauch
 * added parameter lookup to rosbridge_tcp.py, modules where those are used, and default parameters to launch file; internal default-values still get used when launch-file does not provide them; internal defaults can be changed within rosbridge_tcp.py
 * increaing max_msg_length - still hardcoded
 * preparing pull request for upstream..
@@ -501,7 +501,7 @@ Changelog for package rosbridge_server
   [ERROR] [WallTime: 1356115083.100585] Uncaught exception, closing connection.
   [ERROR] [WallTime: 1356115083.100900] Exception in callback <tornado.stack_context._StackContextWrapper object at 0x1dd6e10>
 * Removing ultrajson from rosbridge.
-  If JSON parsing becomes a performance bottle neck, we can readd it.
+  If JSON parsing becomes a performance bottle neck, we can re-add it.
 * Refactors rosbridge_server. Adds scripts dir.
 * Catkinizing rosbridge_library and server.
 * Added command line --port argument.

--- a/rosbridge_server/scripts/rosbridge_tcp.py
+++ b/rosbridge_server/scripts/rosbridge_tcp.py
@@ -23,7 +23,7 @@ except ImportError:
 import sys
 import time
 
-#TODO: take care of socket timeouts and make sure to close sockets after killing programm to release network ports
+#TODO: take care of socket timeouts and make sure to close sockets after killing program to release network ports
 
 #TODO: add new parameters to websocket version! those of rosbridge_tcp.py might not be needed, but the others should work well when adding them to .._websocket.py
 

--- a/rosbridge_suite/CHANGELOG.rst
+++ b/rosbridge_suite/CHANGELOG.rst
@@ -223,6 +223,6 @@ Changelog for package rosbridge_suite
 * Fixed an inconsequential elif bug.
 * Refactored to use simplejson if the package is installed.
 * Added simplejson library and moved the location of the libraries.
-* Temporary commit adding profiling messages. something is goign awry.
+* Temporary commit adding profiling messages. something is going awry.
 * Renamed rosbridge stack to rosbridge_suite
 * Contributors: Austin Hendrix, Brandon Alexander, Jihoon Lee, jon


### PR DESCRIPTION
[`codespell --ignore-words-list=miror`](https://pypi.org/project/codespell)

Related to #594