### PR TITLE
CI: Remove required-ros-distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
           python-version: '3.8'
       - run: pip install bandit codespell flake8
       - run: bandit --recursive --skip B101,B110,B311 .
-      # See setup.cfg for the default settings for codespell and flake8
       - run: codespell
       - run: flake8
+
   test:
     strategy:
       fail-fast: false
@@ -22,12 +22,12 @@ jobs:
         include:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
-          - ros_distribution: foxy
+          - ros: foxy
             os: ubuntu-20.04
-          - ros_distribution: galactic
+          - ros: galactic
             os: ubuntu-20.04
 
-    name: ROS 2 ${{ matrix.ros_distribution }} (${{ matrix.os }})
+    name: ROS 2 ${{ matrix.ros }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -36,9 +36,7 @@ jobs:
           path: ros_ws/src
 
       - uses: ros-tooling/setup-ros@v0.2
-        with:
-          required-ros-distributions: ${{ matrix.ros_distribution }}
 
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: ${{ matrix.ros_distribution }}
+          target-ros2-distro: ${{ matrix.ros }}


### PR DESCRIPTION
**Public Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Alternative to https://github.com/RobotWebTools/rosbridge_suite/pull/649.

Remove `required-ros-distributions` from the `ros-tooling/setup-ros` action, since it installs ros-desktop which is unnecessary and actually detrimental to complete testing. Having ros packages pre-installed means we don't catch missing dependencies in package.xml files.

Also shaves 1-2 minutes off CI time.

Closes https://github.com/RobotWebTools/rosbridge_suite/issues/640
Closes https://github.com/RobotWebTools/rosbridge_suite/issues/649