### PR TITLE
Update ROS 2 distros in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
     - `bloom-release --rosdistro iron rosbridge_suite`
     - `bloom-release --rosdistro jazzy rosbridge_suite`
     - `bloom-release --rosdistro rolling rosbridge_suite`
-  
+
 Note that right now, the Humble release is tracked in the `humble` branch, while Iron and later are tracked in the `ros2` branch.
 
 Once the PRs are merged, packages will be available for each distro after the next sync.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
     - `bloom-release --rosdistro iron rosbridge_suite`
     - `bloom-release --rosdistro jazzy rosbridge_suite`
     - `bloom-release --rosdistro rolling rosbridge_suite`
+  
+Note that right now, the Humble release is tracked in the `humble` branch, while Iron and later are tracked in the `ros2` branch.
 
 Once the PRs are merged, packages will be available for each distro after the next sync.
 Build/sync status can be viewed at: [humble](http://repo.ros2.org/status_page/ros_humble_default.html), [iron](http://repo.ros2.org/status_page/ros_iron_default.html), [jazzy](http://repo.ros2.org/status_page/ros_jazzy_default.html), and [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ rosbridge_suite
 ===============
 
 [![ROS Humble version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#humble)
-[![ROS Iron version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#iron)
-[![ROS Jazzy version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#jazzy)
+[![ROS Iron version](https://img.shields.io/ros/v/iron/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#iron)
+[![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#jazzy)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#rolling)
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 rosbridge_suite
 ===============
 
-[![ROS Foxy version](https://img.shields.io/ros/v/foxy/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#foxy)
-[![ROS Galactic version](https://img.shields.io/ros/v/galactic/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#galactic)
 [![ROS Humble version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#humble)
+[![ROS Iron version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#iron)
+[![ROS Jazzy version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#jazzy)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#rolling)
 
 
@@ -55,8 +55,10 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
 2. Manually edit and clean up the changelogs. Commit the changes.
 3. Run `catkin_prepare_release --bump [major/minor/patch]` to bump versions in package.xml and push changes to origin.
 4. Run bloom-release commands to create PRs to update rosdistro:
-    - `bloom-release --rosdistro foxy --track foxy rosbridge_suite`
-    - `bloom-release --rosdistro galactic --track galactic rosbridge_suite`
-    - `bloom-release --rosdistro rolling --track rolling rosbridge_suite`
+    - `bloom-release --rosdistro humble rosbridge_suite`
+    - `bloom-release --rosdistro humble rosbridge_suite`
+    - `bloom-release --rosdistro jazzy rosbridge_suite`
+    - `bloom-release --rosdistro rolling rosbridge_suite`
 
-Once the PRs are merged, packages will be available for each distro after the next sync. Build/sync status can be viewed at: [foxy](http://repo.ros2.org/status_page/ros_foxy_default.html), [galactic](http://repo.ros2.org/status_page/ros_galactic_default.html), [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).
+Once the PRs are merged, packages will be available for each distro after the next sync.
+Build/sync status can be viewed at: [humble](http://repo.ros2.org/status_page/ros_humble_default.html), [iron](http://repo.ros2.org/status_page/ros_iron_default.html), [jazzy](http://repo.ros2.org/status_page/ros_jazzy_default.html), and [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
 3. Run `catkin_prepare_release --bump [major/minor/patch]` to bump versions in package.xml and push changes to origin.
 4. Run bloom-release commands to create PRs to update rosdistro:
     - `bloom-release --rosdistro humble rosbridge_suite`
-    - `bloom-release --rosdistro humble rosbridge_suite`
+    - `bloom-release --rosdistro iron rosbridge_suite`
     - `bloom-release --rosdistro jazzy rosbridge_suite`
     - `bloom-release --rosdistro rolling rosbridge_suite`
 


### PR DESCRIPTION
**Public API Changes**
N/A

**Description**
This PR updates the ROS 2 distros displayed in the repo's top-level README.