### PR TITLE
Close stale issues as not planned

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v5.1.1
         with:
           operations-per-run: 250
 
@@ -16,6 +16,7 @@ jobs:
           stale-issue-label: stale
           days-before-issue-stale: 180
           days-before-issue-close: 30
+          close-issue-reason: not_planned
 
           stale-pr-message: "This PR has been marked as stale because there has been no activity in the past 6 months. Please add a comment to keep it open. Thank you for your contribution."
           stale-pr-label: stale


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Uses https://github.com/actions/stale/pull/764 to close issues as not planned instead of completed