### PR TITLE
Fix incoming service calls

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -32,7 +32,6 @@
 
 from threading import Thread
 
-from rclpy import spin_until_future_complete
 from rclpy.expand_topic_name import expand_topic_name
 from rosbridge_library.internal.message_conversion import (
     extract_values,
@@ -123,12 +122,11 @@ def call_service(node_handle, service, args=None):
 
     client = node_handle.create_client(service_class, service)
 
-    future = client.call_async(inst)
-    spin_until_future_complete(node_handle, future)
-    if future.result() is not None:
+    result = client.call(inst)
+    if result is not None:
         # Turn the response into JSON and pass to the callback
-        json_response = extract_values(future.result())
+        json_response = extract_values(result)
     else:
-        raise Exception(future.exception())
+        raise Exception(result)
 
     return json_response

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -29,6 +29,7 @@ install(FILES
 
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)
-  add_launch_test(test/websocket/smoke.test.py)
   add_launch_test(test/websocket/advertise_service.test.py)
+  add_launch_test(test/websocket/call_service.test.py)
+  add_launch_test(test/websocket/smoke.test.py)
 endif()

--- a/rosbridge_server/test/websocket/call_service.test.py
+++ b/rosbridge_server/test/websocket/call_service.test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+import os
+import sys
+import unittest
+
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+from twisted.python import log
+
+sys.path.append(os.path.dirname(__file__))  # enable importing from common.py in this directory
+
+import common  # noqa: E402
+from common import expect_messages, websocket_test  # noqa: E402
+
+log.startLogging(sys.stderr)
+
+generate_test_description = common.generate_test_description
+
+
+class TestCallService(unittest.TestCase):
+    @websocket_test
+    async def test_one_call(self, node: Node, ws_client):
+        def service_cb(req, res):
+            self.assertTrue(req.data)
+            res.success = True
+            res.message = "Hello, world!"
+            return res
+
+        service = node.create_service(SetBool, "/test_service", service_cb)
+
+        responses_future, ws_client.message_handler = expect_messages(
+            1, "WebSocket", node.get_logger()
+        )
+        responses_future.add_done_callback(lambda _: node.executor.wake())
+
+        ws_client.sendJson(
+            {
+                "op": "call_service",
+                "type": "std_srvs/SetBool",
+                "service": "/test_service",
+                "args": {"data": True},
+            }
+        )
+
+        responses = await responses_future
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0]["op"], "service_response")
+        self.assertEqual(responses[0]["service"], "/test_service")
+        self.assertEqual(responses[0]["values"], {"success": True, "message": "Hello, world!"})
+        self.assertEqual(responses[0]["result"], True)
+
+        node.destroy_service(service)


### PR DESCRIPTION
**Public API Changes**
N/A

**Description**
Not to be confused with #650 (although possibly related?).

After porting the `IncomingQueue` class from the ROS1 branch in #663, I discovered that incoming service calls from rosbridge clients were no longer working. The rosbridge server would receive the service call and run until this line in the `call_service()` function where it would get stuck:

https://github.com/RobotWebTools/rosbridge_suite/blob/181e039890ce6bf366d98dfed2828c716b3b974d/rosbridge_library/src/rosbridge_library/internal/services.py#L127

On the client side the connection would sit open ("pending" according to the Chrome debugger) waiting for a response that would never arrive.

After doing some digging I believe the problem is that we are now attempting to call `rclpy.spin_until_future_complete()` on a background thread instead of the main thread. I'm not super familiar with the details, but doing some quick research seems to indicate that at least historically trying to call `spin()` from multiple threads can cause problems. For example:

* https://answers.ros.org/question/339827/ros2-rclcpp-eloquent-spin_until_future_complete-in-an-already-spinning-node/
* https://github.com/ros2/rclpy/issues/585
* https://answers.ros.org/question/342302/ros2-rclpy-call-a-service-from-inside-a-service/

(These links are not directly related to the issue at hand but are semi-related problems I've seen regarding spinning and multiple threads.)

Since this code is running in the `IncomingQueue` thread instead of the main thread, it should be safe to use a synchronous service call here without blocking the main event loop. Making this change fixed the service calls and the client received responses again.

One question I have is if we are going to switch back to a synchronous service call, do we want to run it in the `IncomingQueue` thread? Or do we want to create a new thread for each service call so that the `IncomingQueue` is not blocked? The `ServiceCaller` class inherits from `threading.Thread` and historically under the ROS1 branch it looks like it was run with `.start()` instead of `.run()` like it is now.

Perhaps someone with a better understanding of Tornado and the event loop and threads used in rosbridge has a better idea of how this situation could be handled without adding more threads?