### PR TITLE
Stability improvements for multiple clients

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -137,6 +137,8 @@ class MultiSubscriber:
 
     def unregister(self):
         self.node_handle.destroy_subscription(self.subscriber)
+        if self.new_subscriber:
+            self.node_handle.destroy_subscription(self.new_subscriber)
         with self.lock:
             self.subscriptions.clear()
 

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -191,7 +191,7 @@ class MultiSubscriber:
     def has_subscribers(self):
         """Return true if there are subscribers"""
         with self.lock:
-            return len(self.subscriptions) != 0
+            return len(self.subscriptions) + len(self.new_subscriptions) != 0
 
     def callback(self, msg, callbacks=None):
         """Callback for incoming messages on the rclpy subscription.


### PR DESCRIPTION
Public API Changes
None

Description
This changes will improve the stability when multiple clients are connected simultaneously.

Fix 1 (07bd9b8): Changes "has_subscribers" to return the combined count of subscriptions and new subscriptions . This will avoid unregister of subscribers (see line 284-285) if one client disconnects while all others are still waiting for the initial callback (there are still in "new_subscriptions" and not in "subscriptions").

Fix 2 (227bfbe): Removes a possible deadlock if a client is unsubscribed before it receives the initial callback. In that case "self.new_subscriptions.values()" passed as "callbacks" would be empty and trigger a second "self.lock" (line 209) while still in the lock from line 232.