### PR TITLE
fix CI: remove melodic and py2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-          - 2.7
           - 3.8
 
     name: Lint (python-${{ matrix.python_version }})
@@ -29,8 +28,6 @@ jobs:
         include:
           # Test supported ROS 1 distributions
           # http://wiki.ros.org/Distributions
-          - ros_distribution: melodic
-            os: ubuntu-18.04
           - ros_distribution: noetic
             os: ubuntu-20.04
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Removes melodic and python2.7 from CI, due to them being EOL.