### PR TITLE
Interpret call_services_in_new_thread as boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
     - `bloom-release --rosdistro galactic --track galactic rosbridge_suite`
     - `bloom-release --rosdistro rolling --track rolling rosbridge_suite`
 
-Once the PRs are merged, packages will be available for each distro after the next sync. Build/sync status can be viewed at: [foxy](http://repo.ros2.org/status_page/ros_foxy_default.html), [galactic](http://repo.ros2.org/status_page/ros_galactic_default.html), [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).
+Once the PRs are merged, packages will be available for each distro after the next sync. Build/sync status can be viewed at: [foxy](http://repo.ros2.org/status_page/ros_foxy_default.html), [galactic](http://repo.ros2.org/status_page/ros_galactic_default.html), [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html). 

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
     - `bloom-release --rosdistro galactic --track galactic rosbridge_suite`
     - `bloom-release --rosdistro rolling --track rolling rosbridge_suite`
 
-Once the PRs are merged, packages will be available for each distro after the next sync. Build/sync status can be viewed at: [foxy](http://repo.ros2.org/status_page/ros_foxy_default.html), [galactic](http://repo.ros2.org/status_page/ros_galactic_default.html), [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html). 
+Once the PRs are merged, packages will be available for each distro after the next sync. Build/sync status can be viewed at: [foxy](http://repo.ros2.org/status_page/ros_foxy_default.html), [galactic](http://repo.ros2.org/status_page/ros_galactic_default.html), [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -55,7 +55,7 @@ class CallService(Capability):
         # Register the operations that this capability provides
         call_services_in_new_thread = protocol.node_handle.get_parameter(
             "call_services_in_new_thread"
-        ).get_parameter_value()
+        ).get_parameter_value().bool_value
         if call_services_in_new_thread:
             # Calls the service in a separate thread so multiple services can be processed simultaneously.
             protocol.node_handle.get_logger().info("Calling services in new thread")

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -53,9 +53,11 @@ class CallService(Capability):
         Capability.__init__(self, protocol)
 
         # Register the operations that this capability provides
-        call_services_in_new_thread = protocol.node_handle.get_parameter(
-            "call_services_in_new_thread"
-        ).get_parameter_value().bool_value
+        call_services_in_new_thread = (
+            protocol.node_handle.get_parameter("call_services_in_new_thread")
+            .get_parameter_value()
+            .bool_value
+        )
         if call_services_in_new_thread:
             # Calls the service in a separate thread so multiple services can be processed simultaneously.
             protocol.node_handle.get_logger().info("Calling services in new thread")


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
I ran into an issue with having the `call_service` operation run in its own thread  (introduced in #847).  This is not a huge deal as there is a configuration option to turn it off.

However, changing the value of `call_services_in_new_thread` parameter in the `rosbridge_websocket_launch.xml` has no effect on whether or not that functionality is used.

The issue is the parameter object always evaluates to `True` instead of evaluating the value of the parameter object (which can be interpreted as a string, double, bool, etc.).  This change explicitly specifies how it should be interpreted which is probably what was intended when the parameter was introduced.

<!-- Link relevant GitHub issues -->
