### PR TITLE
Fix formatting of operations list

### DIFF
--- a/ROSBRIDGE_PROTOCOL.md
+++ b/ROSBRIDGE_PROTOCOL.md
@@ -83,7 +83,8 @@ Authentication:
 ROS operations:
 
   * **advertise** – advertise that you are publishing a topic
-  * **unadvertise** – stop advertising that you are publishing topic publish - a published ROS-message
+  * **unadvertise** – stop advertising that you are publishing topic
+  * **publish** - a published ROS-message
   * **subscribe** - a request to subscribe to a topic
   * **unsubscribe** - a request to unsubscribe from a topic
   * **call_service** - a service call


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Fixes what I suspect is a mistake in the spec, where `publish` is a separate operation.