### PR TITLE
Fix message conversion

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -91,7 +91,7 @@ ros_primitive_types = [
     "string",
 ]
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
-ros_binary_types = ["uint8[]", "char[]"]
+ros_binary_types = ["uint8[]", "char[]", "sequence<uint8>", "sequence<char>"]
 list_tokens = re.compile("<(.+?)>")
 bounded_array_tokens = re.compile(r"(.+)\[.*\]")
 ros_binary_types_list_braces = [
@@ -327,7 +327,7 @@ def _to_primitive_inst(msg, rostype, roottype, stack):
         msg = float(msg)
 
     # Convert to byte
-    if rostype == 'octet' and isinstance(msg, int):
+    if rostype == "octet" and isinstance(msg, int):
         return bytes([msg])
 
     msgtype = type(msg)

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -288,10 +288,11 @@ def _to_inst(msg, rostype, roottype, inst=None, stack=[]):
 
 
 def _to_binary_inst(msg):
-    try:
-        return standard_b64decode(msg) if isinstance(msg, str) else bytes(bytearray(msg))
-    except Exception:
+    if isinstance(msg, str):
+        return list(standard_b64decode(msg))
+    if isinstance(msg, list):
         return msg
+    return bytes(bytearray(msg))
 
 
 def _to_time_inst(msg, rostype, inst=None):

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -52,7 +52,7 @@ type_map = {
     "bool": ["bool", "boolean"],
     "int": [
         "int8",
-        "byte",
+        "octet",
         "uint8",
         "char",
         "int16",
@@ -74,7 +74,7 @@ ros_time_types = ["builtin_interfaces/Time", "builtin_interfaces/Duration"]
 ros_primitive_types = [
     "bool",
     "boolean",
-    "byte",
+    "octet",
     "char",
     "int8",
     "uint8",

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -214,6 +214,11 @@ def _from_inst(inst, rostype):
         if (not bson_only_mode) and (rostype in type_map.get("float")):
             if math.isnan(inst) or math.isinf(inst):
                 return None
+
+        # JSON does not support byte array. They are converted to int
+        if (not bson_only_mode) and (rostype == "octet"):
+            return int.from_bytes(inst, "little")
+
         return inst
 
     # Check if it's a list or tuple

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -326,6 +326,10 @@ def _to_primitive_inst(msg, rostype, roottype, stack):
         # fix that by casting the int to the expected float
         msg = float(msg)
 
+    # Convert to byte
+    if rostype == 'octet' and isinstance(msg, int):
+        return bytes([msg])
+
     msgtype = type(msg)
     if msgtype in primitive_types and rostype in type_map[msgtype.__name__]:
         return msg

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -240,7 +240,6 @@ class TestMessageConversion(unittest.TestCase):
             c.populate_instance(msg, inst2)
             self.assertEqual(inst, inst2)
 
-    @unittest.skip
     def test_int8array(self):
         def test_int8_msg(rostype, data):
             msg = {"data": data}

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -78,7 +78,6 @@ class TestMessageConversion(unittest.TestCase):
                 self.assertEqual(c._to_primitive_inst(msg, rostype, rostype, []), msg)
                 self.assertEqual(c._to_inst(msg, rostype, rostype), msg)
 
-    @unittest.skip
     def test_byte_primitives(self):
         # Test raw primitives
         for msg in range(0, 200):
@@ -172,7 +171,6 @@ class TestMessageConversion(unittest.TestCase):
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/UInt16")
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/UInt32")
 
-    @unittest.skip
     def test_byte_base_msg(self):
         int8s = range(0, 256)
         for int8 in int8s:

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -188,17 +188,15 @@ class TestMessageConversion(unittest.TestCase):
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Time")
 
-        # TODO: enable this test
-        # msg = {"times": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
-        # self.do_test(msg, "rosbridge_test_msgs/TestTimeArray")
+        msg = {"times": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
+        self.do_test(msg, "rosbridge_test_msgs/TestTimeArray")
 
     def test_duration_msg(self):
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Duration")
 
-        # TODO: enable this test
-        # msg = {"durations": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
-        # self.do_test(msg, "rosbridge_test_msgs/TestDurationArray")
+        msg = {"durations": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
+        self.do_test(msg, "rosbridge_test_msgs/TestDurationArray")
 
     def test_header_msg(self):
         msg = {


### PR DESCRIPTION
**Public Changes**
<!-- Describe any changes to the public API, or write "None" -->

None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Fixed message_conversion.py to pass the tests that I fixed in #645.

```sh-session
$ colcon test --event-handlers console_cohesion+ --packages-select rosbridge_library
Starting >>> rosbridge_library
--- output: rosbridge_library                   
UpdateCTestConfiguration  from :/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/CTestConfiguration.ini
Parse Config file:/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/CTestConfiguration.ini
   Site: desktop
   Build name: (empty)
 Add coverage exclude regular expressions.
SetCTestConfiguration:CMakeCommand:/usr/bin/cmake
Create new tag: 20210924-1506 - Experimental
UpdateCTestConfiguration  from :/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/CTestConfiguration.ini
Parse Config file:/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/CTestConfiguration.ini
Test project /home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_message_conversion

1: Test command: /usr/bin/python3 "-u" "/opt/ros/galactic/share/ament_cmake_test/cmake/run_test.py" "/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/test_results/rosbridge_library/test_message_conversion.xunit.xml" "--package-name" "rosbridge_library" "--output-file" "/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/ament_cmake_pytest/test_message_conversion.txt" "--command" "/usr/bin/python3" "-u" "-m" "pytest" "/home/kenji/ghq/github.com/tier4/rosbridge_suite/rosbridge_library/test/internal/test_message_conversion.py" "-o" "cache_dir=/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/ament_cmake_pytest/test_message_conversion/.cache" "--junit-xml=/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/test_results/rosbridge_library/test_message_conversion.xunit.xml" "--junit-prefix=rosbridge_library"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library':
1:  - /usr/bin/python3 -u -m pytest /home/kenji/ghq/github.com/tier4/rosbridge_suite/rosbridge_library/test/internal/test_message_conversion.py -o cache_dir=/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/ament_cmake_pytest/test_message_conversion/.cache --junit-xml=/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/test_results/rosbridge_library/test_message_conversion.xunit.xml --junit-prefix=rosbridge_library
1: ============================= test session starts ==============================
1: platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
1: cachedir: build/rosbridge_library/ament_cmake_pytest/test_message_conversion/.cache
1: rootdir: /home/kenji/ghq/github.com/tier4/rosbridge_suite
1: plugins: ament-lint-0.10.6, ament-pep257-0.10.6, launch-testing-0.17.0, ament-copyright-0.10.6, ament-xmllint-0.10.6, launch-testing-ros-0.14.2, ament-flake8-0.10.6, cov-2.12.1, asyncio-0.15.1, rerunfailures-10.1, repeat-0.9.1, dash-2.0.0, mock-1.10.4, colcon-core-0.6.1
1: collected 15 items
1: 
1: ../../rosbridge_library/test/internal/test_message_conversion.py ....... [ 46%]
1: ........                                                                 [100%]
1: 
1: - generated xml file: /home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/test_results/rosbridge_library/test_message_conversion.xunit.xml -
1: ============================== 15 passed in 0.58s ==============================
1: -- run_test.py: return code 0
1: -- run_test.py: verify result file '/home/kenji/ghq/github.com/tier4/rosbridge_suite/build/rosbridge_library/test_results/rosbridge_library/test_message_conversion.xunit.xml'
1/1 Test #1: test_message_conversion ..........   Passed    1.39 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
pytest    =   1.39 sec*proc (1 test)

Total Test time (real) =   1.39 sec
---
Finished <<< rosbridge_library [1.46s]

Summary: 1 package finished [1.59s]
```

<!-- Link relevant GitHub issues -->

Related: #643, #645

**How to test**

Before(upstream/ros2)

```sh-session
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1632497492.739524112] [rosbridge_websocket]: [Client 0] [id: publish:/byte:3] publish: example_interfaces/Byte message requires a octet for field data, but got a <class 'int'>
[ERROR 1632497493.727461853] [rosbridge_websocket]: [Client 0] [id: publish:/byte:4] publish: example_interfaces/Byte message requires a octet for field data, but got a <class 'int'>

$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/byte.py | python
publish: {'data': 1}
publish: {'data': 1}
```

After(this PR)

```sh-session
$ ros2 run rosbridge_server rosbridge_websocket

$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/byte.py | python
publish: {'data': 1}
subscribe: {'data': 1}
publish: {'data': 1}
subscribe: {'data': 1}
```

There are other tests as well.
```sh-session
curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/diag.py | python
curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/int8_array.py | python
curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/int8_fixed_array.py | python
```

I'm not sure what is the correct form in sending array data(base64 encoded or JSON array). :thinking: 