### PR TITLE
Use UUID to ensure client_id uniqueness

### DIFF
--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -114,7 +114,6 @@ class IncomingQueue(threading.Thread):
 
 
 class RosbridgeWebSocket(WebSocketHandler):
-    client_id_seed = 0
     clients_connected = 0
     use_compression = False
 
@@ -139,17 +138,16 @@ class RosbridgeWebSocket(WebSocketHandler):
             "bson_only_mode": cls.bson_only_mode,
         }
         try:
+            self.client_id = uuid.uuid4()
             self.protocol = RosbridgeProtocol(
-                cls.client_id_seed, cls.node_handle, parameters=parameters
+                self.client_id, cls.node_handle, parameters=parameters
             )
             self.incoming_queue = IncomingQueue(self.protocol)
             self.incoming_queue.start()
             self.protocol.outgoing = self.send_message
             self.set_nodelay(True)
             self._write_lock = threading.RLock()
-            cls.client_id_seed += 1
             cls.clients_connected += 1
-            self.client_id = uuid.uuid4()
             if cls.client_manager:
                 cls.client_manager.add_client(self.client_id, self.request.remote_ip)
         except Exception as exc:


### PR DESCRIPTION
**Public API Changes**
None
<!-- Describe any changes to the public API, or write "None" -->

**Description**

This is a minor update to the `client_id` that is used in the websocket handler to use a UUID instead of an incremented integer. The UUID was already being generated in `websocket_handler.py` for each client connection but it was not being passed to the RosbridgeProtocol constructor for some reason.

This is an improvement because the protocol expects the client ID to be unique and a UUID has better guarantees than an incremented count. See the code comment in the `__init__` method of `rosbridge_library/src/rosbridge_library/protocol.py` stating the importance of client ID uniqueness.

This is also an improvement because the client ID will be unique across multiple instances of the websocket handler and also client IDs will not repeat with restarted servers. This can help with logging to be able to trace down interactions with a specific client connection.

The client ID will now be a UUID instead of an integer. See an example log message:
```
[INFO] [1645237522.961106930] [rosbridge_websocket]: Rosbridge WebSocket server started on port 9090
[INFO] [1645237524.775806219] [rosbridge_websocket]: Client connected. 1 clients total.
[INFO] [1645237530.143315838] [rosbridge_websocket]: [Client cabf4ca7-bb10-456c-b9ac-377fcc84b36f] Subscribed to /test
[INFO] [1645237841.842307049] [rosbridge_websocket]: Client disconnected. 0 clients total.
```

I made this change as part of https://github.com/RobotWebTools/rosbridge_suite/pull/676 but since that was closed I am making a smaller PR with only this change.

<!-- Describe what has changed, and motivation behind those changes -->


<!-- Link relevant GitHub issues -->
