### PR TITLE
Improve robustness for multiple client connections

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -209,18 +209,18 @@ class MultiSubscriber:
         """
         outgoing = OutgoingMessage(msg)
 
-        # Get the callbacks to call
-        if not callbacks:
-            with self.rlock:
-                callbacks = self.subscriptions.values()
+        with self.rlock:
+            callbacks = callbacks if callbacks else self.subscriptions.values()
 
-        # Pass the JSON to each of the callbacks
-        for callback in callbacks:
-            try:
-                callback(outgoing)
-            except Exception as exc:
-                # Do nothing if one particular callback fails except log it
-                self.node_handle.get_logger().error(f"Exception calling subscribe callback: {exc}")
+            # Pass the JSON to each of the callbacks
+            for callback in callbacks:
+                try:
+                    callback(outgoing)
+                except Exception as exc:
+                    # Do nothing if one particular callback fails except log it
+                    self.node_handle.get_logger().error(
+                        f"Exception calling subscribe callback: {exc}"
+                    )
 
     def _new_sub_callback(self, msg):
         """

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -192,7 +192,7 @@ class MultiSubscriber:
     def has_subscribers(self):
         """Return true if there are subscribers"""
         with self.lock:
-            return len(self.subscriptions) != 0
+            return len(self.subscriptions) + len(self.new_subscriptions) != 0
 
     def callback(self, msg, callbacks=None):
         """Callback for incoming messages on the rclpy subscription.

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -210,7 +210,7 @@ class MultiSubscriber:
         outgoing = OutgoingMessage(msg)
 
         with self.rlock:
-            callbacks = callbacks if callbacks else self.subscriptions.values()
+            callbacks = callbacks or self.subscriptions.values()
 
             # Pass the JSON to each of the callbacks
             for callback in callbacks:

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -208,7 +208,6 @@ class RosbridgeWebSocket(WebSocketHandler):
                 "WebSocketClosedError: Tried to write to a closed websocket",
                 throttle_duration_sec=1.0,
             )
-            raise
         except StreamClosedError:
             cls.node_handle.get_logger().warn(
                 "StreamClosedError: Tried to write to a closed stream",

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -208,6 +208,8 @@ class RosbridgeWebSocket(WebSocketHandler):
                 "WebSocketClosedError: Tried to write to a closed websocket",
                 throttle_duration_sec=1.0,
             )
+            # If we end up here, a client has disconnected before its message callback(s) could be removed.
+            # To avoid log spamming, we only log a warning and do not re-raise the exception here.
         except StreamClosedError:
             cls.node_handle.get_logger().warn(
                 "StreamClosedError: Tried to write to a closed stream",


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Supersedes #741
Fixes #783
Fixes #758

This PR improves multi-client connection robustness by 
- avoiding unregistering of subscribers if one client disconnects while all others are still waiting for the [initial callback](https://github.com/RobotWebTools/rosbridge_suite/blob/87b3bf0a1a69a9bcfad5f32cb75303881607a5f1/rosbridge_library/src/rosbridge_library/internal/subscribers.py#L222-L238)
- avoiding a deadlock that could occur when new clients connect, subscribe to a topic and then immediately disconnect again

---

The deadlock could be easily reproduced by rapidly connecting and disconnecting clients while one client was connected and receiving data.

```bash
# Create a client that stays connected
websocat ws://localhost:9090 --no--close < subscribe.json 

# Spawn a couple of clients that only sent the subscription operations and then disconnect
for i in {1..5}; do websocat ws://localhost:9090 < subscribe.json; done
```


`subscribe.json` (example):
```json
{ "op": "subscribe", "topic": "/ns_1/camera/color/image_raw", "type": "sensor_msgs/msg/Image" }
{ "op": "subscribe", "topic": "/ns_1/camera/depth/camera_info", "type": "sensor_msgs/msg/CameraInfo" }
```

