### PR TITLE
Non standard msg modules

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -109,9 +109,18 @@ def _get_msg_class(typestring):
     Throws various exceptions if loading the msg class fails"""
     global _loaded_msgs, _msgs_lock
     try:
+        # The type string starts with the package and ends with the
+        # class and contains submodules in between. For compatibility
+        # with ROS1 style types, we fall back to use a standard "msg"
+        # submodule name.
         splits = [x for x in typestring.split("/") if x]
-        return _get_class(typestring, splits[1], _loaded_msgs, _msgs_lock)
-    except InvalidModuleException:
+        if len(splits) > 2:
+            submodule = ".".join(splits[1:-1])
+        else:
+            submodule = "msg"
+
+        return _get_class(typestring, submodule, _loaded_msgs, _msgs_lock)
+    except (InvalidModuleException, InvalidClassException):
         return _get_class(typestring, "msg", _loaded_msgs, _msgs_lock)
 
 
@@ -122,9 +131,18 @@ def _get_srv_class(typestring):
     Throws various exceptions if loading the srv class fails"""
     global _loaded_srvs, _srvs_lock
     try:
+        # The type string starts with the package and ends with the
+        # class and contains submodules in between. For compatibility
+        # with ROS1 style types, we fall back to use a standard "srv"
+        # submodule name.
         splits = [x for x in typestring.split("/") if x]
-        return _get_class(typestring, splits[0], _loaded_srvs, _srvs_lock)
-    except InvalidModuleException:
+        if len(splits) > 2:
+            submodule = ".".join(splits[1:-1])
+        else:
+            submodule = "srv"
+
+        return _get_class(typestring, submodule, _loaded_srvs, _srvs_lock)
+    except (InvalidModuleException, InvalidClassException):
         return _get_class(typestring, "srv", _loaded_srvs, _srvs_lock)
 
 

--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -108,7 +108,11 @@ def _get_msg_class(typestring):
 
     Throws various exceptions if loading the msg class fails"""
     global _loaded_msgs, _msgs_lock
-    return _get_class(typestring, "msg", _loaded_msgs, _msgs_lock)
+    try:
+        splits = [x for x in typestring.split("/") if x]
+        return _get_class(typestring, splits[1], _loaded_msgs, _msgs_lock)
+    except InvalidModuleException:
+        return _get_class(typestring, "msg", _loaded_msgs, _msgs_lock)
 
 
 def _get_srv_class(typestring):
@@ -117,7 +121,11 @@ def _get_srv_class(typestring):
 
     Throws various exceptions if loading the srv class fails"""
     global _loaded_srvs, _srvs_lock
-    return _get_class(typestring, "srv", _loaded_srvs, _srvs_lock)
+    try:
+        splits = [x for x in typestring.split("/") if x]
+        return _get_class(typestring, splits[0], _loaded_srvs, _srvs_lock)
+    except InvalidModuleException:
+        return _get_class(typestring, "srv", _loaded_srvs, _srvs_lock)
 
 
 def _get_class(typestring, subname, cache, lock):

--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -110,16 +110,16 @@ def _get_msg_class(typestring):
     global _loaded_msgs, _msgs_lock
     try:
         # The type string starts with the package and ends with the
-        # class and contains submodules in between. For compatibility
-        # with ROS1 style types, we fall back to use a standard "msg"
-        # submodule name.
+        # class and contains module subnames in between. For
+        # compatibility with ROS1 style types, we fall back to use a
+        # standard "msg" subname.
         splits = [x for x in typestring.split("/") if x]
         if len(splits) > 2:
-            submodule = ".".join(splits[1:-1])
+            subname = ".".join(splits[1:-1])
         else:
-            submodule = "msg"
+            subname = "msg"
 
-        return _get_class(typestring, submodule, _loaded_msgs, _msgs_lock)
+        return _get_class(typestring, subname, _loaded_msgs, _msgs_lock)
     except (InvalidModuleException, InvalidClassException):
         return _get_class(typestring, "msg", _loaded_msgs, _msgs_lock)
 
@@ -132,16 +132,16 @@ def _get_srv_class(typestring):
     global _loaded_srvs, _srvs_lock
     try:
         # The type string starts with the package and ends with the
-        # class and contains submodules in between. For compatibility
-        # with ROS1 style types, we fall back to use a standard "srv"
-        # submodule name.
+        # class and contains module subnames in between. For
+        # compatibility with ROS1 style types, we fall back to use a
+        # standard "srv" subname.
         splits = [x for x in typestring.split("/") if x]
         if len(splits) > 2:
-            submodule = ".".join(splits[1:-1])
+            subname = ".".join(splits[1:-1])
         else:
-            submodule = "srv"
+            subname = "srv"
 
-        return _get_class(typestring, submodule, _loaded_srvs, _srvs_lock)
+        return _get_class(typestring, subname, _loaded_srvs, _srvs_lock)
     except (InvalidModuleException, InvalidClassException):
         return _get_class(typestring, "srv", _loaded_srvs, _srvs_lock)
 


### PR DESCRIPTION
**Public API Changes**
None

**Description**
This is a bug fix relating to parsing the python module and class names of message and service type strings when non-standard submodule naming is used.

I have an application that has generated messages in a namespace that is not `msg`. For example, I want to subscribe to a message type `'my_package_interface/msg_core/MyMessage'`. However, the `ros_loader.py` method `_get_msg_class` discards submodule information `'msg_core'` and assumes the subname will be named `'msg'` causing an `InvalidModuleException` to be raised.

I like that the message type parsing is flexible and able to accommodate ROS1 style types that don't have a submodule subname in the type string. However, I think that logic is too strict because it assumes the submodule subname and prevents any naming other than `msg`.

Note that I am trying to use the term "submodule" as it is used in https://docs.python.org/3/tutorial/modules.html even though it could be confused with `git submodule`.
