### PR TITLE
Remove first handler update as queue update is blocked

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -199,7 +199,7 @@ class Subscription:
             self.compression = "cbor-raw"
 
         with self.handler_lock:
-            self.handler = self.handler.set_throttle_rate(self.throttle_rate)
+            self.handler.set_throttle_rate(self.throttle_rate)
             self.handler = self.handler.set_queue_length(self.queue_length)
 
 


### PR DESCRIPTION
The queue length for the subscriber isn't set as the code doesn't get that far after setting the throttle rate and returning the updated handler.



**Public API Changes**
None


**Description**
Remove the first handle update. The throttle and queue_length stacked methods are still added correctly when updating the second queue_length option, via the conditional statements.

**Testing**

Without the change: ROS2 debug messages were added (node handle passed to lower classes) and showed the queue_length wasn't being set in `subscription_modifiers.py/MessageHandler.set_queue_length()

With the change added: Ran the bridge with a ROS image publisher and a bridged image subscriber. Setting the throttling rate, changed the image update rates, with or without queue length. Then setting slow throttling (300ms) with a large existing queue showed a long delay in image updates. With a very small queue, throttling effects were immediate.

<!-- Link relevant GitHub issues -->
None
