### PR TITLE
Switch from ament_cmake_nose to ament_cmake_pytest

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -56,6 +56,6 @@ install(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_nose REQUIRED)
-  ament_add_nose_test(${PROJECT_NAME}_test_stringify_field_types test/test_stringify_field_types.py)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(${PROJECT_NAME}_test_stringify_field_types test/test_stringify_field_types.py)
 endif()

--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -38,7 +38,7 @@
   -->
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>shape_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>


### PR DESCRIPTION
Due to https://github.com/nose-devs/nose/issues/1083, the XML output of nose is incompatible with the ROS build farm. Switching to pytest should resolve the issue. Thanks for the tip @cottsay!