### PR TITLE
Run CI on official ROS docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
           python-version: '3.8'
       - run: pip install bandit codespell flake8
       - run: bandit --recursive --skip B101,B110,B311 .
-      # See setup.cfg for the default settings for codespell and flake8
       - run: codespell
       - run: flake8
+
   test:
     strategy:
       fail-fast: false
@@ -22,23 +22,31 @@ jobs:
         include:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
-          - ros_distribution: foxy
-            os: ubuntu-20.04
-          - ros_distribution: galactic
-            os: ubuntu-20.04
+          - ros: foxy
+            ubuntu: focal
+          - ros: galactic
+            ubuntu: focal
 
-    name: ROS 2 ${{ matrix.ros_distribution }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: ROS 2 ${{ matrix.ros }} (${{ matrix.ubuntu }})
+    runs-on: ubuntu-20.04
+    container:
+      image: ros:${{ matrix.ros }}-ros-base-${{ matrix.ubuntu }}
 
     steps:
       - uses: actions/checkout@v2
         with:
           path: ros_ws/src
 
-      - uses: ros-tooling/setup-ros@v0.2
-        with:
-          required-ros-distributions: ${{ matrix.ros_distribution }}
+      # Install bare minimum dependencies to run ros-tooling/action-ros-ci
+      # All build and test dependencies should live in package.xml files
+      - name: Install CI dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            lcov \
+            python3-colcon-coveragepy-result \
+            python3-colcon-lcov-result
 
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: ${{ matrix.ros_distribution }}
+          target-ros2-distro: ${{ matrix.ros }}


### PR DESCRIPTION
**Public Changes**
None

**Description**
Replace existing CI setup based on `ros-tooling/setup-ros`. CI now runs inside the [official ROS docker image](https://hub.docker.com/_/ros).

This makes CI run in about half the time (3 minutes faster). Unfortunately, it does not solve https://github.com/RobotWebTools/rosbridge_suite/issues/640, because both ros-base (minimal distribution) and ros-core (even more minimal distribution with no dev tools) both still install packages like `sensor_msgs` by default.

An alternative approach would be to keep `ros-tooling/setup-ros` but remove `required-ros-distributions`. This does correctly fail some of the issues described in https://github.com/RobotWebTools/rosbridge_suite/issues/640 (it catches the missing `test_depend` but not the missing `buildtool_depend`). This approach is slightly faster (shaves ~1 minute off CI).

I'm not sure what other options we have here to replicate the failures seen on the ROS build farm. I think this PR is worth landing since it significantly speeds up CI. But maybe the alternative approach is safer (though slower?).

cc @jtbandes for thoughts