### PR TITLE
Fix ROS1 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,7 @@ jobs:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
       - uses: ros-tooling/action-ros-ci@v0.2
+        env:
+          SETUPTOOLS_USE_DISTUTILS: stdlib
         with:
           target-ros1-distro: ${{ matrix.ros_distribution }}

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -50,6 +50,7 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-bson</exec_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
   <test_depend>actionlib_msgs</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
   <test_depend>nav_msgs</test_depend>

--- a/rosbridge_library/test/capabilities/test_advertise.py
+++ b/rosbridge_library/test/capabilities/test_advertise.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 from time import sleep
 
@@ -141,5 +141,5 @@ class TestAdvertise(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestAdvertise)
+    rosunit.unitrun(PKG, NAME, TestAdvertise)
 

--- a/rosbridge_library/test/capabilities/test_advertise.py
+++ b/rosbridge_library/test/capabilities/test_advertise.py
@@ -16,10 +16,15 @@ from rosbridge_library.internal import ros_loader
 from json import loads, dumps
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_advertise'
+
+
 class TestAdvertise(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_advertise")
+        rospy.init_node(NAME)
+
         manager.unregister_timeout = 1.0
 
     def is_topic_published(self, topicname):
@@ -135,8 +140,6 @@ class TestAdvertise(unittest.TestCase):
         self.assertFalse(self.is_topic_published(topic))
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_advertise'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestAdvertise)
 

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -16,10 +16,14 @@ from rosbridge_library.protocol import Protocol
 from rosbridge_library.protocol import InvalidArgumentException, MissingArgumentException
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_call_service'
+
+
 class TestCallService(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_call_service")
+        rospy.init_node(NAME)
 
     def test_missing_arguments(self):
         proto = Protocol("test_missing_arguments")
@@ -98,8 +102,6 @@ class TestCallService(unittest.TestCase):
         self.assertFalse(received["msg"]["result"])
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_call_service'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestCallService)
 

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 import time
 
@@ -103,5 +103,5 @@ class TestCallService(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestCallService)
+    rosunit.unitrun(PKG, NAME, TestCallService)
 

--- a/rosbridge_library/test/capabilities/test_publish.py
+++ b/rosbridge_library/test/capabilities/test_publish.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 from time import sleep
 
@@ -62,5 +62,5 @@ class TestPublish(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestPublish)
+    rosunit.unitrun(PKG, NAME, TestPublish)
 

--- a/rosbridge_library/test/capabilities/test_publish.py
+++ b/rosbridge_library/test/capabilities/test_publish.py
@@ -16,10 +16,14 @@ from std_msgs.msg import String
 from json import dumps, loads
 
 
-class TestAdvertise(unittest.TestCase):
+PKG = 'rosbridge_library'
+NAME = 'test_publish'
+
+
+class TestPublish(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_advertise")
+        rospy.init_node(NAME)
 
     def test_missing_arguments(self):
         proto = Protocol("hello")
@@ -57,8 +61,6 @@ class TestAdvertise(unittest.TestCase):
         self.assertEqual(received["msg"].data, msg["data"])
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_publish'
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestAdvertise)
+    rostest.unitrun(PKG, NAME, TestPublish)
 

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -13,8 +13,15 @@ from rosbridge_library.protocol import Protocol
 from rosbridge_library.protocol import InvalidArgumentException, MissingArgumentException
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_service_capabilities'
+
+
 class TestServiceCapabilities(unittest.TestCase):
+
     def setUp(self):
+        rospy.init_node(NAME)
+
         self.proto = Protocol(self._testMethodName)
         # change the log function so we can verify errors are logged
         self.proto.log = self.mock_log
@@ -177,8 +184,5 @@ class TestServiceCapabilities(unittest.TestCase):
         self.assertFalse(self.received_message["result"])
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_service_capabilities'
 if __name__ == '__main__':
-    rospy.init_node(NAME)
-    rostest.rosrun(PKG, NAME, TestServiceCapabilities)
+    rostest.unitrun(PKG, NAME, TestServiceCapabilities)

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from json import loads, dumps
@@ -185,4 +185,4 @@ class TestServiceCapabilities(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestServiceCapabilities)
+    rosunit.unitrun(PKG, NAME, TestServiceCapabilities)

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 import time
 
@@ -121,5 +121,5 @@ class TestSubscribe(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestSubscribe)
+    rosunit.unitrun(PKG, NAME, TestSubscribe)
 

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -13,10 +13,14 @@ from rosbridge_library.protocol import Protocol
 from rosbridge_library.protocol import InvalidArgumentException, MissingArgumentException
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_subscribe'
+
+
 class TestSubscribe(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_subscribe")
+        rospy.init_node(NAME)
 
     def dummy_cb(self, msg):
         pass
@@ -116,8 +120,6 @@ class TestSubscribe(unittest.TestCase):
         self.assertEqual(received["msg"]["msg"]["data"], msg.data)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_subscribe'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestSubscribe)
 

--- a/rosbridge_library/test/internal/publishers/test_multi_publisher.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_publisher.py
@@ -13,10 +13,14 @@ from rosbridge_library.internal.message_conversion import *
 from std_msgs.msg import String, Int32
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_multi_publisher'
+
+
 class TestMultiPublisher(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_multi_publisher")
+        rospy.init_node(NAME)
 
     def is_topic_published(self, topicname):
         return topicname in dict(rospy.get_published_topics()).keys()
@@ -117,8 +121,6 @@ class TestMultiPublisher(unittest.TestCase):
         self.assertRaises(FieldTypeMismatchException, p.publish, msg)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_multi_publisher'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestMultiPublisher)
 

--- a/rosbridge_library/test/internal/publishers/test_multi_publisher.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_publisher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from time import sleep, time
@@ -122,5 +122,5 @@ class TestMultiPublisher(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestMultiPublisher)
+    rosunit.unitrun(PKG, NAME, TestMultiPublisher)
 

--- a/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
@@ -17,7 +17,7 @@ NAME = 'test_multi_unregistering'
 class TestMultiUnregistering(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node(NAME)
+        rospy.init_node(NAME, log_level=rospy.DEBUG)
 
     def test_publish_once(self):
         """ Make sure that publishing works """
@@ -51,21 +51,28 @@ class TestMultiUnregistering(unittest.TestCase):
 
         rospy.Subscriber(topic, ros_loader.get_message_class(msg_type), cb)
         p = MultiPublisher(topic, msg_type)
+        rospy.logerr("Publish 1")
         p.publish(msg)
 
         sleep(1)  # Time to publish and receive
 
         self.assertEqual(received["msg"].data, msg["data"])
 
+        rospy.logerr("Unregister 1")
         p.unregister()
+        rospy.logerr("Sleep 5 start")
         sleep(5)  # Time to unregister
+        rospy.logerr("Sleep 5 end")
 
         received["msg"] = None  # Reset received
         self.assertIsNone(received["msg"])
         p = MultiPublisher(topic, msg_type)
+        rospy.logerr("Publish 2")
         p.publish(msg)
 
+        rospy.logerr("Sleep 1 start")
         sleep(1)   # Time to publish and receive
+        rospy.logerr("Sleep 1 end")
 
         self.assertEqual(received["msg"].data, msg["data"])
 

--- a/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from time import sleep, time
@@ -88,4 +88,4 @@ class TestMultiUnregistering(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestMultiUnregistering)
+    rosunit.unitrun(PKG, NAME, TestMultiUnregistering)

--- a/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
@@ -13,10 +13,14 @@ from rosbridge_library.internal.message_conversion import *
 from std_msgs.msg import String, Int32
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_multi_unregistering'
+
+
 class TestMultiUnregistering(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_multi_unregistering")
+        rospy.init_node(NAME)
 
     def test_publish_once(self):
         """ Make sure that publishing works """
@@ -83,7 +87,5 @@ class TestMultiUnregistering(unittest.TestCase):
         self.assertEqual(received["msg"].data, msg["data"])
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_multi_unregistering'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestMultiUnregistering)

--- a/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
@@ -53,28 +53,21 @@ class TestMultiUnregistering(unittest.TestCase):
 
         rospy.Subscriber(topic, ros_loader.get_message_class(msg_type), cb)
         p = MultiPublisher(topic, msg_type)
-        rospy.logerr("Publish 1")
         p.publish(msg)
 
         sleep(1)  # Time to publish and receive
 
         self.assertEqual(received["msg"].data, msg["data"])
 
-        rospy.logerr("Unregister 1")
         p.unregister()
-        rospy.logerr("Sleep 5 start")
         sleep(5)  # Time to unregister
-        rospy.logerr("Sleep 5 end")
 
         received["msg"] = None  # Reset received
         self.assertIsNone(received["msg"])
         p = MultiPublisher(topic, msg_type)
-        rospy.logerr("Publish 2")
         p.publish(msg)
 
-        rospy.logerr("Sleep 1 start")
         sleep(1)   # Time to publish and receive
-        rospy.logerr("Sleep 1 end")
 
         self.assertEqual(received["msg"].data, msg["data"])
 

--- a/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import rospy
 import rosunit
 import unittest
@@ -38,6 +39,7 @@ class TestMultiUnregistering(unittest.TestCase):
 
         self.assertEqual(received["msg"].data, msg["data"])
 
+    @unittest.skipIf(os.environ.get("ROS_DISTRO", "") == "melodic", "Don't run new test on melodic")
     def test_publish_twice(self):
         """ Make sure that publishing works """
         topic = "/test_publish_twice"
@@ -74,6 +76,53 @@ class TestMultiUnregistering(unittest.TestCase):
         sleep(1)   # Time to publish and receive
         rospy.logerr("Sleep 1 end")
 
+        self.assertEqual(received["msg"].data, msg["data"])
+
+    @unittest.skipUnless(os.environ.get("ROS_DISTRO", "") == "melodic", "Run old test only on melodic")
+    def test_publish_twice_old(self):
+        """ Make sure that publishing works """
+        topic = "/test_publish_twice"
+        msg_type = "std_msgs/String"
+        msg = {"data": "why halo thar"}
+
+        received = {"msg": None}
+        def cb(msg):
+            received["msg"] = msg
+
+        rospy.Subscriber(topic, ros_loader.get_message_class(msg_type), cb)
+        p = MultiPublisher(topic, msg_type)
+        p.publish(msg)
+
+        sleep(1)
+
+        self.assertEqual(received["msg"].data, msg["data"])
+
+        p.unregister()
+        # The publisher went away at time T. Here's the timeline of the events:
+        # T+1 seconds - the subscriber will retry to reconnect - fail
+        # T+3 seconds - the subscriber will retry to reconnect - fail
+        # T+5 seconds - publish msg -> it's gone
+        # T+7 seconds - the subscriber will retry to reconnect - success
+        # T+8 seconds - publish msg -> OK
+        # T+11 seconds - we receive the message. Looks like a bug in reconnection...
+        #                https://github.com/ros/ros_comm/blob/indigo-devel/clients/rospy/src/rospy/impl/tcpros_base.py#L733
+        #                That line should probably be indented.
+        sleep(5)
+
+        received["msg"] = None
+        self.assertIsNone(received["msg"])
+        p = MultiPublisher(topic, msg_type)
+        p.publish(msg)
+
+        self.assertIsNone(received["msg"])
+
+        sleep(3)
+        p.publish(msg)
+        sleep(2)
+        # Next two lines should be removed when this is fixed:
+        # https://github.com/ros/ros_comm/blob/indigo-devel/clients/rospy/src/rospy/impl/tcpros_base.py#L733
+        self.assertIsNone(received["msg"])
+        sleep(3)
         self.assertEqual(received["msg"].data, msg["data"])
 
 

--- a/rosbridge_library/test/internal/publishers/test_publisher_consistency_listener.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_consistency_listener.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from time import sleep, time
@@ -175,5 +175,5 @@ class TestPublisherConsistencyListener(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestPublisherConsistencyListener)
+    rosunit.unitrun(PKG, NAME, TestPublisherConsistencyListener)
 

--- a/rosbridge_library/test/internal/publishers/test_publisher_consistency_listener.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_consistency_listener.py
@@ -13,10 +13,14 @@ from rosbridge_library.internal.message_conversion import *
 from std_msgs.msg import String, Int32
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_publisher_consistency_listener'
+
+
 class TestPublisherConsistencyListener(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_publisher_consistency_listener")
+        rospy.init_node(NAME)
 
     def test_listener_timeout(self):
         """ See whether the listener can correctly time out """
@@ -170,8 +174,6 @@ class TestPublisherConsistencyListener(unittest.TestCase):
         self.assertEqual(received["msgs"], msgs)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_publisher_consistency_listener'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestPublisherConsistencyListener)
 

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from time import sleep
@@ -216,5 +216,5 @@ class TestPublisherManager(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestPublisherManager)
+    rosunit.unitrun(PKG, NAME, TestPublisherManager)
 

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -12,10 +12,15 @@ from rosbridge_library.internal.message_conversion import FieldTypeMismatchExcep
 from std_msgs.msg import String, Int32
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_publisher_manager'
+
+
 class TestPublisherManager(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_publisher_manager")
+        rospy.init_node(NAME)
+
         manager.unregister_timeout = 1.0
 
     def is_topic_published(self, topicname):
@@ -210,8 +215,6 @@ class TestPublisherManager(unittest.TestCase):
         self.assertRaises(FieldTypeMismatchException, manager.publish, client, topic, msg)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_publisher_manager'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestPublisherManager)
 

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 from rosgraph import Master
 
@@ -186,5 +186,5 @@ class TestMultiSubscriber(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestMultiSubscriber)
+    rosunit.unitrun(PKG, NAME, TestMultiSubscriber)
 

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -14,10 +14,14 @@ from rosbridge_library.internal.message_conversion import *
 from std_msgs.msg import String, Int32
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_multi_subscriber'
+
+
 class TestMultiSubscriber(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_multi_subscriber")
+        rospy.init_node(NAME)
 
     def is_topic_published(self, topicname):
         return topicname in dict(rospy.get_published_topics()).keys()
@@ -181,8 +185,6 @@ class TestMultiSubscriber(unittest.TestCase):
         self.assertEqual(msg.data, received["msg2"]["data"])
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_multi_subscriber'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestMultiSubscriber)
 

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -13,10 +13,14 @@ from rosbridge_library.internal.message_conversion import FieldTypeMismatchExcep
 from std_msgs.msg import String, Int32
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_subscriber_manager'
+
+
 class TestSubscriberManager(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_subscriber_manager")
+        rospy.init_node(NAME)
 
     def is_topic_published(self, topicname):
         return topicname in dict(rospy.get_published_topics()).keys()
@@ -184,8 +188,6 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertEqual(msg.data, received["msg"]["data"])
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_subscriber_manager'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestSubscriberManager)
 

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 from rosgraph import Master
 
@@ -189,5 +189,5 @@ class TestSubscriberManager(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestSubscriberManager)
+    rosunit.unitrun(PKG, NAME, TestSubscriberManager)
 

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 import time
 
@@ -378,4 +378,4 @@ class TestMessageHandlers(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestMessageHandlers)
+    rosunit.unitrun(PKG, NAME, TestMessageHandlers)

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -8,10 +8,14 @@ import time
 from rosbridge_library.internal import subscription_modifiers as subscribe
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_message_handlers'
+
+
 class TestMessageHandlers(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_message_handlers")
+        rospy.init_node(NAME)
 
     def dummy_cb(self, msg):
         pass
@@ -373,7 +377,5 @@ class TestMessageHandlers(unittest.TestCase):
 #        handler = self.help_test_throttle(handler, 50)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_message_handlers'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestMessageHandlers)

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import rostest
+import rosunit
 import sys
 import unittest
 
@@ -159,4 +159,4 @@ class TestCBORConversion(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestCBORConversion)
+    rosunit.unitrun(PKG, NAME, TestCBORConversion)

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -29,6 +29,10 @@ from std_msgs.msg import (
 )
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_cbor_conversion'
+
+
 class TestCBORConversion(unittest.TestCase):
     def test_string(self):
         msg = String(data="foo")
@@ -154,7 +158,5 @@ class TestCBORConversion(unittest.TestCase):
                 self.assertEqual(type(key), str)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_cbor_conversion'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestCBORConversion)

--- a/rosbridge_library/test/internal/test_compression.py
+++ b/rosbridge_library/test/internal/test_compression.py
@@ -7,10 +7,14 @@ import unittest
 from rosbridge_library.internal import pngcompression
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_compression'
+
+
 class TestCompression(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_compression")
+        rospy.init_node(NAME)
 
     def test_compress(self):
         bytes = list(range(128)) * 10000
@@ -26,8 +30,7 @@ class TestCompression(unittest.TestCase):
         decoded = pngcompression.decode(encoded)
         self.assertEqual(string, decoded)
 
-PKG = 'rosbridge_library'
-NAME = 'test_compression'
+
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestCompression)
 

--- a/rosbridge_library/test/internal/test_compression.py
+++ b/rosbridge_library/test/internal/test_compression.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from rosbridge_library.internal import pngcompression
@@ -32,5 +32,5 @@ class TestCompression(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestCompression)
+    rosunit.unitrun(PKG, NAME, TestCompression)
 

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 from json import loads, dumps
 
@@ -283,4 +283,4 @@ class TestMessageConversion(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestMessageConversion)
+    rosunit.unitrun(PKG, NAME, TestMessageConversion)

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -21,10 +21,14 @@ else:
     string_types = (str, unicode)  # noqa: F821
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_message_conversion'
+
+
 class TestMessageConversion(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_message_conversion")
+        rospy.init_node(NAME)
 
     def validate_instance(self, inst1):
         """ Serializes and deserializes the inst to typecheck and ensure that
@@ -278,7 +282,5 @@ class TestMessageConversion(unittest.TestCase):
             self.assertEqual(ret, str_int8s)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_message_conversion'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestMessageConversion)

--- a/rosbridge_library/test/internal/test_outgoing_message.py
+++ b/rosbridge_library/test/internal/test_outgoing_message.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import rostest
+import rosunit
 import sys
 import unittest
 
@@ -34,4 +34,4 @@ class TestOutgoingMessage(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestOutgoingMessage)
+    rosunit.unitrun(PKG, NAME, TestOutgoingMessage)

--- a/rosbridge_library/test/internal/test_outgoing_message.py
+++ b/rosbridge_library/test/internal/test_outgoing_message.py
@@ -7,6 +7,10 @@ from rosbridge_library.internal.outgoing_message import OutgoingMessage
 from std_msgs.msg import String
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_outgoing_message'
+
+
 class TestOutgoingMessage(unittest.TestCase):
     def test_json_values(self):
         msg = String(data="foo")
@@ -29,7 +33,5 @@ class TestOutgoingMessage(unittest.TestCase):
         self.assertTrue(result is again)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_outgoing_message'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestOutgoingMessage)

--- a/rosbridge_library/test/internal/test_ros_loader.py
+++ b/rosbridge_library/test/internal/test_ros_loader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 
 from rosbridge_library.internal import ros_loader
@@ -219,5 +219,5 @@ class TestROSLoader(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestROSLoader)
+    rosunit.unitrun(PKG, NAME, TestROSLoader)
 

--- a/rosbridge_library/test/internal/test_ros_loader.py
+++ b/rosbridge_library/test/internal/test_ros_loader.py
@@ -7,10 +7,14 @@ import unittest
 from rosbridge_library.internal import ros_loader
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_ros_loader'
+
+
 class TestROSLoader(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_ros_loader")
+        rospy.init_node(NAME)
 
     def test_bad_msgnames(self):
         bad = ["", "/", "//", "///", "////", "/////", "bad", "stillbad",
@@ -213,8 +217,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertRaises(ros_loader.InvalidClassException,
                               ros_loader.get_service_response_instance, x)
 
-PKG = 'rosbridge_library'
-NAME = 'test_ros_loader'
+
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestROSLoader)
 

--- a/rosbridge_library/test/internal/test_services.py
+++ b/rosbridge_library/test/internal/test_services.py
@@ -19,6 +19,10 @@ else:
     string_types = (str, unicode)  # noqa: F821
 
 
+PKG = 'rosbridge_library'
+NAME = 'test_services'
+
+
 def populate_random_args(d):
     # Given a dictionary d, replaces primitives with random values
     if isinstance(d, dict):
@@ -88,7 +92,7 @@ class ServiceTester:
 class TestServices(unittest.TestCase):
 
     def setUp(self):
-        rospy.init_node("test_services")
+        rospy.init_node(NAME)
 
     def msgs_equal(self, msg1, msg2):
         if type(msg1) in string_types and type(msg2) in string_types:
@@ -204,8 +208,6 @@ class TestServices(unittest.TestCase):
             t.validate(self.msgs_equal)
 
 
-PKG = 'rosbridge_library'
-NAME = 'test_services'
 if __name__ == '__main__':
     rostest.unitrun(PKG, NAME, TestServices)
 

--- a/rosbridge_library/test/internal/test_services.py
+++ b/rosbridge_library/test/internal/test_services.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys
 import rospy
-import rostest
+import rosunit
 import unittest
 import time
 import random
@@ -209,5 +209,5 @@ class TestServices(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.unitrun(PKG, NAME, TestServices)
+    rosunit.unitrun(PKG, NAME, TestServices)
 


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Behavior or `rospy` in noetic has changed. Therefore test needs to be changed.

Also `setuptools` has changed. It now forces the use of their `distutils` This breaks catkin stuff. Therefore we need to set the environment variable in CI. To use the stdlib version.

Fixes #682 