### PR TITLE
Fix send_message being called with wrong arguments.

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -266,15 +266,15 @@ class Protocol:
             if fragment_list != None:
                 for fragment in fragment_list:
                     if self.bson_only_mode:
-                        self.outgoing(bson.BSON.encode(fragment), compression)
+                        self.outgoing(bson.BSON.encode(fragment), compression=compression)
                     else:
-                        self.outgoing(json.dumps(fragment), compression)
+                        self.outgoing(json.dumps(fragment), compression=compression)
                     # okay to use delay here (sender's send()-function) because rosbridge is sending next request only to service provider when last one had finished)
                     #  --> if this was not the case this delay needed to be implemented in service-provider's (meaning message receiver's) send_message()-function in rosbridge_tcp.py)
                     time.sleep(self.delay_between_messages)
             # else send message as it is
             else:
-                self.outgoing(serialized, compression)
+                self.outgoing(serialized, compression=compression)
                 time.sleep(self.delay_between_messages)
 
     def finish(self):

--- a/rosbridge_server/src/rosbridge_server/tcp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/tcp_handler.py
@@ -33,7 +33,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
 
     def setup(self):
         """
-        Called before the handle() method to perform any initialization 
+        Called before the handle() method to perform any initialization
         actions required. The default implementation does nothing.
         """
         cls = self.__class__
@@ -130,7 +130,7 @@ class RosbridgeTcpSocket(SocketServer.BaseRequestHandler):
             cls.client_count_pub.publish(cls.clients_connected)
         self.protocol.log("info", "disconnected. " + str(cls.clients_connected) + " client total." )
 
-    def send_message(self, message=None):
+    def send_message(self, message=None, compression="none"):
         """
         Callback from rosbridge
         """

--- a/rosbridge_server/src/rosbridge_server/udp_handler.py
+++ b/rosbridge_server/src/rosbridge_server/udp_handler.py
@@ -93,7 +93,7 @@ class RosbridgeUdpSocket:
         if cls.client_count_pub:
             cls.client_count_pub.publish(cls.clients_connected)
         rospy.loginfo("Client disconnected. %d clients total.", cls.clients_connected)
-    def send_message(self, message):
+    def send_message(self, message, compression="none"):
         binary = type(message)==bson.BSON
         self.write(message)
     def check_origin(self, origin):

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -154,7 +154,7 @@ class RosbridgeWebSocket(WebSocketHandler):
             cls.client_manager.remove_client(self.client_id, self.request.remote_ip)
         rospy.loginfo("Client disconnected. %d clients total.", cls.clients_connected)
 
-    def send_message(self, message):
+    def send_message(self, message, compression="none"):
         if type(message) == bson.BSON:
             binary = True
         elif type(message) == bytearray:


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Fixes #811, a regression on the latest release when using TCP/UDP transport
