### PR TITLE
Port #464, #478, #496, and #502 from `ros1` branch

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -84,7 +84,7 @@ class Subscription:
         """Unsubscribes this subscription and cleans up resources"""
         manager.unsubscribe(self.client_id, self.topic)
         with self.handler_lock:
-            self.handler.finish()
+            self.handler.finish(block=False)
         self.clients.clear()
 
     def subscribe(

--- a/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
@@ -30,6 +30,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import sys
+import traceback
+from collections import deque
 from threading import Condition, Thread
 from time import time
 
@@ -77,7 +80,7 @@ class MessageHandler:
         else:
             return QueueMessageHandler(self)
 
-    def finish(self):
+    def finish(self, block=True):
         pass
 
 
@@ -94,7 +97,7 @@ class ThrottleMessageHandler(MessageHandler):
         else:
             return QueueMessageHandler(self)
 
-    def finish(self):
+    def finish(self, block=True):
         pass
 
 
@@ -103,17 +106,17 @@ class QueueMessageHandler(MessageHandler, Thread):
         Thread.__init__(self)
         MessageHandler.__init__(self, previous_handler)
         self.daemon = True
-        self.queue = []
+        self.queue = deque(maxlen=self.queue_length)
         self.c = Condition()
         self.alive = True
         self.start()
 
     def handle_message(self, msg):
         with self.c:
+            if not self.alive:
+                return
             should_notify = len(self.queue) == 0
             self.queue.append(msg)
-            if len(self.queue) > self.queue_length:
-                del self.queue[0 : len(self.queue) - self.queue_length]
             if should_notify:
                 self.c.notify()
 
@@ -126,37 +129,40 @@ class QueueMessageHandler(MessageHandler, Thread):
             return ThrottleMessageHandler(self)
         else:
             with self.c:
-                if len(self.queue) > self.queue_length:
-                    del self.queue[0 : len(self.queue) - self.queue_length]
+                old_queue = self.queue
+                self.queue = deque(maxlen=self.queue_length)
+                while len(old_queue) > 0:
+                    self.queue.append(old_queue.popleft())
                 self.c.notify()
             return self
 
-    def finish(self):
+    def finish(self, block=True):
         """If throttle was set to 0, this pushes all buffered messages"""
         # Notify the thread to finish
         with self.c:
             self.alive = False
             self.c.notify()
 
-        self.join()
+        if block:
+            self.join()
 
     def run(self):
         while self.alive:
+            msg = None
             with self.c:
-                while self.alive and (self.time_remaining() > 0 or len(self.queue) == 0):
-                    if len(self.queue) == 0:
-                        self.c.wait()
-                    else:
-                        self.c.wait(self.time_remaining())
+                if len(self.queue) == 0:
+                    self.c.wait()
+                else:
+                    self.c.wait(self.time_remaining())
                 if self.alive and self.time_remaining() == 0 and len(self.queue) > 0:
-                    try:
-                        MessageHandler.handle_message(self, self.queue[0])
-                    except Exception:
-                        pass
-                    del self.queue[0]
+                    msg = self.queue.popleft()
+            if msg is not None:
+                try:
+                    MessageHandler.handle_message(self, msg)
+                except Exception:
+                    traceback.print_exc(file=sys.stderr)
         while self.time_remaining() == 0 and len(self.queue) > 0:
             try:
                 MessageHandler.handle_message(self, self.queue[0])
             except Exception:
-                pass
-            del self.queue[0]
+                traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

* Synchronize `SubscriberManager` methods with a `threading.Lock`
* Add `block` parameter to `MessageHandler.finish()` method with default value of `True`
  * Use this parameter to allow `QueueMessageHandler.finish()` to run without blocking
* Add `IncomingQueue` class to `websocket_handler.py` to decouple incoming messages from the IOLoop thread

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Earlier this year I ran into some of the issues described in https://github.com/RobotWebTools/rosbridge_suite/issues/425 where the rosbridge server would end up deadlocked or blocked. I was able to solve the problem by porting several PRs from the `ros1` branch (which was `develop` at the time) to my working branch.

* https://github.com/RobotWebTools/rosbridge_suite/pull/464
* https://github.com/RobotWebTools/rosbridge_suite/pull/478
* https://github.com/RobotWebTools/rosbridge_suite/pull/496
* https://github.com/RobotWebTools/rosbridge_suite/pull/502

I recently rebased my working branch to a newer upstream version and after testing confirmed that these fixes are still needed for my application. I thought I would open a PR and see if there was any interest in getting these features into the main ROS2 branch. All credit to the original PR authors; I simply ported the changes over from the ROS1 branch to ROS2.