### PR TITLE
rosapi: Don't start parameter services that aren't spun (backport #944)

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -74,7 +74,9 @@ def init(parent_node_name):
     parent_node_basename = parent_node_name.split("/")[-1]
     param_node_name = f"{parent_node_basename}_params"
     _node = rclpy.create_node(
-        param_node_name, cli_args=["--ros-args", "-r", f"__node:={param_node_name}"]
+        param_node_name,
+        cli_args=["--ros-args", "-r", f"__node:={param_node_name}"],
+        start_parameter_services=False,
     )
     _parent_node_name = get_absolute_node_name(parent_node_name)
 


### PR DESCRIPTION
Backports #944 to the `humble` branch.
