### PR TITLE
Exit cleanly on SIGINT; remove sleep in test

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -309,7 +309,10 @@ def main(args=None):
 
     rclpy.init(args=args)
     node = Rosapi()
-    rclpy.spin(node)
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        node.get_logger().info("Exiting due to SIGINT")
 
     node.destroy_node()
     rclpy.shutdown()

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -315,7 +315,10 @@ def main(args=None):
 
     spin_callback = PeriodicCallback(lambda: rclpy.spin_once(node, timeout_sec=0.01), 1)
     spin_callback.start()
-    start_hook()
+    try:
+        start_hook()
+    except KeyboardInterrupt:
+        node.get_logger().info("Exiting due to SIGINT")
 
     node.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
The rosbridge_websocket and rosapi nodes now exit cleanly on ctrl-C. This makes the smoke test run faster when combined with some more targeted awaits in place of a sleep.