### PR TITLE
Bounded strings field support.

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -284,7 +284,7 @@ def _to_inst(msg, rostype, roottype, inst=None, stack=[]):
         return _to_time_inst(msg, rostype, inst)
 
     if bounded_string_regex.match(rostype):
-        return inst
+        return msg
 
     # Check to see whether this is a primitive type
     if rostype in ros_primitive_types:

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -91,6 +91,7 @@ ros_primitive_types = [
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
 ros_binary_types = ["uint8[]", "char[]", "sequence<uint8>", "sequence<char>"]
 list_tokens = re.compile("<(.+?)>")
+bounded_string_regex = re.compile(r"string<(\d+)>")
 bounded_array_tokens = re.compile(r"(.+)\[.*\]")
 ros_binary_types_list_braces = [
     ("uint8[]", re.compile(r"uint8\[[^\]]*\]")),
@@ -210,6 +211,9 @@ def _from_inst(inst, rostype):
     if rostype in ros_time_types:
         return {"sec": inst.sec, "nanosec": inst.nanosec}
 
+    if bounded_string_regex.match(rostype):
+        return inst
+
     if bson_only_mode is None:
         bson_only_mode = rospy.get_param("~bson_only_mode", False)
     # Check for primitive types
@@ -278,6 +282,9 @@ def _to_inst(msg, rostype, roottype, inst=None, stack=[]):
     # Check the type for time or rostime
     if rostype in ros_time_types:
         return _to_time_inst(msg, rostype, inst)
+
+    if bounded_string_regex.match(rostype):
+        return inst
 
     # Check to see whether this is a primitive type
     if rostype in ros_primitive_types:

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -316,3 +316,23 @@ class TestMessageConversion(unittest.TestCase):
             ints = list(map(int, range(0, 16)))
             ret = test_float32_msg(rostype, ints)
             np.testing.assert_array_equal(ret, np.array(ints))
+
+    def test_bounded_strings(self):
+        def test_round_trip_conversion(rostype, data):
+            msg = {"data": data}
+            inst = ros_loader.get_message_instance(rostype)
+            c.populate_instance(msg, inst)
+            self.validate_instance(inst)
+            return inst.data
+
+        assert "GOAT" == test_round_trip_conversion("rosbridge_test_msgs/TestBoundedString", "GOAT")
+        assert "" == test_round_trip_conversion("rosbridge_test_msgs/TestBoundedString", "")
+        self.assertRaises(
+            Exception, test_round_trip_conversion, "rosbridge_test_msgs/TestBoundedString", 3
+        )
+        self.assertRaises(
+            Exception,
+            test_round_trip_conversion,
+            "rosbridge_test_msgs/TestBoundedString",
+            "toomanycharacters",
+        )

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/TestUInt8FixedSizeArray16.msg
   msg/TestFloat32Array.msg
   msg/TestFloat32BoundedArray.msg
+  msg/TestBoundedString.msg
   srv/AddTwoInts.srv
   srv/SendBytes.srv
   srv/TestArrayRequest.srv

--- a/rosbridge_test_msgs/msg/TestBoundedString.msg
+++ b/rosbridge_test_msgs/msg/TestBoundedString.msg
@@ -1,0 +1,1 @@
+string<=4 data


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Rosbridge did not support messages with bounded string fields, resulting in topic messages/services replies being silently dropped. I added (crudely) support for such string fields.

I could not find any reference to bounded strings at all, so I added a new regex that should match the bounded string cases and use regular python strings internally for such fields. I'm wasn't sure if the validation of the data should be handled by rosbridge, if so there is still some work left on this.

If someone that has a better overview of this part of rosbridge could chime in, please do!