### PR TITLE
Closes RobotWebTools/rosbridge_suite#721

### DIFF
--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -97,7 +97,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
         self.request.settimeout(cls.socket_timeout)
         while True:
             try:
-                if self.bson_only_mode: # is False
+                if self.bson_only_mode:
                     if self.recv_bson() == None:
                         break
                     continue

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -9,7 +9,8 @@ except ImportError:
 
 class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     """
-    TCP Socket server for rosbridge
+    TCP Socket server for rosbridge.
+    An instance of this class is created for each request.
     """
 
     busy = False
@@ -31,6 +32,10 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
     bson_only_mode = False
 
     def setup(self):
+        """
+        Called before the handle() method to perform any initialization 
+        actions required. The default implementation does nothing.
+        """
         cls = self.__class__
         parameters = {
             "fragment_timeout": cls.fragment_timeout,
@@ -86,33 +91,37 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
 
     def handle(self):
         """
-        Listen for TCP messages
+        Listen for TCP messages and do all the work to service a request.
         """
         cls = self.__class__
         self.request.settimeout(cls.socket_timeout)
-        while 1:
+        while True:
             try:
-              if self.bson_only_mode:
-                  if self.recv_bson() == None:
-                      break
-                  continue
+                if self.bson_only_mode: # is False
+                    if self.recv_bson() == None:
+                        break
+                    continue
 
-              # non-BSON handling
-              data = self.request.recv(cls.incoming_buffer)
-              # Exit on empty string
-              if data.strip() == '':
-                  break
-              elif len(data.strip()) > 0:
-                  self.protocol.incoming(data.decode().strip(''))
-              else:
-                  pass
+                # non-BSON handling
+                bytes = self.request.recv(cls.incoming_buffer)
+
+                # Exit on empty message because socket was closed
+                if len(bytes) == 0:
+                    break
+                else:
+                    string_encoded = bytes.decode().strip()
+                    if len(string_encoded) > 0:
+                        self.protocol.incoming(string_encoded)
+
             except Exception as e:
                 pass
                 self.protocol.log("debug", "socket connection timed out! (ignore warning if client is only listening..)")
 
     def finish(self):
         """
-        Called when TCP connection finishes
+        Called when TCP connection finishes.
+        Called after the handle() method to perform any clean-up actions required.
+        If setup() raises an exception, this function will not be called.
         """
         cls = self.__class__
         cls.clients_connected -= 1


### PR DESCRIPTION
**Public API Changes**
None

**Description**

When the TCP connection of the client is closed, the Python Socket.recv(...) function returns an empty byte array. However, since the while loop checks for an empty string, the thread hangs in an infinite loop and causes the connection not to be disconnected.

Also added minor description changes for more clarity.

Fixes #721 