### PR TITLE
Removed global namespace from rosapi

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -88,46 +88,46 @@ class Rosapi(Node):
         else:
             full_name = self.get_namespace() + "/" + self.get_name()
         params.init(full_name)
-        self.create_service(Topics, "/rosapi/topics", self.get_topics)
-        self.create_service(TopicsForType, "/rosapi/topics_for_type", self.get_topics_for_type)
+        self.create_service(Topics, "rosapi/topics", self.get_topics)
+        self.create_service(TopicsForType, "rosapi/topics_for_type", self.get_topics_for_type)
         self.create_service(
             TopicsAndRawTypes,
-            "/rosapi/topics_and_raw_types",
+            "rosapi/topics_and_raw_types",
             self.get_topics_and_raw_types,
         )
-        self.create_service(Services, "/rosapi/services", self.get_services)
+        self.create_service(Services, "rosapi/services", self.get_services)
         self.create_service(
-            ServicesForType, "/rosapi/services_for_type", self.get_services_for_type
+            ServicesForType, "rosapi/services_for_type", self.get_services_for_type
         )
-        self.create_service(Nodes, "/rosapi/nodes", self.get_nodes)
-        self.create_service(NodeDetails, "/rosapi/node_details", self.get_node_details)
-        self.create_service(GetActionServers, "/rosapi/action_servers", self.get_action_servers)
-        self.create_service(TopicType, "/rosapi/topic_type", self.get_topic_type)
-        self.create_service(ServiceType, "/rosapi/service_type", self.get_service_type)
-        self.create_service(Publishers, "/rosapi/publishers", self.get_publishers)
-        self.create_service(Subscribers, "/rosapi/subscribers", self.get_subscribers)
+        self.create_service(Nodes, "rosapi/nodes", self.get_nodes)
+        self.create_service(NodeDetails, "rosapi/node_details", self.get_node_details)
+        self.create_service(GetActionServers, "rosapi/action_servers", self.get_action_servers)
+        self.create_service(TopicType, "rosapi/topic_type", self.get_topic_type)
+        self.create_service(ServiceType, "rosapi/service_type", self.get_service_type)
+        self.create_service(Publishers, "rosapi/publishers", self.get_publishers)
+        self.create_service(Subscribers, "rosapi/subscribers", self.get_subscribers)
         self.create_service(
-            ServiceProviders, "/rosapi/service_providers", self.get_service_providers
+            ServiceProviders, "rosapi/service_providers", self.get_service_providers
         )
-        self.create_service(ServiceNode, "/rosapi/service_node", self.get_service_node)
-        self.create_service(MessageDetails, "/rosapi/message_details", self.get_message_details)
+        self.create_service(ServiceNode, "rosapi/service_node", self.get_service_node)
+        self.create_service(MessageDetails, "rosapi/message_details", self.get_message_details)
         self.create_service(
             ServiceRequestDetails,
-            "/rosapi/service_request_details",
+            "rosapi/service_request_details",
             self.get_service_request_details,
         )
         self.create_service(
             ServiceResponseDetails,
-            "/rosapi/service_response_details",
+            "rosapi/service_response_details",
             self.get_service_response_details,
         )
-        self.create_service(SetParam, "/rosapi/set_param", self.set_param)
-        self.create_service(GetParam, "/rosapi/get_param", self.get_param)
-        self.create_service(HasParam, "/rosapi/has_param", self.has_param)
-        self.create_service(DeleteParam, "/rosapi/delete_param", self.delete_param)
-        self.create_service(GetParamNames, "/rosapi/get_param_names", self.get_param_names)
-        self.create_service(GetTime, "/rosapi/get_time", self.get_time)
-        self.create_service(GetROSVersion, "/rosapi/get_ros_version", self.get_ros_version)
+        self.create_service(SetParam, "rosapi/set_param", self.set_param)
+        self.create_service(GetParam, "rosapi/get_param", self.get_param)
+        self.create_service(HasParam, "rosapi/has_param", self.has_param)
+        self.create_service(DeleteParam, "rosapi/delete_param", self.delete_param)
+        self.create_service(GetParamNames, "rosapi/get_param_names", self.get_param_names)
+        self.create_service(GetTime, "rosapi/get_time", self.get_time)
+        self.create_service(GetROSVersion, "rosapi/get_ros_version", self.get_ros_version)
 
     def get_globs(self):
         return glob_helper.get_globs(self)

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -96,9 +96,7 @@ class Rosapi(Node):
             self.get_topics_and_raw_types,
         )
         self.create_service(Services, "rosapi/services", self.get_services)
-        self.create_service(
-            ServicesForType, "rosapi/services_for_type", self.get_services_for_type
-        )
+        self.create_service(ServicesForType, "rosapi/services_for_type", self.get_services_for_type)
         self.create_service(Nodes, "rosapi/nodes", self.get_nodes)
         self.create_service(NodeDetails, "rosapi/node_details", self.get_node_details)
         self.create_service(GetActionServers, "rosapi/action_servers", self.get_action_servers)

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -310,7 +310,7 @@ class RosbridgeWebsocketNode(Node):
 
         # To be able to access the list of topics and services, you must be able to access the rosapi services.
         if RosbridgeWebSocket.services_glob:
-            RosbridgeWebSocket.services_glob.append("/rosapi/*")
+            RosbridgeWebSocket.services_glob.append("rosapi/*")
 
         Subscribe.topics_glob = RosbridgeWebSocket.topics_glob
         Advertise.topics_glob = RosbridgeWebSocket.topics_glob


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Removed the global namespace from rosapi. Main motivation is mentioned in #810 

Adding namespace in launch file was not working as expected 