### PR TITLE
fix: update new subs with dds from publisher

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -176,6 +176,11 @@ class MultiSubscriber:
             # In any case, the first message is handled using new_sub_callback,
             # which adds the new callback to the subscriptions dictionary.
             self.new_subscriptions.update({client_id: callback})
+            infos = self.node_handle.get_publishers_info_by_topic(self.topic)
+            if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
+                self.qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+            if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
+                self.qos.reliability = ReliabilityPolicy.BEST_EFFORT
             if self.new_subscriber is None:
                 self.new_subscriber = self.node_handle.create_subscription(
                     self.msg_class,


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->


**Description**
<!-- Describe what has changed, and motivation behind those changes -->
New subscribers that are made after a publish need to have the one-off subscriber have the matching DDS config of the existing publisher.

<!-- Link relevant GitHub issues -->
