### PR TITLE
add missing test_depends for rosapi

### DIFF
--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -39,6 +39,9 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>rmw_dds_common</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
test_stringify_field_types was failing on the ROS build farm.