### PR TITLE
Feature config url_path for deployment

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -146,12 +146,11 @@ class RosbridgeWebsocketNode(Node):
         # Done with parameter handling                   #
         ##################################################
 
+        handlers = [(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)]
         if url_path != "/":
-            application = Application([(rf"{url_path}", RosbridgeWebSocket)], **tornado_settings)
-        else:
-            application = Application(
-                [(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)], **tornado_settings
-            )
+            handlers = [(rf"{url_path}", RosbridgeWebSocket)]
+
+        application = Application(handlers, **tornado_settings)
 
         connected = False
         while not connected and self.context.ok():

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -124,6 +124,15 @@ class RosbridgeWebsocketNode(Node):
                 print("--address argument provided without a value.")
                 sys.exit(-1)
 
+        url_path = self.declare_parameter("url_path", "/").value
+        if "--url_path" in sys.argv:
+            idx = sys.argv.index("--url_path") + 1
+            if idx < len(sys.argv):
+                url_path = str(sys.argv[idx])
+            else:
+                print("--url_path argument provided without a value.")
+                sys.exit(-1)
+
         retry_startup_delay = self.declare_parameter("retry_startup_delay", 2.0).value  # seconds.
         if "--retry_startup_delay" in sys.argv:
             idx = sys.argv.index("--retry_startup_delay") + 1
@@ -137,9 +146,12 @@ class RosbridgeWebsocketNode(Node):
         # Done with parameter handling                   #
         ##################################################
 
-        application = Application(
-            [(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)], **tornado_settings
-        )
+        if url_path != "/":
+            application = Application([(rf"{url_path}", RosbridgeWebSocket)], **tornado_settings)
+        else:
+            application = Application(
+                [(r"/", RosbridgeWebSocket), (r"", RosbridgeWebSocket)], **tornado_settings
+            )
 
         connected = False
         while not connected and self.context.ok():


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
1. Fix args `--address` type bug. replaced type int() with str()
2. Add new args `--url_path` and ROS param

url_path should be a configurable parameter because when application is deployed the port (9090) need an ingress to url path.
(for e.g. 127.0.0.0:9090 -> xxx.ap-southeast-1.elb.amazonaws.com/rosbridge_websocket)

https://kubernetes.io/docs/concepts/services-networking/ingress/

<!-- Link relevant GitHub issues -->
