### PR TITLE
Explicitly rename param subnode

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -70,7 +70,11 @@ def init(parent_node_name):
     global _node, _parent_node_name
     # TODO(@jubeira): remove this node; use rosapi node with MultiThreadedExecutor or
     # async / await to prevent the service calls from blocking.
-    _node = rclpy.create_node("rosapi_params")
+    parent_node_basename = parent_node_name.split("/")[-1]
+    param_node_name = f"{parent_node_basename}_params"
+    _node = rclpy.create_node(
+        param_node_name, cli_args=["--ros-args", "-r", f"__node:={param_node_name}"]
+    )
     _parent_node_name = get_absolute_node_name(parent_node_name)
 
 


### PR DESCRIPTION
**Public API Changes**
None(ish)

The param subnode is now named `{parent_node_name}_params` when the rosapi node is renamed. Previously it would have the same name.


**Description**
Previously, without any renaming, running the `rosapi` node would spawn a `rosapi_params` subnode. If the top-level node was renamed (or had a name set by a launch file) the param subnode ended up with the same name as the top-level node. This fixes the behaviour by explicitly setting the name of the subnode to the same as the top-level node with `_params` as a suffix.

Unlike the solution described in [the issue](https://github.com/RobotWebTools/rosbridge_suite/issues/704), this preserves any other global arguments. This means when changing namespace of the top-level node, the subnode will have a matching namespace.

Fixes #704 
