### PR TITLE
Drop melodic workaround in test

### DIFF
--- a/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_unregistering.py
@@ -39,7 +39,6 @@ class TestMultiUnregistering(unittest.TestCase):
 
         self.assertEqual(received["msg"].data, msg["data"])
 
-    @unittest.skipIf(os.environ.get("ROS_DISTRO", "") == "melodic", "Don't run new test on melodic")
     def test_publish_twice(self):
         """ Make sure that publishing works """
         topic = "/test_publish_twice"
@@ -69,53 +68,6 @@ class TestMultiUnregistering(unittest.TestCase):
 
         sleep(1)   # Time to publish and receive
 
-        self.assertEqual(received["msg"].data, msg["data"])
-
-    @unittest.skipUnless(os.environ.get("ROS_DISTRO", "") == "melodic", "Run old test only on melodic")
-    def test_publish_twice_old(self):
-        """ Make sure that publishing works """
-        topic = "/test_publish_twice"
-        msg_type = "std_msgs/String"
-        msg = {"data": "why halo thar"}
-
-        received = {"msg": None}
-        def cb(msg):
-            received["msg"] = msg
-
-        rospy.Subscriber(topic, ros_loader.get_message_class(msg_type), cb)
-        p = MultiPublisher(topic, msg_type)
-        p.publish(msg)
-
-        sleep(1)
-
-        self.assertEqual(received["msg"].data, msg["data"])
-
-        p.unregister()
-        # The publisher went away at time T. Here's the timeline of the events:
-        # T+1 seconds - the subscriber will retry to reconnect - fail
-        # T+3 seconds - the subscriber will retry to reconnect - fail
-        # T+5 seconds - publish msg -> it's gone
-        # T+7 seconds - the subscriber will retry to reconnect - success
-        # T+8 seconds - publish msg -> OK
-        # T+11 seconds - we receive the message. Looks like a bug in reconnection...
-        #                https://github.com/ros/ros_comm/blob/indigo-devel/clients/rospy/src/rospy/impl/tcpros_base.py#L733
-        #                That line should probably be indented.
-        sleep(5)
-
-        received["msg"] = None
-        self.assertIsNone(received["msg"])
-        p = MultiPublisher(topic, msg_type)
-        p.publish(msg)
-
-        self.assertIsNone(received["msg"])
-
-        sleep(3)
-        p.publish(msg)
-        sleep(2)
-        # Next two lines should be removed when this is fixed:
-        # https://github.com/ros/ros_comm/blob/indigo-devel/clients/rospy/src/rospy/impl/tcpros_base.py#L733
-        self.assertIsNone(received["msg"])
-        sleep(3)
         self.assertEqual(received["msg"].data, msg["data"])
 
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**
https://github.com/ros/ros_comm/pull/2123 caused for a difference in behaviour between melodic and noetic. This was temporarily fixed by #680. As https://github.com/ros/ros_comm/pull/2219 has been released to APT, this workaround needs to be dropped. As the melodic test will fail from now on https://github.com/RobotWebTools/rosbridge_suite/runs/5688810515?check_suite_focus=true
