### PR TITLE
Fix array behavior

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -248,8 +248,13 @@ def _from_list_inst(inst, rostype):
         rostype = re.search(bounded_array_tokens, rostype).group(1)
 
     # Shortcut for primitives
-    if rostype in ros_primitive_types and rostype not in type_map.get("float"):
-        return list(inst)
+    if rostype in ros_primitive_types:
+        # Convert to Built-in integer types to dump as JSON
+        if isinstance(inst, np.ndarray) and rostype in type_map.get("int"):
+            return inst.tolist()
+
+        if rostype not in type_map.get("float"):
+            return list(inst)
 
     # Call to _to_inst for every element of the list
     return [_from_inst(x, rostype) for x in inst]

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -293,10 +293,11 @@ def _to_inst(msg, rostype, roottype, inst=None, stack=[]):
 
 
 def _to_binary_inst(msg):
-    try:
-        return standard_b64decode(msg) if isinstance(msg, str) else bytes(bytearray(msg))
-    except Exception:
+    if isinstance(msg, str):
+        return list(standard_b64decode(msg))
+    if isinstance(msg, list):
         return msg
+    return bytes(bytearray(msg))
 
 
 def _to_time_inst(msg, rostype, inst=None):

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -61,8 +61,6 @@ type_map = {
         "uint32",
         "int64",
         "uint64",
-        "float32",
-        "float64",
     ],
     "float": ["float32", "float64", "double", "float"],
     "str": ["string"],

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -353,8 +353,9 @@ def _to_list_inst(msg, rostype, roottype, inst, stack):
     if len(msg) == 0:
         return []
 
-    if isinstance(inst, np.ndarray):
-        return list(inst.astype(float))
+    # Special mappings for numeric types https://design.ros2.org/articles/idl_interface_definition.html
+    if isinstance(inst, array.array) or isinstance(inst, np.ndarray):
+        return msg
 
     # Remove the list indicators from the rostype
     try:

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -91,7 +91,7 @@ ros_primitive_types = [
     "string",
 ]
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
-ros_binary_types = ["uint8[]", "char[]"]
+ros_binary_types = ["uint8[]", "char[]", "sequence<uint8>", "sequence<char>"]
 list_tokens = re.compile("<(.+?)>")
 bounded_array_tokens = re.compile(r"(.+)\[.*\]")
 ros_binary_types_list_braces = [

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -302,10 +302,8 @@ class Protocol:
                 return bson.BSON.encode(msg)
             else:
                 return json.dumps(msg)
-        except Exception:
-            if cid is not None:
-                # Only bother sending the log message if there's an id
-                self.log("error", "Unable to serialize %s message to client" % msg["op"], cid)
+        except Exception as e:
+            self.log("error", f"Unable to serialize message '{msg}': {e}")
             return None
 
     def deserialize(self, msg, cid=None):

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -238,7 +238,6 @@ class TestMessageConversion(unittest.TestCase):
             c.populate_instance(msg, inst2)
             self.assertEqual(inst, inst2)
 
-    @unittest.skip
     def test_int8array(self):
         def test_int8_msg(rostype, data):
             msg = {"data": data}


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

`uint8[]` will be sent in `binary` format instead of `list` format.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Split from #646.

Fixed the behavior around arrays.

<!-- Link relevant GitHub issues -->

**How to test**

### Fixed Array

**Before(upstream/ros2)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1641822931.215073518] [rosbridge_websocket]: [Client 0] [id: publish:/fixed_array:3] publish: invalid literal for int() with base 10: b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'
[ERROR 1641822932.220379579] [rosbridge_websocket]: [Client 0] [id: publish:/fixed_array:4] publish: invalid literal for int() with base 10: b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/int8_fixed_array.py | python
publish: {'uuid': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
publish: {'uuid': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
```

**After(this PR)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/int8_fixed_array.py | python
publish: {'uuid': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
subscribe: {'uuid': 'AAECAwQFBgcICQoLDA0ODw=='}
publish: {'uuid': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
subscribe: {'uuid': 'AAECAwQFBgcICQoLDA0ODw=='}
```

### Multi Array

**Before(upstream/ros2)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/int8_array.py | python
publish: {'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
subscribe: {'layout': {'dim': [], 'data_offset': 0}, 'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
publish: {'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
subscribe: {'layout': {'dim': [], 'data_offset': 0}, 'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
```

This means `uint8[]` such as in `sensor_msgs/msg/Image` won't be `binary`.

https://github.com/ros2/common_interfaces/blob/f41462f5dd36f5c3ae28866f18f356423ffb84e4/sensor_msgs/msg/Image.msg#L26
https://github.com/ros2/example_interfaces/blob/2977bbe4e5e30c74d3594d31a8212193f5c27761/msg/UInt8MultiArray.msg#L9

**After(this PR)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/int8_array.py | python
publish: {'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
subscribe: {'layout': {'dim': [], 'data_offset': 0}, 'data': 'AAECAwQFBgcICQoLDA0ODw=='}
{'layout': {'dim': [], 'data_offset': 0}, 'data': 'AAECAwQFBgcICQoLDA0ODw=='}
publish: {'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}
subscribe: {'layout': {'dim': [], 'data_offset': 0}, 'data': 'AAECAwQFBgcICQoLDA0ODw=='}
{'layout': {'dim': [], 'data_offset': 0}, 'data': 'AAECAwQFBgcICQoLDA0ODw=='}
```

### uint32[3] (#699)

**Before(upstream/ros2)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1641822637.451501204] [rosbridge_websocket]: [Client 0] [id: publish:/uint32_fixed_array:3] publish: The 'vertex_indices' field must be a set or sequence with length 3 and each value of type 'int' and eac
h unsigned integer in [0, 4294967295]
[ERROR 1641822638.448902374] [rosbridge_websocket]: [Client 0] [id: publish:/uint32_fixed_array:4] publish: The 'vertex_indices' field must be a set or sequence with length 3 and each value of type 'int' and eac
h unsigned integer in [0, 4294967295]

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/mesh_triangle.py | python
publish: {'vertex_indices': [1, 2, 3]}
publish: {'vertex_indices': [1, 2, 3]}
```

**After(this PR)**

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
// No error

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/mesh_triangle.py | python
publish: {'vertex_indices': [1, 2, 3]}
subscribe: {'vertex_indices': [1, 2, 3]}
publish: {'vertex_indices': [1, 2, 3]}
subscribe: {'vertex_indices': [1, 2, 3]}
```

