### PR TITLE
[694] update DurabilityPolicy api that are being deprecated

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -34,7 +34,7 @@
 from threading import Timer
 
 from rclpy.duration import Duration
-from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from rosbridge_library.internal import message_conversion, ros_loader
 from rosbridge_library.internal.message_conversion import msg_class_type_repr
 from rosbridge_library.internal.topics import (
@@ -105,7 +105,7 @@ class MultiPublisher:
         # without the need of a custom message publisher implementation.
         publisher_qos = QoSProfile(
             depth=queue_size,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
 
         # For latched clients, no lifespan has to be specified (i.e. latch forever).

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -37,7 +37,7 @@ import time
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from rosbridge_library.capabilities.advertise import Advertise
 from rosbridge_library.capabilities.advertise_service import AdvertiseService
 from rosbridge_library.capabilities.call_service import CallService
@@ -102,9 +102,15 @@ class RosbridgeWebsocketNode(Node):
             self.declare_parameter("websocket_ping_timeout", 30).value
         )
 
-        # SSL options
-        certfile = self.declare_parameter("certfile").value
-        keyfile = self.declare_parameter("keyfile").value
+        # SSL options, cannot set default to None - rclpy throws warning
+        certfile = self.declare_parameter("certfile", "").value
+        keyfile = self.declare_parameter("keyfile", "").value
+        # if not set, set to None
+        if certfile == "":
+            certfile = None
+        if keyfile == "":
+            keyfile = None
+
         # if authentication should be used
         RosbridgeWebSocket.authenticate = self.declare_parameter("authenticate", False).value
 
@@ -118,7 +124,7 @@ class RosbridgeWebsocketNode(Node):
         # QoS profile with transient local durability (latched topic in ROS 1).
         client_count_qos_profile = QoSProfile(
             depth=10,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
 
         RosbridgeWebSocket.client_count_pub = self.create_publisher(

--- a/rosbridge_server/src/rosbridge_server/client_mananger.py
+++ b/rosbridge_server/src/rosbridge_server/client_mananger.py
@@ -33,7 +33,7 @@
 import threading
 
 from rclpy.clock import ROSClock
-from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import Int32
 
 from rosbridge_msgs.msg import ConnectedClient, ConnectedClients
@@ -43,7 +43,7 @@ class ClientManager:
     def __init__(self, node_handle):
         qos = QoSProfile(
             depth=1,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
 
         # Publisher for number of connected clients


### PR DESCRIPTION
Signed-off-by: Evan Flynn <evanflynn.msu@gmail.com>

**Public API Changes**
None


**Description**

closes #694 to fix deprecation warnings for `DurabilityPolicy` api
