### PR TITLE
Add graceful shutdown

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -319,11 +319,10 @@ def main(args=None):
     node = Rosapi()
     try:
         rclpy.spin(node)
+        node.destroy_node()
+        rclpy.shutdown()
     except KeyboardInterrupt:
-        node.get_logger().info("Exiting due to SIGINT")
-
-    node.destroy_node()
-    rclpy.shutdown()
+        print("Exiting due to SIGINT")
 
 
 if __name__ == "__main__":

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -331,12 +331,12 @@ def main(args=None):
     spin_callback.start()
     try:
         start_hook()
+        node.destroy_node()
+        rclpy.shutdown()
     except KeyboardInterrupt:
-        node.get_logger().info("Exiting due to SIGINT")
-
-    node.destroy_node()
-    rclpy.shutdown()
-    shutdown_hook()  # shutdown hook to stop the server
+        print("Exiting due to SIGINT")
+    finally:
+        shutdown_hook()  # shutdown hook to stop the server
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Public API Changes**
None


**Description**
This patch adds graceful shutdown for the `rosapi/rosapi_node` and `rosbridge_server/rosbridge_websocket.py` nodes when a `SIGINT` is recieved (e.g. via `ctrl+c`). `rclpy` by default adds an sigint handler which takes care of the shutdown already.

Without this patch, the following exception logs are printed:

```
[rosbridge_websocket-1] Traceback (most recent call last):
[rosbridge_websocket-1]   File "/opt/ros2_ws/install/rosbridge_server/lib/rosbridge_server/rosbridge_websocket", line 343, in <module>
[rosbridge_websocket-1]     main()
[rosbridge_websocket-1]   File "/opt/ros2_ws/install/rosbridge_server/lib/rosbridge_server/rosbridge_websocket", line 338, in main
[rosbridge_websocket-1]     rclpy.shutdown()
[rosbridge_websocket-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 126, in shutdown
[rosbridge_websocket-1]     _shutdown(context=context)
[rosbridge_websocket-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/utilities.py", line 58, in shutdown
[rosbridge_websocket-1]     return context.shutdown()
[rosbridge_websocket-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/context.py", line 102, in shutdown
[rosbridge_websocket-1]     self.__context.shutdown()
[rosbridge_websocket-1] rclpy._rclpy_pybind11.RCLError: failed to shutdown: rcl_shutdown already called on the given context, at ./src/rcl/init.c:241
[rosapi_node-2] [INFO] [1664897157.258284532] [rosapi]: Exiting due to SIGINT
[rosapi_node-2] Failed to publish log message to rosout: publisher's context is invalid, at ./src/rcl/publisher.c:389
[rosapi_node-2] Traceback (most recent call last):
[rosapi_node-2]   File "/opt/ros2_ws/install/rosapi/lib/rosapi/rosapi_node", line 330, in <module>
[rosapi_node-2]     main()
[rosapi_node-2]   File "/opt/ros2_ws/install/rosapi/lib/rosapi/rosapi_node", line 326, in main
[rosapi_node-2]     rclpy.shutdown()
[rosapi_node-2]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 126, in shutdown
[rosapi_node-2]     _shutdown(context=context)
[rosapi_node-2]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/utilities.py", line 58, in shutdown
[rosapi_node-2]     return context.shutdown()
[rosapi_node-2]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/context.py", line 102, in shutdown
[rosapi_node-2]     self.__context.shutdown()
[rosapi_node-2] rclpy._rclpy_pybind11.RCLError: failed to shutdown: rcl_shutdown already called on the given context, at ./src/rcl/init.c:241

```
