### PR TITLE
Remove unnecessary checking of topic globs. (#793)

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -289,25 +289,6 @@ class Subscribe(Capability):
         self.basic_type_check(msg, self.unsubscribe_msg_fields)
 
         topic = msg["topic"]
-        if Subscribe.topics_glob is not None and Subscribe.topics_glob:
-            self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
-            match = False
-            for glob in Subscribe.topics_glob:
-                if fnmatch.fnmatch(topic, glob):
-                    self.protocol.log(
-                        "debug",
-                        "Found match with glob " + glob + ", continuing unsubscription...",
-                    )
-                    match = True
-                    break
-            if not match:
-                self.protocol.log(
-                    "warn",
-                    "No match found for topic, cancelling unsubscription from: " + topic,
-                )
-                return
-        else:
-            self.protocol.log("debug", "No topic security glob, not checking unsubscription.")
 
         if topic not in self._subscriptions:
             return
@@ -332,25 +313,6 @@ class Subscribe(Capability):
 
         """
         # TODO: fragmentation, proper ids
-        if Subscribe.topics_glob and Subscribe.topics_glob:
-            self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
-            match = False
-            for glob in Subscribe.topics_glob:
-                if fnmatch.fnmatch(topic, glob):
-                    self.protocol.log(
-                        "debug",
-                        "Found match with glob " + glob + ", continuing topic publish...",
-                    )
-                    match = True
-                    break
-            if not match:
-                self.protocol.log(
-                    "warn",
-                    "No match found for topic, cancelling topic publish to: " + topic,
-                )
-                return
-        else:
-            self.protocol.log("debug", "No topic security glob, not checking topic publish.")
 
         outgoing_msg = {"op": "publish", "topic": topic}
         if compression == "png":


### PR DESCRIPTION
This is a forward port of #793




**Public API Changes**
None


**Description**
From #793:

> We do not have to check the topic globs on each incoming ros message. It is enough to check if the topic is allowed to be subscribed in the actual subscribe call as the message callback method (publish) is only called when the topic is subscribed to.
