### PR TITLE
Extend stale issue timeout to 12 months

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,18 +7,19 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v5.1.1
         with:
-          operations-per-run: 250
-
-          stale-issue-message: "This issue has been marked as stale because there has been no activity in the past 6 months. Please add a comment to keep it open."
+          stale-issue-message: "This issue has been marked as stale because there has been no activity in the past 12 months. Please add a comment to keep it open."
           stale-issue-label: stale
-          days-before-issue-stale: 180
+          days-before-issue-stale: 365
           days-before-issue-close: 30
           close-issue-reason: not_planned
 
-          stale-pr-message: "This PR has been marked as stale because there has been no activity in the past 6 months. Please add a comment to keep it open. Thank you for your contribution."
+          stale-pr-message: "This PR has been marked as stale because there has been no activity in the past 6 months. Please add a comment to keep it open."
           stale-pr-label: stale
           days-before-pr-stale: 180
           days-before-pr-close: 30


### PR DESCRIPTION
**Description**
Extend stale issue timeout to 12 months, as we did in https://github.com/foxglove/studio/pull/3798. The issue list is much more under control now so I think we can be less aggressive.