### PR TITLE
Remove unnecessary checking of topic globs on every message callback

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -289,25 +289,6 @@ class Subscribe(Capability):
         self.basic_type_check(msg, self.unsubscribe_msg_fields)
 
         topic = msg["topic"]
-        if Subscribe.topics_glob is not None and Subscribe.topics_glob:
-            self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
-            match = False
-            for glob in Subscribe.topics_glob:
-                if fnmatch.fnmatch(topic, glob):
-                    self.protocol.log(
-                        "debug",
-                        "Found match with glob " + glob + ", continuing unsubscription...",
-                    )
-                    match = True
-                    break
-            if not match:
-                self.protocol.log(
-                    "warn",
-                    "No match found for topic, cancelling unsubscription from: " + topic,
-                )
-                return
-        else:
-            self.protocol.log("debug", "No topic security glob, not checking unsubscription.")
 
         if topic not in self._subscriptions:
             return
@@ -332,25 +313,6 @@ class Subscribe(Capability):
 
         """
         # TODO: fragmentation, proper ids
-        if Subscribe.topics_glob and Subscribe.topics_glob:
-            self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
-            match = False
-            for glob in Subscribe.topics_glob:
-                if fnmatch.fnmatch(topic, glob):
-                    self.protocol.log(
-                        "debug",
-                        "Found match with glob " + glob + ", continuing topic publish...",
-                    )
-                    match = True
-                    break
-            if not match:
-                self.protocol.log(
-                    "warn",
-                    "No match found for topic, cancelling topic publish to: " + topic,
-                )
-                return
-        else:
-            self.protocol.log("debug", "No topic security glob, not checking topic publish.")
 
         outgoing_msg = {"op": "publish", "topic": topic}
         if compression == "png":


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Topic globs are currently checked on every message callback. This is however not necessary, as we check topic globs already at the point when a subscription request is made. If the topic is not allowed to be subscribed, no subscriber is created and the message callback is never called.

This PR removes unnecessary topic glob checking which results in a marginal performance improvements (especially for high-rate topics)

I think it makes sense to backport this to `ros1` branch as well