### PR TITLE
Fix byte behavior

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -52,7 +52,7 @@ type_map = {
     "bool": ["bool", "boolean"],
     "int": [
         "int8",
-        "byte",
+        "octet",
         "uint8",
         "char",
         "int16",
@@ -74,7 +74,7 @@ ros_time_types = ["builtin_interfaces/Time", "builtin_interfaces/Duration"]
 ros_primitive_types = [
     "bool",
     "boolean",
-    "byte",
+    "octet",
     "char",
     "int8",
     "uint8",

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -223,6 +223,11 @@ def _from_inst(inst, rostype):
         if (not bson_only_mode) and (rostype in type_map.get("float")):
             if math.isnan(inst) or math.isinf(inst):
                 return None
+
+        # JSON does not support byte array. They are converted to int
+        if (not bson_only_mode) and (rostype == "octet"):
+            return int.from_bytes(inst, "little")
+
         return inst
 
     # Check if it's a list or tuple

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -326,6 +326,10 @@ def _to_primitive_inst(msg, rostype, roottype, stack):
         # fix that by casting the int to the expected float
         msg = float(msg)
 
+    # Convert to byte
+    if rostype == "octet" and isinstance(msg, int):
+        return bytes([msg])
+
     msgtype = type(msg)
     if msgtype in primitive_types and rostype in type_map[msgtype.__name__]:
         return msg

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -78,7 +78,6 @@ class TestMessageConversion(unittest.TestCase):
                 self.assertEqual(c._to_primitive_inst(msg, rostype, rostype, []), msg)
                 self.assertEqual(c._to_inst(msg, rostype, rostype), msg)
 
-    @unittest.skip
     def test_byte_primitives(self):
         # Test raw primitives
         for msg in range(0, 200):
@@ -172,7 +171,6 @@ class TestMessageConversion(unittest.TestCase):
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/UInt16")
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/UInt32")
 
-    @unittest.skip
     def test_byte_base_msg(self):
         int8s = range(0, 256)
         for int8 in int8s:


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

None.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Split from #646.

Fixed the behavior around bytes.

<!-- Link relevant GitHub issues -->

**How to test**

Before(upstream/ros2)

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket
[ERROR 1632497492.739524112] [rosbridge_websocket]: [Client 0] [id: publish:/byte:3] publish: example_interfaces/Byte message requires a octet for field data, but got a <class 'int'>
[ERROR 1632497493.727461853] [rosbridge_websocket]: [Client 0] [id: publish:/byte:4] publish: example_interfaces/Byte message requires a octet for field data, but got a <class 'int'>

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/byte.py | python
publish: {'data': 1}
publish: {'data': 1}
```

After(this PR)

```sh-session
$ # Terminal 1
$ ros2 run rosbridge_server rosbridge_websocket

$ # Terminal 2
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/byte.py | python
publish: {'data': 1}
subscribe: {'data': 1}
publish: {'data': 1}
subscribe: {'data': 1}
```