### PR TITLE
Skip unnecessary conversion for cbor/cbor-raw compression (#792)

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
+++ b/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
@@ -3,6 +3,11 @@ from rosbridge_library.internal.message_conversion import (
     extract_values as extract_json_values,
 )
 
+try:
+    from cbor import dumps as encode_cbor
+except ImportError:
+    from rosbridge_library.util.cbor import dumps as encode_cbor
+
 
 class OutgoingMessage:
     """A message wrapper for caching encoding operations."""
@@ -11,6 +16,8 @@ class OutgoingMessage:
         self._message = message
         self._json_values = None
         self._cbor_values = None
+        self._cbor_msg = None
+        self._cbor_raw_msg = None
 
     @property
     def message(self):
@@ -25,3 +32,16 @@ class OutgoingMessage:
         if self._cbor_values is None:
             self._cbor_values = extract_cbor_values(self._message)
         return self._cbor_values
+
+    def get_cbor(self, outgoing_msg):
+        if self._cbor_msg is None:
+            outgoing_msg["msg"] = self.get_cbor_values()
+            self._cbor_msg = encode_cbor(outgoing_msg)
+
+        return self._cbor_msg
+
+    def get_cbor_raw(self, outgoing_msg):
+        if self._cbor_raw_msg is None:
+            self._cbor_raw_msg = encode_cbor(outgoing_msg)
+
+        return self._cbor_raw_msg

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -97,7 +97,7 @@ class TestSubscribe(unittest.TestCase):
 
         received = {"msg": None}
 
-        def send(outgoing):
+        def send(outgoing, **kwargs):
             received["msg"] = outgoing
 
         proto.send = send

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -176,12 +176,11 @@ class RosbridgeWebSocket(WebSocketHandler):
         )
         self.incoming_queue.finish()
 
-    def send_message(self, message):
+    def send_message(self, message, compression="none"):
         if isinstance(message, bson.BSON):
             binary = True
-        elif isinstance(message, bytearray):
+        elif compression in ["cbor", "cbor-raw"]:
             binary = True
-            message = bytes(message)
         else:
             binary = False
 


### PR DESCRIPTION
Forward port of #792

**Public API Changes**
None

**Description**
From #792

> * Skip unnecessary conversion for cbor compression.
>
>This change avoids some unnecessary conversions when using cbor/cbor-raw compression, leading to a significantly perfomance boost.
>
> * Add caching for subscriptions with cbor compression.

Note that for python3, the performance boost is not that significant.
