### PR TITLE
Fixed multiple subscriber on transient_local topic

### DIFF
--- a/rosbridge_server/test/websocket/transient_local_publisher.test.py
+++ b/rosbridge_server/test/websocket/transient_local_publisher.test.py
@@ -32,24 +32,25 @@ class TestTransientLocalPublisher(unittest.TestCase):
         pub_a.publish(String(data="hello"))
 
         await sleep(node, 1)
+ 
+        for num in range(3):
+            ws_client = await make_client()
+            ws_client.sendJson(
+                {
+                    "op": "subscribe",
+                    "topic": "/a_topic",
+                    "type": "std_msgs/String",
+                }
+            )
 
-        ws_client1 = await make_client()
-        ws_client1.sendJson(
-            {
-                "op": "subscribe",
-                "topic": "/a_topic",
-                "type": "std_msgs/String",
-            }
-        )
+            ws_completed_future, ws_client.message_handler = expect_messages(
+                1, "WebSocket " + str(num), node.get_logger()
+            )
+            ws_completed_future.add_done_callback(lambda _: node.executor.wake())
 
-        ws1_completed_future, ws_client1.message_handler = expect_messages(
-            1, "WebSocket 1", node.get_logger()
-        )
-        ws1_completed_future.add_done_callback(lambda _: node.executor.wake())
-
-        self.assertEqual(
-            await ws1_completed_future,
-            [{"op": "publish", "topic": "/a_topic", "msg": {"data": "hello"}}],
-        )
+            self.assertEqual(
+                await ws_completed_future,
+                [{"op": "publish", "topic": "/a_topic", "msg": {"data": "hello"}}],
+            )
 
         node.destroy_publisher(pub_a)

--- a/rosbridge_server/test/websocket/transient_local_publisher.test.py
+++ b/rosbridge_server/test/websocket/transient_local_publisher.test.py
@@ -32,7 +32,7 @@ class TestTransientLocalPublisher(unittest.TestCase):
         pub_a.publish(String(data="hello"))
 
         await sleep(node, 1)
- 
+
         for num in range(3):
             ws_client = await make_client()
             ws_client.sendJson(


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Problem: Only the first subscription to a transient_local topic does receive the "latched" data.

The MultiSubscriber class creates a new subscription to initially receive the "latched" data for each new client. After this subscription returns with a message the client is shifted over to the "real" subscription and the other one is destroyed. Because this intermittent subscribers does not use the same QoS settings as the real one it will never receive latched data from transient_local topics except there is send new data from the publisher.

Fix: This PR adds the QoS settings as a global variable to the MultiSubscriber class and uses it when creating intermittent subscribers for new clients. With the correct settings these will directly get back with the latched data. 

The transient_local_publisher test is also changed to subscribe three times to cover this case.

