### PR TITLE
Optimized large binary array publishing

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -299,6 +299,11 @@ def _to_binary_inst(msg):
         return list(standard_b64decode(msg))
     if isinstance(msg, list):
         return msg
+    if isinstance(msg, bytes):
+        # Using the frombytes() method with a memoryview of the data allows for zero copying of data thanks to Python's buffer protocol (HUGE time-saver for large arrays)
+        data = array.array('B')
+        data.frombytes(memoryview(msg))
+        return data
     return bytes(bytearray(msg))
 
 

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -301,7 +301,7 @@ def _to_binary_inst(msg):
         return msg
     if isinstance(msg, bytes):
         # Using the frombytes() method with a memoryview of the data allows for zero copying of data thanks to Python's buffer protocol (HUGE time-saver for large arrays)
-        data = array.array('B')
+        data = array.array("B")
         data.frombytes(memoryview(msg))
         return data
     return bytes(bytearray(msg))


### PR DESCRIPTION
**Public API Changes**
None


**Description**
In my use case for rosbridge, I am sending rosbridge a lot of sensor data (using bson) from an external simulator and want to publish the data on ROS. I recently noticed that publishing large binary arrays (size on the order of 10^5 or larger) is extremely slow on the ros2 branch (compared to using the ros1 branch with python 2). I was able to track down the source of the problem to the `rosbridge_library/internal/message_conversion.py` file. The issue is that once the bson message has been deserialized, rosbridge actually creates a copy of the binary data into the appropriate ROS message in the function `_to_binary_inst(msg)`, and then publishes the message. The act of copying large arrays from the decoded message into the ROS message is the bottleneck.

The few lines of code I added check if the incoming data array is of type bytes, in which case it leverages Python's buffer protocol to perform a zero copy of the data into the appropriate ROS message. This change applies to anyone wanting to publish large binary arrays of data (i.e. the message field is of type uint8[]  or char[]), such as camera or lidar data from an external source.

Without this change, copying an array of size 10^5 would take on the order of 10^-2 seconds. But with the change, the zero copy takes on the order of 10^-5 seconds (for the same amount of data). This is a HUGE speed-up.