### PR TITLE
Fix error when advertising duplicate service

### DIFF
--- a/rosbridge_server/test/websocket/advertise_service.test.py
+++ b/rosbridge_server/test/websocket/advertise_service.test.py
@@ -19,7 +19,8 @@ generate_test_description = common.generate_test_description
 
 class TestAdvertiseService(unittest.TestCase):
     @websocket_test
-    async def test_two_concurrent_calls(self, node: Node, ws_client):
+    async def test_two_concurrent_calls(self, node: Node, make_client):
+        ws_client = await make_client()
         ws_client.sendJson(
             {
                 "op": "advertise_service",

--- a/rosbridge_server/test/websocket/advertise_service_duplicate.test.py
+++ b/rosbridge_server/test/websocket/advertise_service_duplicate.test.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import unittest
+
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+from twisted.python import log
+
+sys.path.append(os.path.dirname(__file__))  # enable importing from common.py in this directory
+
+import common  # noqa: E402
+from common import expect_messages, sleep, websocket_test  # noqa: E402
+
+log.startLogging(sys.stderr)
+
+generate_test_description = common.generate_test_description
+
+
+class TestAdvertiseService(unittest.TestCase):
+    @websocket_test
+    async def test_double_advertise(self, node: Node, make_client):
+        ws_client1 = await make_client()
+        ws_client1.sendJson(
+            {
+                "op": "advertise_service",
+                "type": "std_srvs/SetBool",
+                "service": "/test_service",
+            }
+        )
+        client = node.create_client(SetBool, "/test_service")
+        client.wait_for_service()
+
+        requests1_future, ws_client1.message_handler = expect_messages(
+            1, "WebSocket 1", node.get_logger()
+        )
+        requests1_future.add_done_callback(lambda _: node.executor.wake())
+
+        client.call_async(SetBool.Request(data=True))
+
+        requests1 = await requests1_future
+        self.assertEqual(
+            requests1,
+            [
+                {
+                    "op": "call_service",
+                    "service": "/test_service",
+                    "id": "service_request:/test_service:1",
+                    "args": {"data": True},
+                }
+            ],
+        )
+
+        ws_client1.sendClose()
+
+        ws_client2 = await make_client()
+        ws_client2.sendJson(
+            {
+                "op": "advertise_service",
+                "type": "std_srvs/SetBool",
+                "service": "/test_service",
+            }
+        )
+
+        # wait for the server to handle the new advertisement
+        await sleep(node, 1)
+
+        requests2_future, ws_client2.message_handler = expect_messages(
+            1, "WebSocket 2", node.get_logger()
+        )
+        requests2_future.add_done_callback(lambda _: node.executor.wake())
+
+        response2_future = client.call_async(SetBool.Request(data=False))
+
+        requests2 = await requests2_future
+        self.assertEqual(
+            requests2,
+            [
+                {
+                    "op": "call_service",
+                    "id": "service_request:/test_service:1",
+                    "service": "/test_service",
+                    "args": {"data": False},
+                }
+            ],
+        )
+
+        ws_client2.sendJson(
+            {
+                "op": "service_response",
+                "service": "/test_service",
+                "values": {"success": True, "message": "Hello world 2"},
+                "id": "service_request:/test_service:1",
+                "result": True,
+            }
+        )
+
+        self.assertEqual(
+            await response2_future, SetBool.Response(success=True, message="Hello world 2")
+        )

--- a/rosbridge_server/test/websocket/call_service.test.py
+++ b/rosbridge_server/test/websocket/call_service.test.py
@@ -19,7 +19,7 @@ generate_test_description = common.generate_test_description
 
 class TestCallService(unittest.TestCase):
     @websocket_test
-    async def test_one_call(self, node: Node, ws_client):
+    async def test_one_call(self, node: Node, make_client):
         def service_cb(req, res):
             self.assertTrue(req.data)
             res.success = True
@@ -28,6 +28,7 @@ class TestCallService(unittest.TestCase):
 
         service = node.create_service(SetBool, "/test_service", service_cb)
 
+        ws_client = await make_client()
         responses_future, ws_client.message_handler = expect_messages(
             1, "WebSocket", node.get_logger()
         )

--- a/rosbridge_server/test/websocket/smoke.test.py
+++ b/rosbridge_server/test/websocket/smoke.test.py
@@ -19,7 +19,8 @@ generate_test_description = common.generate_test_description
 
 class TestWebsocketSmoke(unittest.TestCase):
     @websocket_test
-    async def test_smoke(self, node: Node, ws_client):
+    async def test_smoke(self, node: Node, make_client):
+        ws_client = await make_client()
         # For consistency, the number of messages must not exceed the the protocol
         # Subscriber queue_size.
         NUM_MSGS = 10


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Fixes an issue reported by @Stephenjerry in https://github.com/RobotWebTools/rosbridge_suite/issues/650#issuecomment-973810774. When a duplicate service is advertised by the client, the code now correctly shuts down the original service.

There is still a `WebSocketClosedError` received with only a single client, when it advertises a service and then disconnects. Filed https://github.com/RobotWebTools/rosbridge_suite/issues/684 to track this.