### PR TITLE
Remove get_service_instance from ros_loader

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -101,13 +101,6 @@ def get_message_instance(typestring):
     return cls()
 
 
-def get_service_instance(typestring):
-    """If not loaded, loads the specified type.
-    Then returns an instance of it, or None."""
-    cls = get_service_class(typestring)
-    return cls()
-
-
 def get_service_request_instance(typestring):
     cls = get_service_class(typestring)
     return cls.Request()


### PR DESCRIPTION
**Public Changes**
<!-- Describe any changes to the public API, or write "None" -->

None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Since services can't be instantiated in ROS2, I removed the function.
I've noticed this in #644.

<!-- Link relevant GitHub issues -->

Related: #644

**How to test**
ROS1
```sh-session
$ echo $ROS_DISTRO
noetic

$ python -c "from std_srvs.srv import Trigger; print(Trigger())"
<std_srvs.srv._Trigger.Trigger object at 0x7f42024894c0>
```

ROS2
```sh-session
$ echo $ROS_DISTRO
galactic

$ python -c "from std_srvs.srv import Trigger; print(Trigger())"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/ros/galactic/lib/python3.8/site-packages/std_srvs/srv/_trigger.py", line 278, in __init__
    raise NotImplementedError('Service classes can not be instantiated')
NotImplementedError: Service classes can not be instantiated
```