### PR TITLE
Miscellaneous fixes: flake8 --select=E402,E731,E741,F821

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       # See setup.cfg for the default settings for codespell and flake8
       - run: codespell
       - run: flake8
-      # Undefined names need to be fixed (#604) and the --exit-zero removed.
-      - run: flake8 --exit-zero --select=F82 --statistics
   test:
     strategy:
       fail-fast: false

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -232,7 +232,7 @@ def get_service_node(queried_type, services_glob, include_hidden=False):
 
 def get_service_host(service):
     """ Returns the name of the machine that is hosting the given service, or empty string """
-    uri = get_service_uri(service)
+    uri = get_service_uri(service)  # noqa: F821  # To be fixed in issue #604
     if uri is None:
         uri = ""
     else:

--- a/rosbridge_library/src/rosbridge_library/util/__init__.py
+++ b/rosbridge_library/src/rosbridge_library/util/__init__.py
@@ -1,4 +1,6 @@
-# try to import json-lib: 1st try ujson, 2nd try simplejson, else import standard python json
+# try to import json-lib: 1st try ujson, 2nd try simplejson, else import standard Python json
+from io import StringIO  # noqa: F401
+
 try:
     import ujson as json
 except ImportError:
@@ -6,9 +8,6 @@ except ImportError:
         import simplejson as json
     except ImportError:
         import json  # noqa: F401
-
-string_types = (str,)
-from io import StringIO  # noqa: F401
 
 import bson
 try:
@@ -19,3 +18,5 @@ except AttributeError:
         "Please use the MongoDB BSON implementation. "
         "See: https://github.com/RobotWebTools/rosbridge_suite/issues/198"
     )
+
+string_types = (str,)

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -227,7 +227,7 @@ class TestMessageConversion(unittest.TestCase):
             inst = ros_loader.get_message_instance(rostype)
             msg = c.extract_values(inst)
             self.do_test(msg, rostype)
-            l = loads(dumps(msg))
+            _ = loads(dumps(msg))
             inst2 = ros_loader.get_message_instance(rostype)
             c.populate_instance(msg, inst2)
             self.assertEqual(inst, inst2)

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -298,7 +298,7 @@ def main(args=None):
     spin_callback.start()
     start_hook()
 
-    node.destroy_node()
+    node.destroy_node()  # noqa: F821  # To be fixed in issue #604
     rclpy.shutdown()
     shutdown_hook()  # shutdown hook to stop the server
 

--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -13,7 +13,9 @@ class RosbridgeUdpFactory(DatagramProtocol):
         if endpoint in self.socks:
             self.socks[endpoint].datagramReceived(message)
         else:
-            writefunc = lambda msg: self.transport.write(msg, (host,port))
+            def writefunc(msg):
+                self.transport.write(msg, (host, port))
+
             self.socks[endpoint] = RosbridgeUdpSocket(writefunc)
             self.socks[endpoint].startProtocol()
             self.socks[endpoint].datagramReceived(message)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ ignore-words-list = miror
 count = True
 max-complexity = 36
 max-line-length = 228
-select = C,E5,E9,F63,F7
+select = C,E5,E9,F63,F7,F82
 show-source = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ ignore-words-list = miror
 count = True
 max-complexity = 36
 max-line-length = 228
-select = C,E5,E9,F63,F7,F82
+select = C,E402,E5,E731,E741,E9,F63,F7,F82
 show-source = True


### PR DESCRIPTION
Fix six miscellaneous flake8 issues that formatters like [psf/black](https://github.com/psf/black) will not auto-fix.
```
2     E402 module level import not at top of file
1     E731 do not assign a lambda expression, use a def
1     E741 ambiguous variable name 'l'
2     F821 undefined name 'get_service_uri'
```