### PR TITLE
use permissive QoS to ensure compatibilty with publishers

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -106,13 +106,17 @@ class MultiSubscriber:
         # incompatible. Here we make a "best effort" attempt to match existing
         # publishers for the requested topic. This is not perfect because more
         # publishers may come online after our subscriber is set up, but we try
-        # to provide sane defaults. For more information, see:
+        # to provide sane defaults.
+        # For this reason we use volatile durability and best effort reliability
+        # to prioritize topic compatibility when the publisher policy is not known.
+        # For more information, see:
         # - https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
         # - https://github.com/RobotWebTools/rosbridge_suite/issues/551
+        # - https://github.com/RobotWebTools/rosbridge_suite/issues/769
         qos = QoSProfile(
             depth=10,
             durability=DurabilityPolicy.VOLATILE,
-            reliability=ReliabilityPolicy.RELIABLE,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
         )
 
         infos = node_handle.get_publishers_info_by_topic(topic)


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Changes the topic subscription default QoS reliability to `BEST_EFFORT` because a `BEST_EFFORT` subscription is compatible with both `BEST_EFFORT` and `RELIABLE` as opposed to `RELIABLE` which is only compatible with `RELIABLE` publishers.

<!-- Link relevant GitHub issues -->
This change addresses the issue with creating subscribers before a topic is published and ensures compatibility. See discussion at #769 