### PR TITLE
Skip unnecessary conversion for cbor/cbor-raw compression

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -36,16 +36,10 @@ PYTHON2 = sys.version_info < (3, 0)
 import fnmatch
 from threading import Lock
 from functools import partial
-from rospy import loginfo, get_rostime
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.subscribers import manager
 from rosbridge_library.internal.subscription_modifiers import MessageHandler
 from rosbridge_library.internal.pngcompression import encode as encode_png
-
-try:
-    from cbor import dumps as encode_cbor
-except ImportError:
-    from rosbridge_library.util.cbor import dumps as encode_cbor
 
 try:
     from ujson import dumps as encode_json
@@ -326,16 +320,9 @@ class Subscribe(Capability):
             outgoing_msg_dumped = encode_json(outgoing_msg)
             outgoing_msg = {"op": "png", "data": encode_png(outgoing_msg_dumped)}
         elif compression=="cbor":
-            outgoing_msg[u"msg"] = message.get_cbor_values()
-            outgoing_msg = encode_cbor(outgoing_msg)
+            outgoing_msg = message.get_cbor(outgoing_msg)
         elif compression=="cbor-raw":
-            now = get_rostime()
-            outgoing_msg[u"msg"] = {
-                u"secs": now.secs,
-                u"nsecs": now.nsecs,
-                u"bytes": message._message._buff
-            }
-            outgoing_msg = encode_cbor(outgoing_msg)
+            outgoing_msg = message.get_cbor_raw(outgoing_msg)
         else:
             outgoing_msg["msg"] = message.get_json_values()
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -327,7 +327,7 @@ class Subscribe(Capability):
             outgoing_msg = {"op": "png", "data": encode_png(outgoing_msg_dumped)}
         elif compression=="cbor":
             outgoing_msg[u"msg"] = message.get_cbor_values()
-            outgoing_msg = bytearray(encode_cbor(outgoing_msg))
+            outgoing_msg = encode_cbor(outgoing_msg)
         elif compression=="cbor-raw":
             now = get_rostime()
             outgoing_msg[u"msg"] = {
@@ -335,11 +335,11 @@ class Subscribe(Capability):
                 u"nsecs": now.nsecs,
                 u"bytes": message._message._buff
             }
-            outgoing_msg = bytearray(encode_cbor(outgoing_msg))
+            outgoing_msg = encode_cbor(outgoing_msg)
         else:
             outgoing_msg["msg"] = message.get_json_values()
 
-        self.protocol.send(outgoing_msg)
+        self.protocol.send(outgoing_msg, compression=compression)
 
     def finish(self):
         for subscription in self._subscriptions.values():

--- a/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
+++ b/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
@@ -1,5 +1,10 @@
 from rosbridge_library.internal.message_conversion import extract_values as extract_json_values
 from rosbridge_library.internal.cbor_conversion import extract_cbor_values
+from rospy import get_rostime
+try:
+    from cbor import dumps as encode_cbor
+except ImportError:
+    from rosbridge_library.util.cbor import dumps as encode_cbor
 
 
 class OutgoingMessage:
@@ -8,6 +13,8 @@ class OutgoingMessage:
         self._message = message
         self._json_values = None
         self._cbor_values = None
+        self._cbor_msg = None
+        self._cbor_raw_msg = None
 
     @property
     def message(self):
@@ -22,3 +29,22 @@ class OutgoingMessage:
         if self._cbor_values is None:
             self._cbor_values = extract_cbor_values(self._message)
         return self._cbor_values
+
+    def get_cbor(self, outgoing_msg):
+        if self._cbor_msg is None:
+            outgoing_msg[u"msg"] = self.get_cbor_values()
+            self._cbor_msg = encode_cbor(outgoing_msg)
+
+        return self._cbor_msg
+
+    def get_cbor_raw(self, outgoing_msg):
+        if self._cbor_raw_msg is None:
+            now = get_rostime()
+            outgoing_msg[u"msg"] = {
+                u"secs": now.secs,
+                u"nsecs": now.nsecs,
+                u"bytes": self._message._buff
+            }
+            self._cbor_raw_msg = encode_cbor(outgoing_msg)
+
+        return self._cbor_raw_msg

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -236,7 +236,7 @@ class Protocol:
         """
         pass
 
-    def send(self, message, cid=None):
+    def send(self, message, cid=None, compression="none"):
         """ Called internally in preparation for sending messages to the client
 
         This method pre-processes the message then passes it to the overridden
@@ -247,7 +247,7 @@ class Protocol:
         cid     -- (optional) an associated id
 
         """
-        serialized = self.serialize(message, cid)
+        serialized = message if compression in ["cbor", "cbor-raw"] else self.serialize(message, cid)
         if serialized is not None:
             if self.png == "png":
                 # TODO: png compression on outgoing messages
@@ -266,15 +266,15 @@ class Protocol:
             if fragment_list != None:
                 for fragment in fragment_list:
                     if self.bson_only_mode:
-                        self.outgoing(bson.BSON.encode(fragment))
+                        self.outgoing(bson.BSON.encode(fragment), compression)
                     else:
-                        self.outgoing(json.dumps(fragment))
+                        self.outgoing(json.dumps(fragment), compression)
                     # okay to use delay here (sender's send()-function) because rosbridge is sending next request only to service provider when last one had finished)
                     #  --> if this was not the case this delay needed to be implemented in service-provider's (meaning message receiver's) send_message()-function in rosbridge_tcp.py)
                     time.sleep(self.delay_between_messages)
             # else send message as it is
             else:
-                self.outgoing(serialized)
+                self.outgoing(serialized, compression)
                 time.sleep(self.delay_between_messages)
 
     def finish(self):
@@ -303,7 +303,7 @@ class Protocol:
                 return msg
             if has_binary(msg) or self.bson_only_mode:
                 return bson.BSON.encode(msg)
-            else:    
+            else:
                 return json.dumps(msg)
         except:
             if cid is not None:

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -105,7 +105,7 @@ class TestSubscribe(unittest.TestCase):
 
         received = {"msg": None}
 
-        def send(outgoing):
+        def send(outgoing, **kwargs):
             received["msg"] = outgoing
 
         proto.send = send


### PR DESCRIPTION
**Public API Changes**
None

**Description**
This change avoids some unnecessary conversions when using `cbor`/`cbor-raw` compression, leading to a significantly perfomance boost.
Additionally, the cbor encoded message is now cached, to avoid encoding for every client that is subscribed to the topic.
