### PR TITLE
Check if node info is None before unpacking

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -172,7 +172,7 @@ class Rosapi(Node):
             response.subscribing,
             response.publishing,
             response.services,
-        ) = proxy.get_node_info(request.node)
+        ) = proxy.get_node_info(request.node) or ([], [], [])
         return response
 
     def get_action_servers(self, request, response):

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -168,11 +168,9 @@ class Rosapi(Node):
 
     def get_node_details(self, request, response):
         """Called by the rosapi/Nodes service. Returns a node description"""
-        (
-            response.subscribing,
-            response.publishing,
-            response.services,
-        ) = proxy.get_node_info(request.node) or ([], [], [])
+        (response.subscribing, response.publishing, response.services,) = proxy.get_node_info(
+            request.node
+        ) or ([], [], [])
         return response
 
     def get_action_servers(self, request, response):


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
If node is None (e.g. because node name no longer exists), return empty response instead of trying to unpack NoneType object.

<!-- Link relevant GitHub issues -->
Fixes https://github.com/RobotWebTools/rosbridge_suite/issues/865