### PR TITLE
Register `call_service` operation to run in its own thread

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -32,6 +32,7 @@
 
 import fnmatch
 from functools import partial
+from threading import Thread
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.services import ServiceCaller
@@ -52,7 +53,10 @@ class CallService(Capability):
         Capability.__init__(self, protocol)
 
         # Register the operations that this capability provides
-        protocol.register_operation("call_service", self.call_service)
+        # This calls the service in a separate thread so multiple services can be processed simultaneously.
+        protocol.register_operation(
+            "call_service", lambda msg: Thread(target=self.call_service, args=(msg,)).start()
+        )
 
     def call_service(self, message):
         # Pull out the ID

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -13,6 +13,7 @@
   <arg name="unregister_timeout" default="10.0" />
 
   <arg name="use_compression" default="false" />
+  <arg name="call_services_in_new_thread" default="false" />
 
   <arg name="topics_glob" default="" />
   <arg name="services_glob" default="" />
@@ -33,6 +34,7 @@
       <param name="max_message_size" value="$(var max_message_size)"/>
       <param name="unregister_timeout" value="$(var unregister_timeout)"/>
       <param name="use_compression" value="$(var use_compression)"/>
+      <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
 
       <param name="topics_glob" value="$(var topics_glob)"/>
       <param name="services_glob" value="$(var services_glob)"/>
@@ -49,6 +51,7 @@
       <param name="max_message_size" value="$(var max_message_size)"/>
       <param name="unregister_timeout" value="$(var unregister_timeout)"/>
       <param name="use_compression" value="$(var use_compression)"/>
+      <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
 
       <param name="topics_glob" value="$(var topics_glob)"/>
       <param name="services_glob" value="$(var services_glob)"/>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -174,6 +174,10 @@ class RosbridgeWebsocketNode(Node):
     def protocol_parameter_handling(self):
         RosbridgeWebSocket.use_compression = self.declare_parameter("use_compression", False).value
 
+        RosbridgeWebSocket.call_services_in_new_thread = self.declare_parameter(
+            "call_services_in_new_thread", False
+        ).value
+
         # get RosbridgeProtocol parameters
         RosbridgeWebSocket.fragment_timeout = self.declare_parameter(
             "fragment_timeout", RosbridgeWebSocket.fragment_timeout


### PR DESCRIPTION
**Public API Changes**
None

**Description**
I have changed the operation registered for `call_service` so that it's not blocking -- that is, the `CallService.call_service()` implementation now runs in its own separate thread.

This enables us to process multiple service calls in parallel, whereas right now the tools do them sequentially.

If folks are apprehensive about this blanket change, I could also envision allowing both options, so we could have a `call_service_blocking` operation that works as before, and a `call_service` that uses the changes from this PR... or some other way to configure things. Open to feedback!

Fixes #825
