### PR TITLE
Fix unused variables: flake8 --select=F841

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
@@ -77,8 +77,6 @@ class Fragmentation(Capability):
         if message_length <= fragment_size:
             return [message]
 
-        # msg_id = message.get("id", None)  # Unused variable
-
         expected_duration = int(
             math.ceil(math.ceil(message_length / float(fragment_size)))
             * self.protocol.delay_between_messages

--- a/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
@@ -77,7 +77,7 @@ class Fragmentation(Capability):
         if message_length <= fragment_size:
             return [message]
 
-        msg_id = message.get("id", None)
+        # msg_id = message.get("id", None)  # Unused variable
 
         expected_duration = int(
             math.ceil(math.ceil(message_length / float(fragment_size)))

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -70,7 +70,7 @@ class TestCallService(unittest.TestCase):
 
     def test_call_service_fail(self):
         # Dummy service that instantly fails
-        service_server = rospy.Service("set_bool_fail", SetBool, lambda req: None)
+        _ = rospy.Service("set_bool_fail", SetBool, lambda req: None)
 
         proto = Protocol("test_call_service_fail")
         s = CallService(proto)

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
@@ -35,7 +35,7 @@ receive_message_intervall = 0.0
 
 def calculate_service_response(request):
     request_object = json.loads(request)  # parse string for service request
-    args = request_object["args"]  # get parameter field (args)
+    # args = request_object["args"]  # get parameter field (args)                   # unused variable
     #    count = int(args["count"] )                                                # get parameter(s) as described in corresponding ROS srv-file
     #
     #    message = ""                                                               # calculate service response

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -201,7 +201,7 @@ class RosbridgeWebsocketNode(Node):
         if "--unregister_timeout" in sys.argv:
             idx = sys.argv.index("--unregister_timeout") + 1
             if idx < len(sys.argv):
-                unregister_timeout = float(sys.argv[idx])
+                RosbridgeWebSocket.unregister_timeout = float(sys.argv[idx])
             else:
                 print("--unregister_timeout argument provided without a value.")
                 sys.exit(-1)

--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -1,6 +1,5 @@
 import rospy
 from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
-from rosbridge_library.util import bson
 from twisted.internet.protocol import DatagramProtocol
 
 
@@ -70,7 +69,6 @@ class RosbridgeUdpSocket:
         rospy.loginfo("Client disconnected. %d clients total.", cls.clients_connected)
 
     def send_message(self, message):
-        # binary = isinstance(message, bson.BSON)  # Unused variable
         self.write(message)
 
     def check_origin(self, origin):

--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -70,7 +70,7 @@ class RosbridgeUdpSocket:
         rospy.loginfo("Client disconnected. %d clients total.", cls.clients_connected)
 
     def send_message(self, message):
-        binary = isinstance(message, bson.BSON)
+        # binary = isinstance(message, bson.BSON)  # Unused variable
         self.write(message)
 
     def check_origin(self, origin):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ ignore-words-list = miror
 count = True
 max-complexity = 36
 max-line-length = 217
-ignore = E203,F841,W503
+ignore = E203,W503
 show-source = True
 statistics = True
 


### PR DESCRIPTION
Fix ~five of the~ six flake8 issues related to variables that are assigned to but then not used.
```
6     F841 local variable 'msg_id' is assigned to but never used
```

~This PR does not fix the following issue where the `--unregister_timeout` command line option should probably be removed,~  NOTE: Fixed in second commit.
```
./rosbridge_server/scripts/rosbridge_websocket.py:194:17: F841 local variable 'unregister_timeout' is assigned to but never used
                unregister_timeout = float(sys.argv[idx])
                ^
```