### PR TITLE
Bump minimum required cmake version to fix unstable builds.

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosapi)
 
 find_package(catkin REQUIRED COMPONENTS message_generation)

--- a/rosbridge_library/CMakeLists.txt
+++ b/rosbridge_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosbridge_library)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs geometry_msgs)

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosbridge_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosbridge_server)
 
 find_package(catkin REQUIRED)

--- a/rosbridge_suite/CMakeLists.txt
+++ b/rosbridge_suite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosbridge_suite)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Fixes unstable builds on the ros build farm. See also https://answers.ros.org/question/361001/how-to-fix-unstable-build-on-buildfarm-for-noetic-because-of-cmp0048/

Jenkins with unstable builds: https://build.ros.org/job/Ndev__rosbridge_suite__ubuntu_focal_amd64/