### PR TITLE
Add pre-commit for bandit, codespell, and flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,17 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  lint:
+  pre-commit:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - run: pip install bandit codespell flake8
-      - run: bandit --recursive --skip B101,B110,B311 .
-      # See setup.cfg for the default settings for codespell and flake8
-      - run: codespell
-      - run: flake8
+      - run: pip install pre-commit
+      - run: pre-commit --version
+      - run: pre-commit install
+      - run: pre-commit run  # --all-files
   test:
     strategy:
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+default_language_version:
+  python: python3.8
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
+  # submodules: true
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+
+  - repo: https://github.com/PyCQA/bandit/
+    rev: 1.7.0
+    hooks:
+      - id: bandit
+        args:
+          - --recursive
+          - --skip
+          - B101,B110,B311
+          - .
+
+  #- repo: https://github.com/psf/black
+  #  rev: 21.7b0
+  #  hooks:
+  #    - id: black
+
+  # See setup.cfg for the default settings for codespell
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+
+  # See setup.cfg for the default settings for flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+
+  #- repo: https://github.com/PyCQA/isort
+  #  rev: 5.9.3
+  #  hooks:
+  #    - id: isort
+  #      args:
+  #        - --profile
+  #        - black


### PR DESCRIPTION
As discussed at https://github.com/RobotWebTools/rosbridge_suite/pull/629#issuecomment-903066649 add https://pre-commit.com for our fastest lint steps (bandit, codespell, flake8, and soon black and isort) to run locally in the git commit process and also in `.github/workflows/ci.yml`.

* [ ] Land this PR.
* [ ] Land the black/isort PR (after #623) and un-comment those tasks.
* [ ] ~Enable precommit.ci for this repo (autofixing) and then remove from ci.yml.~