### PR TITLE
Cleanup comments: flake8 --select=E262,E266

### DIFF
--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
@@ -3,10 +3,9 @@ import socket
 from rosbridge_library.util import json
 
 
-
-####################### variables begin ########################################
+# ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
-################################################################################
+# ##############################################################################
 
 client_socket_timeout = 6                       # seconds
 max_msg_length = 2000000                        # bytes
@@ -19,10 +18,10 @@ service_name = "nested_srv"                     # service name
 receiving_fragment_size = 1000
 receive_message_intervall = 0.0
 
-####################### variables end ##########################################
+# ##################### variables end ##########################################
 
 
-################################################################################
+# ##############################################################################
 
 def request_service():
     service_request_object = { "op" : "call_service",                           # op-code for rosbridge
@@ -36,14 +35,14 @@ def request_service():
     print("sending JSON-message to rosbridge:", service_request)
     sock.send(service_request)
 
-################################################################################
+# ##############################################################################
 
 
-####################### script begin ###########################################
+# ##################### script begin ###########################################
 # should not need to be changed (but could be improved ;) )                    #
-################################################################################
+# ##############################################################################
 try:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)                    #connect to rosbridge
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)                    # connect to rosbridge
     sock.settimeout(client_socket_timeout)
     sock.connect((rosbridge_ip, rosbridge_port))
 
@@ -54,7 +53,9 @@ try:
     done = False
     result = None
     reconstructed = None
-    while not done:     # should not need a loop (maximum wait can be set by client_socket_timeout), but since its for test/demonstration only .. leave it as it is for now
+    # should not need a loop (maximum wait can be set by client_socket_timeout), 
+    # but since its for test/demonstration only .. leave it as it is for now
+    while not done:
         try:
             incoming = sock.recv(max_msg_length)                                # receive service_response from rosbridge
             if buffer == "":
@@ -73,7 +74,7 @@ try:
                     done = True
             except Exception:
                 #print "direct access to JSON failed.."
-                #print e
+                #print(e)
                 pass
             try:                                        
                 #print "defragmenting incoming messages"
@@ -87,7 +88,7 @@ try:
                     try:
                         result.append(json.loads(fragment))                     # try to parse json from string, and append if successful
                     except Exception:
-                        #print e
+                        #print(e)
                         #print result_string
                         raise                                                   # re-raise the last exception, allows to see and continue with processing of exception
 
@@ -106,10 +107,10 @@ try:
                         reconstructed = reconstructed + fragment["data"]
                     done = True
             except Exception:
-                #print e
+                #print(e)
                 pass
         except Exception:
-#            print e
+            #print(e)
             pass
 
 
@@ -118,10 +119,10 @@ try:
         print("response was None -> service was not available")
     else:
         print("received:")
-        print(returned_data)#["values"]#["data"].decode('base64','strict')         # decode values-field
+        print(returned_data)  # ["values"]#["data"].decode('base64','strict')   # decode values-field
     
 except Exception as e:
     print("ERROR - could not receive service_response")
     print(e)
 
-sock.close()                                                                    # close socket
+sock.close()

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
@@ -6,9 +6,9 @@ from random import randint
 from rosbridge_library.util import json
 
 
-####################### variables begin ########################################
+# ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
-################################################################################
+# ##############################################################################
 
 tcp_socket_timeout = 10                          # seconds
 max_msg_length = 20000                           # bytes
@@ -21,23 +21,23 @@ service_name = "nested_srv"                      # service name
 
 send_fragment_size = 1000
 # delay between sends to rosbridge is not needed anymore, if using my version of protocol (uses buffer to collect data from stream)
-send_fragment_delay = 0.000#1
+send_fragment_delay = 0.000  # 1
 receive_fragment_size = 10
 receive_message_intervall = 0.0
 
-####################### variables end ##########################################
+# ##################### variables end ##########################################
 
 
-####################### service_calculation begin ##############################
+# ##################### service_calculation begin ##############################
 # change this function to match whatever service should be provided            #
-################################################################################
+# ##############################################################################
 
 def calculate_service_response(request):
     request_object = json.loads(request)                                        # parse string for service request
     args = request_object["args"]                                               # get parameter field (args)
-#    count = int(args["count"] )                                                 # get parameter(s) as described in corresponding ROS srv-file
+#    count = int(args["count"] )                                                # get parameter(s) as described in corresponding ROS srv-file
 #
-#    message = ""                                                                # calculate service response
+#    message = ""                                                               # calculate service response
 #    for i in range(0,count):
 #        message += str(chr(randint(32,126)))
 #        if i% 100000 == 0:
@@ -51,7 +51,7 @@ def calculate_service_response(request):
     --> use .decode("base64","strict") at client side
     """
     #message = message.encode('base64','strict')
-    service_response_data = message                                   # service response (as defined in srv-file)
+    service_response_data = message                                             # service response (as defined in srv-file)
 
     response_object = { "op": "service_response",
                         "id": request_object["id"],
@@ -60,13 +60,12 @@ def calculate_service_response(request):
     response_message = json.dumps(response_object)
     return response_message
 
-####################### service_calculation end ################################
+# ##################### service_calculation end ################################
 
 
-
-####################### helper functions / and variables begin #################
+# ##################### helper functions / and variables begin #################
 # should not need to be changed (but could be improved )                       #
-################################################################################
+# ##############################################################################
 
 buffer = ""
 
@@ -114,7 +113,7 @@ def wait_for_service_request():                                                 
                     return data                                                 # if parsing was successful --> return data string
             except Exception:
                 #print "direct_access error:"
-                #print e
+                #print(e)
                 pass
                
             #print "trying to defragment"
@@ -182,7 +181,7 @@ def list_of_fragments(full_message, fragment_size):                             
     fragmented_messages_list = []                                               # generate list of fragmented messages (including headers)
     if len(fragments) > 1:
         for count, fragment in enumerate(fragments):                            # iterate through list and have index counter
-            fragmented_message_object = {"op":"fragment",                       #   create python-object for each fragment message
+            fragmented_message_object = {"op":"fragment",                       # create Python-object for each fragment message
                                          "id": str(message_id),
                                          "data": str(fragment),
                                          "num": count,
@@ -194,12 +193,12 @@ def list_of_fragments(full_message, fragment_size):                             
         fragmented_messages_list.append(str(fragment))
     return fragmented_messages_list                                             # return list of 'ready-to-send' fragmented messages
 
-####################### helper functions end ###################################
+# ##################### helper functions end ###################################
 
 
-####################### script begin ###########################################
+# ##################### script begin ###########################################
 # should not need to be changed (but could be improved )                       #
-################################################################################
+# ##############################################################################
 
 tcp_socket = connect_tcp_socket()                                               # open tcp_socket
 advertise_service()                                                             # advertise service in ROS (via rosbridge)

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
@@ -3,10 +3,9 @@ import socket
 from rosbridge_library.util import json
 
 
-
-####################### variables begin ########################################
+# ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
-################################################################################
+# ##############################################################################
 
 client_socket_timeout = 6                       # seconds
 max_msg_length = 2000000                        # bytes
@@ -15,14 +14,14 @@ rosbridge_ip = "localhost"                      # hostname or ip
 rosbridge_port = 9090                           # port as integer
 
 service_name = "send_bytes"                     # service name
-request_byte_count = 500000                   ## note: receiving more than ~100.000 bytes without setting a fragment_size was not possible during testing..
+request_byte_count = 500000                     # NOTE: receiving more than ~100.000 bytes without setting a fragment_size was not possible during testing.
 receiving_fragment_size = 1000
 receive_message_intervall = 0.0
 
-####################### variables end ##########################################
+# ##################### variables end ##########################################
 
 
-################################################################################
+# ##############################################################################
 
 def request_service():
     service_request_object = { "op" : "call_service",                           # op-code for rosbridge
@@ -36,14 +35,14 @@ def request_service():
     print("sending JSON-message to rosbridge:", service_request)
     sock.send(service_request)
 
-################################################################################
+# ##############################################################################
 
 
-####################### script begin ###########################################
+# ##################### script begin ###########################################
 # should not need to be changed (but could be improved ;) )                    #
-################################################################################
+# ##############################################################################
 try:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)                    #connect to rosbridge
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)                    # connect to rosbridge
     sock.settimeout(client_socket_timeout)
     sock.connect((rosbridge_ip, rosbridge_port))
 
@@ -54,7 +53,9 @@ try:
     done = False
     result = None
     reconstructed = None
-    while not done:     # should not need a loop (maximum wait can be set by client_socket_timeout), but since its for test/demonstration only .. leave it as it is for now
+    # should not need a loop (maximum wait can be set by client_socket_timeout),
+    # but since its for test/demonstration only .. leave it as it is for now
+    while not done:
         try:
             incoming = sock.recv(max_msg_length)                                # receive service_response from rosbridge
             if buffer == "":
@@ -73,7 +74,7 @@ try:
                     done = True
             except Exception:
                 #print "direct access to JSON failed.."
-                #print e
+                #print(e)
                 pass
             try:                                        
                 #print "defragmenting incoming messages"
@@ -87,7 +88,7 @@ try:
                     try:
                         result.append(json.loads(fragment))                     # try to parse json from string, and append if successful
                     except Exception:
-                        #print e
+                        #print(e)
                         #print result_string
                         raise                                                   # re-raise the last exception, allows to see and continue with processing of exception
 
@@ -106,10 +107,10 @@ try:
                         reconstructed = reconstructed + fragment["data"]
                     done = True
             except Exception:
-                #print e
+                #print(e)
                 pass
         except Exception:
-#            print e
+#            print(e)
             pass
 
 
@@ -118,10 +119,10 @@ try:
         print("response was None -> service was not available")
     else:
         print("received:")
-        print(returned_data["values"]["data"].decode('base64','strict'))         # decode values-field
+        print(returned_data["values"]["data"].decode('base64','strict'))        # decode values-field
     
 except Exception as e:
     print("ERROR - could not receive service_response")
     print(e)
 
-sock.close()                                                                    # close socket
+sock.close()

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_server_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_server_fragmented.py
@@ -6,9 +6,9 @@ from random import randint
 from rosbridge_library.util import json
 
 
-####################### variables begin ########################################
+# ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
-################################################################################
+# ##############################################################################
 
 tcp_socket_timeout = 10                          # seconds
 max_msg_length = 20000                           # bytes
@@ -20,17 +20,18 @@ service_type = "rosbridge_library/SendBytes"                       # make sure t
 service_name = "send_bytes"                      # service name
 
 send_fragment_size = 1000
-# delay between sends to rosbridge is not needed anymore, if using my version of protocol (uses buffer to collect data from stream)
-send_fragment_delay = 0.000#1
+# delay between sends to rosbridge is not needed anymore, if using my version of
+# protocol (uses buffer to collect data from stream)
+send_fragment_delay = 0.000  # 1
 receive_fragment_size = 10
 receive_message_intervall = 0.0
 
-####################### variables end ##########################################
+# ##################### variables end ##########################################
 
 
-####################### service_calculation begin ##############################
+# ##################### service_calculation begin ##############################
 # change this function to match whatever service should be provided            #
-################################################################################
+# ##############################################################################
 
 def calculate_service_response(request):
     request_object = json.loads(request)                                        # parse string for service request
@@ -56,18 +57,18 @@ def calculate_service_response(request):
     response_object = { "op": "service_response",
                         "id": request_object["id"],
                         "service": service_name,
-                        "values": service_response_data                           # put service response in "data"-field of response object (in this case it's twice "data", because response value is also named data (in srv-file)
+                        "values": service_response_data                         # put service response in "data"-field of response object (in this case it's twice "data", because response value is also named data (in srv-file)
                       }
     response_message = json.dumps(response_object)
     return response_message
 
-####################### service_calculation end ################################
+# ##################### service_calculation end ################################
 
 
 
-####################### helper functions / and variables begin #################
+# ##################### helper functions / and variables begin #################
 # should not need to be changed (but could be improved )                       #
-################################################################################
+# ##############################################################################
 
 buffer = ""
 
@@ -115,7 +116,7 @@ def wait_for_service_request():                                                 
                     return data                                                 # if parsing was successful --> return data string
             except Exception:
                 #print "direct_access error:"
-                #print e
+                #print(e)
                 pass
                
             #print "trying to defragment"
@@ -183,7 +184,7 @@ def list_of_fragments(full_message, fragment_size):                             
     fragmented_messages_list = []                                               # generate list of fragmented messages (including headers)
     if len(fragments) > 1:
         for count, fragment in enumerate(fragments):                            # iterate through list and have index counter
-            fragmented_message_object = {"op":"fragment",                       #   create python-object for each fragment message
+            fragmented_message_object = {"op":"fragment",                       # create Python-object for each fragment message
                                          "id": str(message_id),
                                          "data": str(fragment),
                                          "num": count,
@@ -195,12 +196,12 @@ def list_of_fragments(full_message, fragment_size):                             
         fragmented_messages_list.append(str(fragment))
     return fragmented_messages_list                                             # return list of 'ready-to-send' fragmented messages
 
-####################### helper functions end ###################################
+# ##################### helper functions end ###################################
 
 
-####################### script begin ###########################################
+# ##################### script begin ###########################################
 # should not need to be changed (but could be improved )                       #
-################################################################################
+# ##############################################################################
 
 tcp_socket = connect_tcp_socket()                                               # open tcp_socket
 advertise_service()                                                             # advertise service in ROS (via rosbridge)


### PR DESCRIPTION
Fixes two comment-related flake8 issues that formatters like [psf/black](https://github.com/psf/black) will not auto-fix.
```
8     E262 inline comment should start with '# '
42    E265 block comment should start with '# '
```