### PR TITLE
Remove `ament_cmake_core` and `ament_cmake_ros` dependencies in message packages

### DIFF
--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22)
 project(rosbridge_msgs)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22)
 project(rosbridge_test_msgs)
 
-find_package(ament_cmake_core REQUIRED)
-find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Rolling CI has had a warning about `ament_cmake_core` and `ament_cmake_ros` not being included in the message definition packages, which... isn't needed.