### PR TITLE
Add CI build for ROS distro `iron`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             os: ubuntu-20.04
           - ros: humble
             os: ubuntu-22.04
+          - ros: iron
+            os: ubuntu-22.04
           - ros: rolling
             os: ubuntu-22.04
 


### PR DESCRIPTION
**Public API Changes**
Adds CI build for ROS distro `iron`.
