### PR TITLE
Refactor smoke test to make WebSocket test harness reusable

### DIFF
--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -1,0 +1,152 @@
+import functools
+import json
+from typing import Any, Awaitable, Callable
+
+import launch
+import launch_ros
+import rclpy
+import rclpy.task
+from autobahn.twisted.websocket import WebSocketClientFactory, WebSocketClientProtocol
+from rcl_interfaces.srv import GetParameters
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from twisted.internet import reactor
+from twisted.internet.endpoints import TCP4ClientEndpoint
+
+
+class TestClientProtocol(WebSocketClientProtocol):
+    """
+    Set message_handler to handle messages received from the server.
+    """
+
+    message_handler: Callable[[Any], None]
+
+    def __init__(self, *args, **kwargs):
+        self.received = []
+        self.connected_future = rclpy.task.Future()
+        self.message_handler = lambda _: None
+        super().__init__(*args, **kwargs)
+
+    def onOpen(self):
+        self.connected_future.set_result(None)
+
+    def sendJson(self, msg_dict, *, times=1):
+        msg = json.dumps(msg_dict).encode("utf-8")
+        for _ in range(times):
+            print(f"WebSocket client sent message: {msg}")
+            self.sendMessage(msg)
+
+    def onMessage(self, payload, binary):
+        print(f"WebSocket client received message: {payload}")
+        self.message_handler(json.loads(payload))
+
+
+def generate_test_description(ready_fn) -> launch.LaunchDescription:
+    """
+    Generate a launch description that runs the websocket server. Re-export this from a test file and use add_launch_test() to run the test.
+    """
+    try:
+        node = launch_ros.actions.Node(
+            executable="rosbridge_websocket",
+            package="rosbridge_server",
+            parameters=[{"port": 0}],
+        )
+    except TypeError:
+        # Deprecated keyword arg node_executable: https://github.com/ros2/launch_ros/pull/140
+        node = launch_ros.actions.Node(
+            node_executable="rosbridge_websocket",
+            package="rosbridge_server",
+            parameters=[{"port": 0}],
+        )
+
+    return launch.LaunchDescription(
+        [
+            node,
+            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+        ]
+    )
+
+
+async def get_server_port(node: Node) -> int:
+    """
+    Returns the port which the WebSocket server is running on
+    """
+    client = node.create_client(GetParameters, "/rosbridge_websocket/get_parameters")
+    try:
+        if not client.wait_for_service(5):
+            raise RuntimeError("GetParameters service not available")
+        port_param = await client.call_async(GetParameters.Request(names=["actual_port"]))
+        return port_param.values[0].integer_value
+    finally:
+        node.destroy_client(client)
+
+
+async def connect_to_server(node: Node) -> TestClientProtocol:
+    port = await get_server_port(node)
+    factory = WebSocketClientFactory("ws://127.0.0.1:" + str(port))
+    factory.protocol = TestClientProtocol
+
+    future = rclpy.task.Future()
+    future.add_done_callback(lambda _: node.executor.wake())
+
+    def connect():
+        TCP4ClientEndpoint(reactor, "127.0.0.1", port).connect(factory).addCallback(
+            future.set_result
+        )
+
+    reactor.callFromThread(connect)
+
+    protocol = await future
+    protocol.connected_future.add_done_callback(lambda _: node.executor.wake())
+    await protocol.connected_future  # wait for onOpen before proceeding
+    return protocol
+
+
+def run_websocket_test(
+    node_name: str, test_fn: Callable[[Node, TestClientProtocol], Awaitable[None]]
+):
+    context = rclpy.Context()
+    rclpy.init(context=context)
+    executor = SingleThreadedExecutor(context=context)
+    node = rclpy.create_node(node_name, context=context)
+    executor.add_node(node)
+
+    async def task():
+        ws_client = await connect_to_server(node)
+        await test_fn(node, ws_client)
+        reactor.callFromThread(reactor.stop)
+
+    future = executor.create_task(task)
+
+    reactor.callInThread(rclpy.spin_until_future_complete, node, future, executor)
+    reactor.run(installSignalHandlers=False)
+
+    rclpy.shutdown(context=context)
+    node.destroy_node()
+
+
+def sleep(node: Node, duration: float) -> Awaitable[None]:
+    """
+    Async-compatible delay function based on a ROS timer.
+    """
+    future = rclpy.task.Future()
+
+    def callback():
+        future.set_result(None)
+        timer.cancel()
+        node.destroy_timer(timer)
+
+    timer = node.create_timer(duration, callback)
+    return future
+
+
+def websocket_test(test_fn):
+    """
+    Decorator for tests which use a ROS node and WebSocket server and client
+    """
+
+    @functools.wraps(test_fn)
+    def run_test(self):
+        run_websocket_test(test_fn.__name__, lambda *args: test_fn(self, *args))
+
+    return run_test

--- a/rosbridge_server/test/websocket/smoke.test.py
+++ b/rosbridge_server/test/websocket/smoke.test.py
@@ -37,6 +37,7 @@ class TestWebsocketSmoke(unittest.TestCase):
         ws_completed_future = rclpy.task.Future()
 
         def sub_handler(msg):
+            node.get_logger().info(f"Received message via ROS subscriber: {msg}")
             ros_received.append(msg)
             if len(ros_received) == NUM_MSGS:
                 node.get_logger().info("Received all messages on ROS subscriber")
@@ -49,7 +50,7 @@ class TestWebsocketSmoke(unittest.TestCase):
         def ws_handler(msg):
             ws_received.append(msg)
             if len(ws_received) == NUM_MSGS:
-                node.get_logger().info("Received all messages on ROS subscriber")
+                node.get_logger().info("Received all WebSocket messages")
                 ws_completed_future.set_result(None)
             elif len(ws_received) > NUM_MSGS:
                 raise AssertionError(
@@ -75,6 +76,9 @@ class TestWebsocketSmoke(unittest.TestCase):
                 "type": "std_msgs/String",
             }
         )
+
+        await sleep(node, WARMUP_DELAY)
+
         ws_client.sendJson(
             {
                 "op": "publish",
@@ -85,8 +89,6 @@ class TestWebsocketSmoke(unittest.TestCase):
             },
             times=NUM_MSGS,
         )
-
-        await sleep(node, WARMUP_DELAY)
 
         for _ in range(NUM_MSGS):
             pub_b.publish(String(data=B_STRING))

--- a/rosbridge_server/test/websocket/smoke.test.py
+++ b/rosbridge_server/test/websocket/smoke.test.py
@@ -1,215 +1,101 @@
 #!/usr/bin/env python
-import json
+import os
 import sys
 import unittest
 
-import launch
-import launch.actions
-import launch_ros
-import launch_ros.actions
 import rclpy
 import rclpy.task
-from autobahn.twisted.websocket import WebSocketClientFactory, WebSocketClientProtocol
-from rcl_interfaces.srv import GetParameters
-from rclpy.executors import SingleThreadedExecutor
 from std_msgs.msg import String
-from twisted.internet import reactor
-from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.python import log
+
+sys.path.append(os.path.dirname(__file__))  # enable importing from common.py in this directory
+
+import common  # noqa: E402
+from common import sleep, websocket_test  # noqa: E402
 
 log.startLogging(sys.stderr)
 
-# For consistency, the number of messages must not exceed the the protocol
-# Subscriber queue_size.
-NUM_MSGS = 10
-MSG_SIZE = 10
-A_TOPIC = "/a_topic"
-B_TOPIC = "/b_topic"
-A_STRING = "A" * MSG_SIZE
-B_STRING = "B" * MSG_SIZE
-WARMUP_DELAY = 1.0  # seconds
-TIME_LIMIT = 5.0  # seconds
-
-
-def generate_test_description(ready_fn):
-    try:
-        node = launch_ros.actions.Node(
-            executable="rosbridge_websocket",
-            package="rosbridge_server",
-            parameters=[{"port": 0}],
-        )
-    except TypeError:
-        # Deprecated keyword arg node_executable: https://github.com/ros2/launch_ros/pull/140
-        node = launch_ros.actions.Node(
-            node_executable="rosbridge_websocket",
-            package="rosbridge_server",
-            parameters=[{"port": 0}],
-        )
-
-    return launch.LaunchDescription(
-        [
-            node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
-        ]
-    )
-
-
-class TestClientProtocol(WebSocketClientProtocol):
-    def __init__(self, *args, **kwargs):
-        self.received = []
-        self.connected_future = rclpy.task.Future()
-        self.completed_future = rclpy.task.Future()
-        super().__init__(*args, **kwargs)
-
-    def onOpen(self):
-        self.connected_future.set_result(None)
-
-    def sendDict(self, msg_dict, times=1):
-        msg = json.dumps(msg_dict).encode("utf-8")
-        for _ in range(times):
-            print(f"WebSocket client sent message: {msg}")
-            self.sendMessage(msg)
-
-    def onMessage(self, payload, binary):
-        print(f"WebSocket client received message: {payload}")
-        self.received.append(payload)
-        if len(self.received) == NUM_MSGS:
-            print("Received all messages on WebSocket subscriber")
-            self.completed_future.set_result(None)
-        elif len(self.received) > NUM_MSGS:
-            raise AssertionError(
-                f"Received {len(self.received)} WebSocket messages but expected {NUM_MSGS}"
-            )
+generate_test_description = common.generate_test_description
 
 
 class TestWebsocketSmoke(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        rclpy.init()
+    @websocket_test
+    async def test_smoke(self, node, ws_client):
+        # For consistency, the number of messages must not exceed the the protocol
+        # Subscriber queue_size.
+        NUM_MSGS = 10
+        MSG_SIZE = 10
+        A_TOPIC = "/a_topic"
+        B_TOPIC = "/b_topic"
+        A_STRING = "A" * MSG_SIZE
+        B_STRING = "B" * MSG_SIZE
+        WARMUP_DELAY = 1.0  # seconds
 
-    @classmethod
-    def tearDownClass(cls):
-        rclpy.shutdown()
-
-    def setUp(self):
-        self.executor = SingleThreadedExecutor()
-        self.node = rclpy.create_node("websocket_smoke_test")
-        self.executor.add_node(self.node)
-
-    def tearDown(self):
-        self.node.destroy_node()
-
-    async def get_server_port(self):
-        """
-        Returns the port which the WebSocket server is running on
-        """
-        client = self.node.create_client(GetParameters, "/rosbridge_websocket/get_parameters")
-        try:
-            if not client.wait_for_service(5):
-                raise RuntimeError("GetParameters service not available")
-            port_param = await client.call_async(GetParameters.Request(names=["actual_port"]))
-            return port_param.values[0].integer_value
-        finally:
-            self.node.destroy_client(client)
-
-    async def connect_to_server(self):
-        port = await self.get_server_port()
-        factory = WebSocketClientFactory("ws://127.0.0.1:" + str(port))
-        factory.protocol = TestClientProtocol
-
-        future = rclpy.task.Future()
-        future.add_done_callback(lambda _: self.executor.wake())
-
-        def connect():
-            TCP4ClientEndpoint(reactor, "127.0.0.1", port).connect(factory).addCallback(
-                future.set_result
-            )
-
-        reactor.callFromThread(connect)
-
-        protocol = await future
-        protocol.connected_future.add_done_callback(lambda _: self.executor.wake())
-        await protocol.connected_future  # wait for onOpen before proceeding
-        return protocol
-
-    def sleep(self, duration):
-        future = rclpy.task.Future()
-
-        def callback():
-            future.set_result(None)
-            timer.cancel()
-            self.node.destroy_timer(timer)
-
-        timer = self.node.create_timer(duration, callback)
-        return future
-
-    def test_smoke(self):
         ros_received = []
+        ws_received = []
         sub_completed_future = rclpy.task.Future()
+        ws_completed_future = rclpy.task.Future()
 
         def sub_handler(msg):
             ros_received.append(msg)
             if len(ros_received) == NUM_MSGS:
-                self.node.get_logger().info("Received all messages on ROS subscriber")
+                node.get_logger().info("Received all messages on ROS subscriber")
                 sub_completed_future.set_result(None)
             elif len(ros_received) > NUM_MSGS:
                 raise AssertionError(
                     f"Received {len(ros_received)} messages on ROS subscriber but expected {NUM_MSGS}"
                 )
 
-        sub_a = self.node.create_subscription(String, A_TOPIC, sub_handler, NUM_MSGS)
-        pub_b = self.node.create_publisher(String, B_TOPIC, NUM_MSGS)
+        def ws_handler(msg):
+            ws_received.append(msg)
+            if len(ws_received) == NUM_MSGS:
+                node.get_logger().info("Received all messages on ROS subscriber")
+                ws_completed_future.set_result(None)
+            elif len(ws_received) > NUM_MSGS:
+                raise AssertionError(
+                    f"Received {len(ws_received)} WebSocket messages but expected {NUM_MSGS}"
+                )
 
-        async def run_test():
-            print("Connecting to server...")
-            ws_client = await self.connect_to_server()
-            print("Connected!")
+        ws_client.message_handler = ws_handler
+        sub_a = node.create_subscription(String, A_TOPIC, sub_handler, NUM_MSGS)
+        pub_b = node.create_publisher(String, B_TOPIC, NUM_MSGS)
 
-            ws_client.sendDict(
-                {
-                    "op": "subscribe",
-                    "topic": B_TOPIC,
-                    "type": "std_msgs/String",
-                    "queue_length": 0,  # Test the roslib default.
-                }
-            )
-            ws_client.sendDict(
-                {
-                    "op": "advertise",
-                    "topic": A_TOPIC,
-                    "type": "std_msgs/String",
-                }
-            )
-            ws_client.sendDict(
-                {
-                    "op": "publish",
-                    "topic": A_TOPIC,
-                    "msg": {
-                        "data": A_STRING,
-                    },
+        ws_client.sendJson(
+            {
+                "op": "subscribe",
+                "topic": B_TOPIC,
+                "type": "std_msgs/String",
+                "queue_length": 0,  # Test the roslib default.
+            }
+        )
+        ws_client.sendJson(
+            {
+                "op": "advertise",
+                "topic": A_TOPIC,
+                "type": "std_msgs/String",
+            }
+        )
+        ws_client.sendJson(
+            {
+                "op": "publish",
+                "topic": A_TOPIC,
+                "msg": {
+                    "data": A_STRING,
                 },
-                NUM_MSGS,
-            )
+            },
+            times=NUM_MSGS,
+        )
 
-            await self.sleep(WARMUP_DELAY)
+        await sleep(node, WARMUP_DELAY)
 
-            for _ in range(NUM_MSGS):
-                pub_b.publish(String(data=B_STRING))
+        for _ in range(NUM_MSGS):
+            pub_b.publish(String(data=B_STRING))
 
-            ws_client.completed_future.add_done_callback(lambda _: self.executor.wake())
-            await sub_completed_future
-            await ws_client.completed_future
+        ws_completed_future.add_done_callback(lambda _: node.executor.wake())
+        await sub_completed_future
+        await ws_completed_future
 
-            reactor.callFromThread(reactor.stop)
-            return ws_client.received
-
-        future = self.executor.create_task(run_test)
-        reactor.callInThread(rclpy.spin_until_future_complete, self.node, future, self.executor)
-        reactor.run(installSignalHandlers=False)
-
-        ws_received = future.result()
-        for received in ws_received:
-            msg = json.loads(received)
+        for msg in ws_received:
             self.assertEqual("publish", msg["op"])
             self.assertEqual(B_TOPIC, msg["topic"])
             self.assertEqual(B_STRING, msg["msg"]["data"])
@@ -219,5 +105,5 @@ class TestWebsocketSmoke(unittest.TestCase):
             self.assertEqual(A_STRING, msg.data)
         self.assertEqual(NUM_MSGS, len(ros_received))
 
-        self.node.destroy_subscription(sub_a)
-        self.node.destroy_publisher(pub_b)
+        node.destroy_subscription(sub_a)
+        node.destroy_publisher(pub_b)


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Factor out the ROS and Twisted setup code from the smoke test, so we can reuse it for other tests in the future.