### PR TITLE
Avoid stale subscription when unsubscribing during resubscription (#947)

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -196,7 +196,7 @@ class MultiSubscriber:
         with self.rlock:
             if client_id in self.new_subscriptions:
                 del self.new_subscriptions[client_id]
-            else:
+            if client_id in self.subscriptions:
                 del self.subscriptions[client_id]
 
     def has_subscribers(self):


### PR DESCRIPTION
**Public API Changes**
None

**Description**
If a client asks to subscribe to the same topic more than once, then disconnects, all subscriptions from that client should be torn down, not just the newest one.  Addresses #947 .