### PR TITLE
Disable fragmentation for binary cbor messages

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -254,7 +254,11 @@ class Protocol:
                 pass
 
             fragment_list = None
-            if self.fragment_size is not None and len(serialized) > self.fragment_size:
+            if (
+                self.fragment_size is not None
+                and len(serialized) > self.fragment_size
+                and compression not in ["cbor", "cbor-raw"]
+            ):
                 mid = message.get("id", None)
 
                 # TODO: think about splitting into fragments that have specified size including header-fields!


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Fix error while trying to fragment cbor-encoded binary messages.
This PR disables fragmentation when the used compression is `cbor` or `cbor-raw`, since it would otherwise only result in an error

<!-- Link relevant GitHub issues -->
Fixes #844
