### PR TITLE
Release/0.11.16

### DIFF
--- a/rosapi/CHANGELOG.rst
+++ b/rosapi/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rosapi
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.11.16 (2022-10-18)
+--------------------
 * Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
 * Contributors: Hans-Joachim Krauch
 

--- a/rosapi/CHANGELOG.rst
+++ b/rosapi/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosapi
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
+* Contributors: Hans-Joachim Krauch
+
 0.11.15 (2022-10-06)
 --------------------
 

--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosapi</name>
-  <version>0.11.15</version>
+  <version>0.11.16</version>
   <description>
     Provides service calls for getting ros meta-information, like list of
     topics, services, params, etc.

--- a/rosbridge_library/CHANGELOG.rst
+++ b/rosbridge_library/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbridge_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
+* Fix send_message being called with wrong arguments. (`#812 <https://github.com/RobotWebTools/rosbridge_suite/issues/812>`_)
+* Contributors: Hans-Joachim Krauch
+
 0.11.15 (2022-10-06)
 --------------------
 * Remove unnecessary checking of topic globs. (`#793 <https://github.com/RobotWebTools/rosbridge_suite/issues/793>`_)

--- a/rosbridge_library/CHANGELOG.rst
+++ b/rosbridge_library/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rosbridge_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.11.16 (2022-10-18)
+--------------------
 * Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
 * Fix send_message being called with wrong arguments. (`#812 <https://github.com/RobotWebTools/rosbridge_suite/issues/812>`_)
 * Contributors: Hans-Joachim Krauch

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbridge_library</name>
-  <version>0.11.15</version>
+  <version>0.11.16</version>
   <description>
     The core rosbridge package, responsible for interpreting JSON and performing
     the appropriate ROS action, like subscribe, publish, call service, and

--- a/rosbridge_msgs/CHANGELOG.rst
+++ b/rosbridge_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbridge_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
+* Contributors: Hans-Joachim Krauch
+
 0.11.15 (2022-10-06)
 --------------------
 

--- a/rosbridge_msgs/CHANGELOG.rst
+++ b/rosbridge_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rosbridge_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.11.16 (2022-10-18)
+--------------------
 * Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
 * Contributors: Hans-Joachim Krauch
 

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbridge_msgs</name>
-  <version>0.11.15</version>
+  <version>0.11.16</version>
   <description>Package containing message files</description>
 
   <maintainer email="achim@intermodalics.eu">Hans-Joachim Krauch</maintainer>

--- a/rosbridge_server/CHANGELOG.rst
+++ b/rosbridge_server/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rosbridge_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.11.16 (2022-10-18)
+--------------------
 * Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
 * Fix send_message being called with wrong arguments. (`#812 <https://github.com/RobotWebTools/rosbridge_suite/issues/812>`_)
 * Contributors: Hans-Joachim Krauch

--- a/rosbridge_server/CHANGELOG.rst
+++ b/rosbridge_server/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbridge_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
+* Fix send_message being called with wrong arguments. (`#812 <https://github.com/RobotWebTools/rosbridge_suite/issues/812>`_)
+* Contributors: Hans-Joachim Krauch
+
 0.11.15 (2022-10-06)
 --------------------
 * Skip unnecessary conversion for cbor/cbor-raw compression (`#792 <https://github.com/RobotWebTools/rosbridge_suite/issues/792>`_)

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbridge_server</name>
-  <version>0.11.15</version>
+  <version>0.11.16</version>
   <description>A WebSocket interface to rosbridge.</description>
 
   <license>BSD</license>

--- a/rosbridge_suite/CHANGELOG.rst
+++ b/rosbridge_suite/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rosbridge_suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.11.16 (2022-10-18)
+--------------------
 * Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
 * Contributors: Hans-Joachim Krauch
 

--- a/rosbridge_suite/CHANGELOG.rst
+++ b/rosbridge_suite/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbridge_suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Bump minimum required cmake version. (`#814 <https://github.com/RobotWebTools/rosbridge_suite/issues/814>`_)
+* Contributors: Hans-Joachim Krauch
+
 0.11.15 (2022-10-06)
 --------------------
 

--- a/rosbridge_suite/package.xml
+++ b/rosbridge_suite/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbridge_suite</name>
-  <version>0.11.15</version>
+  <version>0.11.16</version>
   <description>
     Rosbridge provides a JSON API to ROS functionality for non-ROS programs.
     There are a variety of front ends that interface with rosbridge, including


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Prepares for a new release. This PR is required as a direct push to `ros1` is disabled.