### PR TITLE
Fixed subscriber "leak" when clients disconnect

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -214,11 +214,12 @@ class SubscriberManager():
 
         """
         with self._lock:
-            self._subscribers[topic].unsubscribe(client_id)
+            if topic in self._subscribers:
+                self._subscribers[topic].unsubscribe(client_id)
 
-            if not self._subscribers[topic].has_subscribers():
-                self._subscribers[topic].unregister()
-                del self._subscribers[topic]
+                if not self._subscribers[topic].has_subscribers():
+                    self._subscribers[topic].unregister()
+                    del self._subscribers[topic]
 
 
 manager = SubscriberManager()


### PR DESCRIPTION
Fixes #580.

Check for existence of topic key in subscribers before using it when unsubscribing subscribers when a client disconnects.
If the key doesn't exist, this fix stops the KeyError exception from propagating out of the unsubscribe loop which leave subscribers connected after clients have disconnected.

