### PR TITLE
Update maintainer to point to Foxglove email group

### DIFF
--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -15,7 +15,7 @@
 
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 

--- a/rosapi_msgs/package.xml
+++ b/rosapi_msgs/package.xml
@@ -15,7 +15,7 @@
 
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -16,7 +16,7 @@
 
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -6,7 +6,7 @@
 
   <author email="achim@intermodalics.eu">Hans-Joachim Krauch</author>
   <maintainer email="achim@intermodalics.eu">Hans-Joachim Krauch</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <license>BSD</license>
 

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -12,7 +12,7 @@
 
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>

--- a/rosbridge_suite/package.xml
+++ b/rosbridge_suite/package.xml
@@ -19,7 +19,7 @@
 
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
 

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -14,7 +14,7 @@
 
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
-  <maintainer email="jacob@foxglove.dev">Jacob Bandes-Storch</maintainer>
+  <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Point to whole Foxglove ros-tooling group instead of just me.