### PR TITLE
(dependabot) ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      dependency-name: "*"
-      update-types: ["version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Dependabot should ignore all patch updates.

It will only create PRs for minor and major updates. Security updates are not affected.