### PR TITLE
fix list field bug

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -243,9 +243,9 @@ def _from_list_inst(inst, rostype):
         rostype = re.search(list_tokens, rostype).group(1)
     except AttributeError:
         rostype = re.search(bounded_array_tokens, rostype).group(1)
-    
+
     # Remove index number from rostype
-    rostype = rostype.split(',')[0]
+    rostype = rostype.split(",")[0]
 
     # Shortcut for primitives
     if rostype in ros_primitive_types:

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -243,6 +243,9 @@ def _from_list_inst(inst, rostype):
         rostype = re.search(list_tokens, rostype).group(1)
     except AttributeError:
         rostype = re.search(bounded_array_tokens, rostype).group(1)
+    
+    # Remove index number from rostype
+    rostype = rostype.split(',')[0]
 
     # Shortcut for primitives
     if rostype in ros_primitive_types:

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -380,6 +380,9 @@ def _to_list_inst(msg, rostype, roottype, clock, inst, stack):
     except AttributeError:
         rostype = re.search(bounded_array_tokens, rostype).group(1)
 
+    # Remove index number from rostype
+    rostype = rostype.split(",")[0]
+
     # Call to _to_inst for every element of the list
     return [_to_inst(x, rostype, roottype, clock, None, stack) for x in msg]
 


### PR DESCRIPTION
**Public API Changes**
None

**Description**
The issue was with the array's rostype being in a format like `<float, 1>`, which includes a number after the type separated by a comma. When this is passed to `_from_list_inst()`, it returns a rostype like `float, 1`, which does not qualify as a primitive type in the `_from_list_inst()` and `_from_inst()` methods.

As a solution, I added a patch in the `_from_list_inst()` method that treats the string before the comma as the rostype.

Relavant to: https://github.com/RobotWebTools/rosbridge_suite/issues/910
