### PR TITLE
bugfix: topic list crashes if no topics are available

### DIFF
--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -65,9 +65,13 @@ def get_topics_and_types(topics_glob):
 
         # Add topics with unknown type messages.
         unknown_type = topics.difference([x for x, _ in topic_types])
-        return zip(* topic_types + [[x,''] for x in unknown_type])
+        topic_types.extend([[x, ''] for x in unknown_type])
+        if topic_types:
+            return zip(*topic_types)
+        else:
+            return [], []
     except:
-        return []
+        return [], []
 
 
 def get_topics_for_type(type, topics_glob):


### PR DESCRIPTION
**Public API Changes**
None


**Description**
This is due to the [function](https://github.com/RobotWebTools/rosbridge_suite/blob/b0d0d711931d8ab7a5f079f948ced8875b4dc5d9/rosapi/scripts/rosapi_node#L72) expecting an object unpackable to 2 iterables, but an empty iterable is returned if no topics are available.

This happens only when using glob, which might have been the reason why this bug was not caught earlier.
