### PR TITLE
fix encode Exception a bytes-like object is required, not 'str'

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
+++ b/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from base64 import standard_b64decode, standard_b64encode
-from io import StringIO
+from io import BytesIO, StringIO
 from math import ceil, floor, sqrt
 
 from PIL import Image
@@ -46,10 +46,10 @@ def encode(string):
     while length < bytes_needed:
         string += "\n"
         length += 1
-    i = Image.frombytes("RGB", (int(width), int(height)), string)
-    buff = StringIO()
+    i = Image.frombytes("RGB", (int(width), int(height)), string.encode())
+    buff = BytesIO()
     i.save(buff, "png")
-    encoded = standard_b64encode(buff.getvalue())
+    encoded = standard_b64encode(buff.getvalue()).decode()
     return encoded
 
 


### PR DESCRIPTION
 - fix encode "a bytes-like object is required, not 'str'"