### PR TITLE
Fix time behavior

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -37,9 +37,9 @@ import re
 from base64 import standard_b64decode, standard_b64encode
 
 import numpy as np
-import rclpy
 from rcl_interfaces.msg import Parameter
 from rclpy.clock import ROSClock
+from rclpy.time import Duration, Time
 from rosbridge_library.internal import ros_loader
 from rosbridge_library.util import bson
 
@@ -208,10 +208,7 @@ def _from_inst(inst, rostype):
 
     # Check for time or duration
     if rostype in ros_time_types:
-        try:
-            return {"sec": inst.sec, "nanosec": inst.nanosec}
-        except AttributeError:
-            return {"secs": inst.secs, "nsecs": inst.nsecs}
+        return {"sec": inst.sec, "nanosec": inst.nanosec}
 
     if bson_only_mode is None:
         bson_only_mode = rospy.get_param("~bson_only_mode", False)
@@ -306,24 +303,24 @@ def _to_binary_inst(msg):
 def _to_time_inst(msg, rostype, inst=None):
     # Create an instance if we haven't been provided with one
 
-    if rostype == "time" and msg == "now":
+    if rostype == "builtin_interfaces/Time" and msg == "now":
         return ROSClock().now().to_msg()
 
     if inst is None:
-        if rostype == "time":
-            inst = rclpy.time.Time().to_msg()
-        elif rostype == "duration":
-            inst = rclpy.duration.Duration().to_msg()
+        if rostype == "builtin_interfaces/Time":
+            inst = Time().to_msg()
+        elif rostype == "builtin_interfaces/Duration":
+            inst = Duration().to_msg()
         else:
             return None
 
     # Copy across the fields, try ROS1 and ROS2 fieldnames
-    for field in ["secs", "nsecs", "sec", "nanosec"]:
-        try:
-            if field in msg:
-                setattr(inst, field, msg[field])
-        except TypeError:
-            continue
+    for field in ["sec", "secs"]:
+        if field in msg:
+            setattr(inst, "sec", msg[field])
+    for field in ["nanosec", "nsecs"]:
+        if field in msg:
+            setattr(inst, "nanosec", msg[field])
 
     return inst
 

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -318,9 +318,11 @@ def _to_time_inst(msg, rostype, inst=None):
     for field in ["sec", "secs"]:
         if field in msg:
             setattr(inst, "sec", msg[field])
+            break
     for field in ["nanosec", "nsecs"]:
         if field in msg:
             setattr(inst, "nanosec", msg[field])
+            break
 
     return inst
 

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -186,8 +186,8 @@ class TestMessageConversion(unittest.TestCase):
 
     def test_time_msg(self):
         now_inst = c._to_inst("now", "builtin_interfaces/Time", "builtin_interfaces/Time")
-        self.assertTrue("sec" in now_inst)
-        self.assertTrue("nanosec" in now_inst)
+        self.assertTrue("sec" in now_inst.get_fields_and_field_types())
+        self.assertTrue("nanosec" in now_inst.get_fields_and_field_types())
 
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Time")

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -185,6 +185,10 @@ class TestMessageConversion(unittest.TestCase):
             self.do_primitive_test(x, "std_msgs/String")
 
     def test_time_msg(self):
+        now_inst = c._to_inst("now", "builtin_interfaces/Time", "builtin_interfaces/Time")
+        self.assertTrue("sec" in now_inst)
+        self.assertTrue("nanosec" in now_inst)
+
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Time")
 

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -188,17 +188,15 @@ class TestMessageConversion(unittest.TestCase):
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Time")
 
-        # TODO: enable this test
-        # msg = {"times": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
-        # self.do_test(msg, "rosbridge_test_msgs/TestTimeArray")
+        msg = {"times": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
+        self.do_test(msg, "rosbridge_test_msgs/TestTimeArray")
 
     def test_duration_msg(self):
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Duration")
 
-        # TODO: enable this test
-        # msg = {"durations": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
-        # self.do_test(msg, "rosbridge_test_msgs/TestDurationArray")
+        msg = {"durations": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
+        self.do_test(msg, "rosbridge_test_msgs/TestDurationArray")
 
     def test_header_msg(self):
         msg = {

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -195,6 +195,15 @@ class TestMessageConversion(unittest.TestCase):
         msg = {"times": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
         self.do_test(msg, "rosbridge_test_msgs/TestTimeArray")
 
+        # For ROS1 compatibility
+        inst1 = c._to_inst(
+            {"sec": 3, "nanosec": 5}, "builtin_interfaces/Time", "builtin_interfaces/Time"
+        )
+        inst2 = c._to_inst(
+            {"secs": 3, "nsecs": 5}, "builtin_interfaces/Time", "builtin_interfaces/Time"
+        )
+        self.assertEqual(inst1, inst2)
+
     def test_duration_msg(self):
         msg = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Duration")


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

To be discussed.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Split from #646.

Since the current code doesn't pass the tests, I fixed it.
However, this deletes a lot of code, so should be discussed carefully.

<!-- Link relevant GitHub issues -->

**How to test**

### Time Array

**Before(upstream/ros2)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1639116972.608771088] [rosbridge_websocket]: [Client 0] [id: publish:/time:3] publish: The 'times' field must be a set or sequence and each value of type 'Time'
[ERROR 1639116973.613656065] [rosbridge_websocket]: [Client 0] [id: publish:/time:4] publish: The 'times' field must be a set or sequence and each value of type 'Time

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/time_array.py | python
publish: {'times': [{'sec': 1, 'nanosec': 2}, {'sec': 3, 'nanosec': 4}]}
publish: {'times': [{'sec': 1, 'nanosec': 2}, {'sec': 3, 'nanosec': 4}]}
```

**After(this PR)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/time_array.py | python
publish: {'times': [{'sec': 1, 'nanosec': 2}, {'sec': 3, 'nanosec': 4}]}
subscribe: {'times': [{'sec': 1, 'nanosec': 2}, {'sec': 3, 'nanosec': 4}]}
publish: {'times': [{'sec': 1, 'nanosec': 2}, {'sec': 3, 'nanosec': 4}]}
subscribe: {'times': [{'sec': 1, 'nanosec': 2}, {'sec': 3, 'nanosec': 4}]}
```

### Time (new format of `sec/nanosec`)


**Before(upstream/ros2)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/time_new_format.py | python
publish: {'sec': 1, 'nanosec': 2}
subscribe: {'sec': 1, 'nanosec': 2}
publish: {'sec': 1, 'nanosec': 2}
subscribe: {'sec': 1, 'nanosec': 2}
```

**After(this PR)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/time_new_format.py | python
publish: {'sec': 1, 'nanosec': 2}
subscribe: {'sec': 1, 'nanosec': 2}
publish: {'sec': 1, 'nanosec': 2}
subscribe: {'sec': 1, 'nanosec': 2}
```

### Time (old format of `secs/nsecs`)

**Before(upstream/ros2)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1641824688.064981748] [rosbridge_websocket]: [Client 2] [id: publish:/time:3] publish: 'Time' object has no attribute 'secs'
[ERROR 1641824689.066817317] [rosbridge_websocket]: [Client 2] [id: publish:/time:4] publish: 'Time' object has no attribute 'secs'

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/time_old_format.py | python
publish: {'secs': 1, 'nsecs': 2}
publish: {'secs': 1, 'nsecs': 2}
```

**After(this PR)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1641824706.049035256] [rosbridge_websocket]: [Client 0] [id: publish:/time:3] publish: Message type builtin_interfaces/Time does not have a field secs
[ERROR 1641824707.049698653] [rosbridge_websocket]: [Client 0] [id: publish:/time:4] publish: Message type builtin_interfaces/Time does not have a field secs

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/time_old_format.py | python
publish: {'secs': 1, 'nsecs': 2}
publish: {'secs': 1, 'nsecs': 2}
```