### PR TITLE
Remove unused service_host and search_param services

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -24,8 +24,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/Nodes.srv
   srv/NodeDetails.srv
   srv/Publishers.srv
-  srv/SearchParam.srv
-  srv/ServiceHost.srv
   srv/ServiceNode.srv
   srv/ServiceProviders.srv
   srv/ServiceRequestDetails.srv

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -50,8 +50,6 @@ from rosapi.srv import (
     NodeDetails,
     Nodes,
     Publishers,
-    SearchParam,
-    ServiceHost,
     ServiceNode,
     ServiceProviders,
     ServiceRequestDetails,
@@ -127,10 +125,6 @@ class Rosapi(Node):
         self.create_service(DeleteParam, "/rosapi/delete_param", self.delete_param)
         self.create_service(GetParamNames, "/rosapi/get_param_names", self.get_param_names)
         self.create_service(GetTime, "/rosapi/get_time", self.get_time)
-
-        # TODO(@jubeira): Implement missing services:
-        # rospy.Service('/rosapi/service_host', ServiceHost, get_service_host)
-        # rospy.Service('/rosapi/search_param', SearchParam, search_param)
 
     def get_globs(self):
         return glob_helper.get_globs(self)
@@ -295,20 +289,6 @@ class Rosapi(Node):
         self.get_logger().warn(
             "Malformed parameter name: {}; expecting <node_name>:<param_name>".format(param_name)
         )
-
-
-# TODO(@jubeira): make all of these methods of the node and port them.
-
-# Note(@jubeira): there is no equivalent for this in ROS2 so far. The service doesn't seem to e used anywhere in rosbridge.
-def get_service_host(request):
-    """Called by the rosapi/ServiceNode service.  Given the name of a service, returns the name of the machine
-    that is hosting that service."""
-    return ServiceHost(proxy.get_service_host(request.service))
-
-
-# Note(@jubeira): rclpy does not have an equivalent for this. To be checked if this service is necessary or not.
-def search_param(request):
-    return SearchParam(params.search_param(request.name, glob_helper.params))
 
 
 def dict_to_typedef(typedefdict):

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -236,14 +236,3 @@ def _get_param_names(node_name):
         return [f"{node_name}:{param_name}" for param_name in response.result.names]
     else:
         return []
-
-
-# TODO(@jubeira): functions to be ported below.
-def search_param(name, params_glob):
-    if params_glob and not any(fnmatch.fnmatch(str(name), glob) for glob in params_glob):
-        # If the glob list is not empty and there are no glob matches,
-        # stop the attempt to find the parameter.
-        return None
-    # If the glob list is empty (i.e. false) or the parameter matches
-    # one of the glob strings, continue to find the parameter.
-    return rospy.search_param(name)  # noqa: F821 as discussed in #608

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -258,14 +258,3 @@ def get_service_node(queried_type, services_glob, include_hidden=False):
         return node_name[0]
     else:
         return ""
-
-
-def get_service_host(service):
-    """Returns the name of the machine that is hosting the given service, or empty string"""
-    uri = get_service_uri(service)  # noqa: F821  # To be fixed in issue #604
-    if uri is None:
-        uri = ""
-    else:
-        uri = uri[9:]
-        uri = uri[: uri.find(":")]
-    return uri

--- a/rosapi/srv/SearchParam.srv
+++ b/rosapi/srv/SearchParam.srv
@@ -1,3 +1,0 @@
-string name
----
-string global_name

--- a/rosapi/srv/ServiceHost.srv
+++ b/rosapi/srv/ServiceHost.srv
@@ -1,3 +1,0 @@
-string service
----
-string host


### PR DESCRIPTION
**Public API Changes**
Removed `search_param` and `service_host` from rosapi, which were not published as services, and would never have worked in ros 2 since they reference rospy (ros 1).

Also removed associated `.srv` files.

Fixes https://github.com/RobotWebTools/rosbridge_suite/issues/604 (cc @cclauss)