### PR TITLE
Timeout in service call_service if no response within server_timeout_time

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -117,7 +117,7 @@ def call_service(
     server_timeout_time: float = 1.0,
     sleep_time: float = 0.001,
 ) -> dict:
-    call_start_time = time.monotonic();
+    call_start_time = time.monotonic()
     # Given the service name, fetch the type and class of the service,
     # and a request instance
     service = expand_topic_name(service, node_handle.get_name(), node_handle.get_namespace())
@@ -146,8 +146,8 @@ def call_service(
     future = client.call_async(inst)
     while rclpy.ok() and not future.done():
         if call_start_time + server_timeout_time <= time.monotonic():
-            future.cancel();
-            break;
+            future.cancel()
+            break
         time.sleep(sleep_time)
     result = future.result()
 

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -116,7 +116,7 @@ class TestServiceCapabilities(unittest.TestCase):
         loop_iterations = 0
         while self.received_message is None:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            time.sleep(0.5)
+            time.sleep(0.1)
             loop_iterations += 1
             if loop_iterations > 3:
                 self.fail("Timed out waiting for service call message.")


### PR DESCRIPTION
**Public API Changes**
N/A

**Description**
Currently, if you attempt to call a service that has no active servers, then the client call will hang indefinitely blocking other calls. This does not appear to follow the intent of the timeout available.

You can test it by creating a client to a random service, e.g.:
`ros2 service call /Foo std_srvs/SetBool '{data: True}'`

Which will result in this "service" being listed even though there are no servers:
`ros2 service list` returns: `/Foo`

Then you call the websocket on the `/Foo` service (python)
```python
#!/usr/bin/env python    
    
from websockets.sync.client import connect    
    
def hello():    
    with connect("ws://localhost:9090") as websocket:    
        websocket.send("{ \"op\": \"call_service\",\"service\": \"/Foo\"}")          
        print("SENT");    
        message = websocket.recv()       
        print(f"Received: {message}")    
    
hello()
```

Before the change, this call will hang indefinitely. After the change, this will return after the timeout period has elapsed.

<!-- Link relevant GitHub issues -->
