### PR TITLE
Fix length-limited list types

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -90,7 +90,8 @@ ros_primitive_types = [
 ]
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
 ros_binary_types = ["uint8[]", "char[]", "sequence<uint8>", "sequence<char>"]
-list_tokens = re.compile("<(.+?)>")
+# Remove the list type wrapper, and length specifier, from rostypes i.e. sequence<double, 3>
+list_tokens = re.compile("<(.+?)(, \d+)?>")
 bounded_array_tokens = re.compile(r"(.+)\[.*\]")
 ros_binary_types_list_braces = [
     ("uint8[]", re.compile(r"uint8\[[^\]]*\]")),
@@ -392,7 +393,6 @@ def _to_object_inst(msg, rostype, roottype, clock, inst, stack):
         inst.stamp = clock.now().to_msg()
 
     inst_fields = inst.get_fields_and_field_types()
-
     for field_name in msg:
         # Add this field to the field stack
         field_stack = stack + [field_name]

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -91,7 +91,7 @@ ros_primitive_types = [
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
 ros_binary_types = ["uint8[]", "char[]", "sequence<uint8>", "sequence<char>"]
 # Remove the list type wrapper, and length specifier, from rostypes i.e. sequence<double, 3>
-list_tokens = re.compile("<(.+?)(, \d+)?>")
+list_tokens = re.compile(r"<(.+?)(, \d+)?>")
 bounded_array_tokens = re.compile(r"(.+)\[.*\]")
 ros_binary_types_list_braces = [
     ("uint8[]", re.compile(r"uint8\[[^\]]*\]")),

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -316,3 +316,21 @@ class TestMessageConversion(unittest.TestCase):
             ints = list(map(int, range(0, 16)))
             ret = test_float32_msg(rostype, ints)
             np.testing.assert_array_equal(ret, np.array(ints))
+
+    # Test a float32 array with a length with non-numeric characters in it
+    def test_float32_complexboundedarray(self):
+        def test_nestedboundedarray_msg(rostype, data):
+            msg = {"data": {"data": data}}
+            inst = ros_loader.get_message_instance(rostype)
+            c.populate_instance(msg, inst)
+            self.validate_instance(inst)
+            return inst.data
+
+        for msgtype in ["TestNestedBoundedArray"]:
+            rostype = "rosbridge_test_msgs/" + msgtype
+
+            # From List[float]
+            floats = list(map(float, range(0, 16)))
+            ret = test_nestedboundedarray_msg(rostype, floats)
+
+            self.assertEqual(c._from_inst(ret, rostype), {"data": floats})

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/TestUInt8FixedSizeArray16.msg
   msg/TestFloat32Array.msg
   msg/TestFloat32BoundedArray.msg
+  msg/TestNestedBoundedArray.msg
   srv/AddTwoInts.srv
   srv/SendBytes.srv
   srv/TestArrayRequest.srv

--- a/rosbridge_test_msgs/msg/TestNestedBoundedArray.msg
+++ b/rosbridge_test_msgs/msg/TestNestedBoundedArray.msg
@@ -1,0 +1,1 @@
+TestFloat32BoundedArray data


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Removes the `, N` length specifier at the end of list types like `sequence<type, length>`. Fixes issues with serializing `shape_msgs/Polygon`, which has a `float64[<=3]` field.

<!-- Link relevant GitHub issues -->
Fixes #910  