### PR TITLE
Add support for the "id" field in subscribe.

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -151,7 +151,7 @@ class Subscription():
     def _publish(self, message):
         """ Internal method to propagate published messages to the registered
         publish callback """
-        self.publish(message, self.fragment_size, self.compression)
+        self.publish(message, self.fragment_size, self.compression, self.clients.keys())
 
     def on_msg(self, msg):
         """ Raw callback called by subscription manager for all incoming
@@ -290,7 +290,7 @@ class Subscribe(Capability):
 
         self.protocol.log("info", "Unsubscribed from %s" % topic)
 
-    def publish(self, topic, message, fragment_size=None, compression="none"):
+    def publish(self, topic, message, fragment_size=None, compression="none", ids=list()):
         """ Publish a message to the client
 
         Keyword arguments:
@@ -339,7 +339,12 @@ class Subscribe(Capability):
         else:
             outgoing_msg["msg"] = message.get_json_values()
 
-        self.protocol.send(outgoing_msg)
+        for id in ids:
+            if id:
+                outgoing_msg[u"id"] = id
+            elif u"id" in outgoing_msg:
+                del outgoing_msg[u"id"]
+            self.protocol.send(outgoing_msg)
 
     def finish(self):
         for subscription in self._subscriptions.values():

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -115,6 +115,109 @@ class TestSubscribe(unittest.TestCase):
         time.sleep(0.25)
         self.assertEqual(received["msg"]["msg"]["data"], msg.data)
 
+    def test_subscribe_ids(self):
+        """ Test that when an ID is given at subscription time, messages are passed on with the given ID.
+        It implies that when multiple subscrptions are done on the same topic but with different IDs the
+        related messages should be all independently passed on with their own ID.
+        To make the test more complete, we add one subscription with no ID and make sure that the messages
+        get also passed on, with no "id" field.
+        """
+        import uuid
+        ids = [str(uuid.uuid4()) for i in range(10)]
+        ids.append(None) # testing for missing ID
+
+        def subscription_func(make_subscription):
+            for id in ids:
+                make_subscription(id)
+
+        def test(source_message, outgoing_messages):
+            for message in outgoing_messages:
+                self.assertEqual(message["msg"]["data"], source_message.data)
+                if "id" not in message:
+                    message["id"] = None # testing for missing ID
+                self.assertIn(message["id"], ids)
+                ids.remove(message["id"])
+            self.assertFalse(ids, "The id list is not empty, which means that some"
+                                "of the subscribers did not get a message.")
+        
+        def unsubscription_func(make_unsubscription):
+            pass
+        
+        self.subscription_test("subscribe_ids", subscription_func, unsubscription_func, test)
+    
+    def test_subscribe_unsubscribe_ids(self):
+        """ This test ensures that unsubscriptions with IDs are properly handled.
+        Namely, multiple subscriptions are done on a same topic but with different IDs. Should one of the subscription
+        be cancelled, the others shall not be affected and the messages shall still be passed on with their respective
+        IDs.
+        """
+        import uuid
+        ids = [str(uuid.uuid4()) for i in range(2)]
+
+        def subscription_func(make_subscription):
+            for id in ids:
+                make_subscription(id)
+        
+        def unsubscription_func(make_unsubscription):
+            make_unsubscription(ids[0])
+
+        def test(source_message, outgoing_messages):
+            self.assertEqual(len(outgoing_messages), 1, "Only one message must have been forwarded, as one out of two"
+                                                        "subscriptions has been cancelled.")
+            message = outgoing_messages[0]
+            self.assertEqual(message["msg"]["data"], source_message.data)
+            self.assertEqual(message["id"], ids[1])
+        
+        self.subscription_test("subscribe_ids", subscription_func, unsubscription_func, test)
+
+    def subscription_test(self, test_name, subscription_func, unsubscription_func, test):
+        """ Helper function used for the two above tests.
+        It gathers all their boilerplate code.
+        """
+        proto = Protocol(test_name)
+        topic = f"/{test_name}_works"
+        
+        # Tricks to capture messages on the subscribed topic
+        outgoing_messages = list()
+        from copy import deepcopy
+        def send(outgoing):
+            outgoing_messages.append(deepcopy(outgoing))
+        proto.send = send
+
+        # Prepare subscriptions
+        sub = subscribe.Subscribe(proto)
+        def make_subscription(id=None):
+            msg_type = "std_msgs/String"
+            msg = {"op": "subscribe", "topic": topic, "type": msg_type}
+            if id is not None:
+                msg["id"] = id
+            sub.subscribe(loads(dumps(msg)))
+
+        def make_unsubscription(id=None):
+            msg = {"op": "unsubscribe", "topic": topic}
+            if id is not None:
+                msg["id"] = id
+            sub.unsubscribe(loads(dumps(msg)))
+
+        # Make subscriptions
+        subscription_func(make_subscription)
+
+        # Make unsubscriptions
+        unsubscription_func(make_unsubscription)
+
+        # Publish a message on the same topic in ROS (through the bridge)
+        msg = String()
+        msg.data = "test that {test_name} works"
+        p = rospy.Publisher(topic, String, queue_size=5)
+        time.sleep(0.25)
+        p.publish(msg)
+
+        # Test the values
+        time.sleep(2.5) # Let the messages propagate to and from ROS.
+
+        test(msg, outgoing_messages)
+        
+
 
 PKG = 'rosbridge_library'
 NAME = 'test_subscribe'

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -175,7 +175,7 @@ class TestSubscribe(unittest.TestCase):
         It gathers all their boilerplate code.
         """
         proto = Protocol(test_name)
-        topic = f"/{test_name}_works"
+        topic = "/" + test_name + "_works"
         
         # Tricks to capture messages on the subscribed topic
         outgoing_messages = list()
@@ -207,7 +207,7 @@ class TestSubscribe(unittest.TestCase):
 
         # Publish a message on the same topic in ROS (through the bridge)
         msg = String()
-        msg.data = "test that {test_name} works"
+        msg.data = "test that " + test_name + " works"
         p = rospy.Publisher(topic, String, queue_size=5)
         time.sleep(0.25)
         p.publish(msg)


### PR DESCRIPTION
**Public API Changes**

Implement the protocol's documentation regarding the use of the optional "id" field for the "subscribe" and "unsubscribe" operations.

**Description**

For the "subscribe" and "unsubscribe" operations, the "id" field is now
taken into account. This means that when it is provided, the subsequent
"publish" operations, from the bridge to the client, will carry the "id"
field with the same value.

Also, if multiple subscriptions are done on the same topic with
different values for "id", the related messages are sent as many times
as there are subscriptions with different "id" values.

If one uses the "unsubscribe" operation on a topic without the "id"
field, all subscriptions to that topic are closed.

** Related Issue **

#673 