### PR TITLE
Fixed float arrays conversion

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -247,7 +247,9 @@ def _from_list_inst(inst, rostype):
     # Shortcut for primitives
     if rostype in ros_primitive_types:
         # Convert to Built-in integer types to dump as JSON
-        if isinstance(inst, np.ndarray) and (rostype in type_map.get("int") or rostype in type_map.get("float")):
+        if isinstance(inst, np.ndarray) and (
+            rostype in type_map.get("int") or rostype in type_map.get("float")
+        ):
             return inst.tolist()
 
         if rostype not in type_map.get("float"):

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -247,7 +247,7 @@ def _from_list_inst(inst, rostype):
     # Shortcut for primitives
     if rostype in ros_primitive_types:
         # Convert to Built-in integer types to dump as JSON
-        if isinstance(inst, np.ndarray) and rostype in type_map.get("int"):
+        if isinstance(inst, np.ndarray) and (rostype in type_map.get("int") or rostype in type_map.get("float")):
             return inst.tolist()
 
         if rostype not in type_map.get("float"):

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -282,3 +282,27 @@ class TestMessageConversion(unittest.TestCase):
             b64str_int8s = standard_b64encode(bytes(int8s)).decode("ascii")
             ret = test_int8_msg(rostype, b64str_int8s)
             np.testing.assert_array_equal(ret, np.array(int8s))
+
+    def test_float32array(self):
+        def test_float32_msg(rostype, data):
+            msg = {"data": data}
+            inst = ros_loader.get_message_instance(rostype)
+            c.populate_instance(msg, inst)
+            self.validate_instance(inst)
+            return inst.data
+
+        for msgtype in ["TestFloat32Array"]:
+            rostype = "rosbridge_test_msgs/" + msgtype
+
+            # From List[float]
+            floats = list(map(float, range(0, 256)))
+            ret = test_float32_msg(rostype, floats)
+            np.testing.assert_array_equal(ret, np.array(floats))
+
+        for msgtype in ["TestFloat32BoundedArray"]:
+            rostype = "rosbridge_test_msgs/" + msgtype
+
+            # From List[float]
+            floats = list(map(float, range(0, 16)))
+            ret = test_float32_msg(rostype, floats)
+            np.testing.assert_array_equal(ret, np.array(floats))

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -18,6 +18,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/TestTimeArray.msg
   msg/TestUInt8.msg
   msg/TestUInt8FixedSizeArray16.msg
+  msg/TestFloat32Array.msg
+  msg/TestFloat32BoundedArray.msg
   srv/AddTwoInts.srv
   srv/SendBytes.srv
   srv/TestArrayRequest.srv

--- a/rosbridge_test_msgs/msg/TestFloat32Array.msg
+++ b/rosbridge_test_msgs/msg/TestFloat32Array.msg
@@ -1,0 +1,1 @@
+float32[] data

--- a/rosbridge_test_msgs/msg/TestFloat32BoundedArray.msg
+++ b/rosbridge_test_msgs/msg/TestFloat32BoundedArray.msg
@@ -1,0 +1,1 @@
+float32[16] data


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Messages with `float32` arrays (bounded and unbounded) were being silently dropped. After debugging I found that the conversion was the problem. I added the fix and the respective tests.

