### PR TITLE
CI: Remove `foxy` and `galactic` builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
         include:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
-          - ros: foxy
-            os: ubuntu-20.04
-          - ros: galactic
-            os: ubuntu-20.04
           - ros: humble
             os: ubuntu-22.04
           - ros: iron


### PR DESCRIPTION
**Public API Changes**
CI: Remove `foxy` and `galactic` builds

**Description**
Required for latest `ros-tooling/setup-ros` (see https://github.com/RobotWebTools/rosbridge_suite/pull/872)