### PR TITLE
Do not use bare 'except:': flake8 --select=E722

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -108,7 +108,7 @@ def _set_param(node_name, name, value, parameter_type=None):
     try:
         # call_get_parameters will fail if node does not exist.
         call_set_parameters(node=_node, node_name=node_name, parameters=[parameter])
-    except:
+    except Exception:
         pass
 
 
@@ -138,7 +138,7 @@ def get_param(node_name, name, default, params_glob):
             # if type is 0 (parameter not set), the next line will raise an exception
             # and return value shall go to default.
             value = getattr(pvalue, _parameter_type_mapping[pvalue.type])
-        except:
+        except Exception:
             # If either the node or the parameter does not exist, return default.
             value = default
 
@@ -160,7 +160,7 @@ def has_param(node_name, name, params_glob):
             response = call_get_parameters(
                 node=_node, node_name=node_name,
                 parameter_names=[name])
-        except:
+        except Exception:
             return False
 
     return response.values[0].type > 0 and response.values[0].type < len(_parameter_type_mapping)

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -242,16 +242,10 @@ def _to_inst(msg, rostype, roottype, inst=None, stack=[]):
 
 
 def _to_binary_inst(msg):
-    if type(msg) in string_types:
-        try:
-            return standard_b64decode(msg)
-        except :
-            return msg
-    else:
-        try:
-            return bytes(bytearray(msg))
-        except:
-            return msg
+    try:
+        return standard_b64decode(msg) if isinstance(msg, str) else bytes(bytearray(msg))
+    except Exception:
+        return msg
 
 
 def _to_time_inst(msg, rostype, inst=None):

--- a/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
@@ -153,12 +153,12 @@ class QueueMessageHandler(MessageHandler, Thread):
                 if self.alive and self.time_remaining() == 0 and len(self.queue) > 0:
                     try:
                         MessageHandler.handle_message(self, self.queue[0])
-                    except:
+                    except Exception:
                         pass
                     del self.queue[0]
         while self.time_remaining() == 0 and len(self.queue) > 0:
             try:
                 MessageHandler.handle_message(self, self.queue[0])
-            except:
+            except Exception:
                 pass
             del self.queue[0]

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -293,7 +293,7 @@ class Protocol:
                 return bson.BSON.encode(msg)
             else:    
                 return json.dumps(msg)
-        except:
+        except Exception:
             if cid is not None:
                 # Only bother sending the log message if there's an id
                 self.log("error", "Unable to serialize %s message to client"

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -56,11 +56,8 @@ class TestSubscribe(unittest.TestCase):
             self.assertEqual(subscription.queue_length, min_queue_length)
             self.assertEqual(subscription.fragment_size, min_frag_size)
             self.assertEqual(subscription.compression, "png")
-        except:
+        finally:
             subscription.unregister()
-            raise
-
-        subscription.unregister()
 
     def test_missing_arguments(self):
         proto = Protocol("test_missing_arguments")

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -73,11 +73,8 @@ class TestMessageHandlers(unittest.TestCase):
 
         try:
             self.assertEqual(["hello"] + list(range(990, 1000)), received["msgs"])
-        except:
+        finally:
             handler.finish()
-            raise
-
-        handler.finish()
 
     def test_queue_message_handler_rate(self):
         handler = subscribe.MessageHandler(None, self.dummy_cb)
@@ -207,7 +204,7 @@ class TestMessageHandlers(unittest.TestCase):
             for x in range(10):
                 self.assertEqual(x, received["msg"])
                 time.sleep(throttle_rate_sec)
-        except:
+        except:  # noqa: E722  # Will finish and raise
             handler.finish()
             raise
 

--- a/rosbridge_library/test/internal/test_services.py
+++ b/rosbridge_library/test/internal/test_services.py
@@ -52,7 +52,7 @@ class ServiceTester:
         gen = populate_random_args(gen)
         try:
             rsp = c.populate_instance(gen, rsp)
-        except:
+        except:  # noqa: E722  # Will print() and raise
             print("populating instance")
             print(rsp)
             print("populating with")

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -163,7 +163,7 @@ class RosbridgeWebSocket(WebSocketHandler):
             else:
                 _log_exception()
                 raise
-        except:
+        except:  # noqa: E722  # Will log and raise
             _log_exception()
             raise
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ ignore-words-list = miror
 count = True
 max-complexity = 36
 max-line-length = 228
-select = C,E262,E266,E402,E5,E722,E731,E741,E9,F63,F7,F82
+select = C,E262,E266,E4,E5,E7,E9,F4,F5,F6,F7,F81,F82,F83,F9,W1,W6
 show-source = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ ignore-words-list = miror
 count = True
 max-complexity = 36
 max-line-length = 228
-select = C,E402,E5,E731,E741,E9,F63,F7,F82
+select = C,E262,E266,E402,E5,E722,E731,E741,E9,F63,F7,F82
 show-source = True


### PR DESCRIPTION
Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on. Prefer `except Exception:`. If you’re sure what you’re doing, be explicit and write `except BaseException:`.

https://realpython.com/the-most-diabolical-python-antipattern/
https://www.python.org/dev/peps/pep-0008/