### PR TITLE
Drop support for ROS 2 Iron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
           # NOTE: Humble does not work on the `ros2` branch, so it is tested in its own branch.
-          - ros: iron
-            os: ubuntu-22.04
           - ros: jazzy
             os: ubuntu-24.04
           - ros: rolling

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ rosbridge_suite
 ===============
 
 [![ROS Humble version](https://img.shields.io/ros/v/humble/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#humble)
-[![ROS Iron version](https://img.shields.io/ros/v/iron/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#iron)
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#jazzy)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/rosbridge_suite)](https://index.ros.org/p/rosbridge_suite/github-RobotWebTools-rosbridge_suite/#rolling)
 
@@ -56,11 +55,10 @@ Releasing requires push access to [RobotWebTools/rosbridge_suite](https://github
 3. Run `catkin_prepare_release --bump [major/minor/patch]` to bump versions in package.xml and push changes to origin.
 4. Run bloom-release commands to create PRs to update rosdistro:
     - `bloom-release --rosdistro humble rosbridge_suite`
-    - `bloom-release --rosdistro iron rosbridge_suite`
     - `bloom-release --rosdistro jazzy rosbridge_suite`
     - `bloom-release --rosdistro rolling rosbridge_suite`
 
-Note that right now, the Humble release is tracked in the `humble` branch, while Iron and later are tracked in the `ros2` branch.
+Note that right now, the Humble release is tracked in the `humble` branch, while Jazzy and later are tracked in the `ros2` branch.
 
 Once the PRs are merged, packages will be available for each distro after the next sync.
-Build/sync status can be viewed at: [humble](http://repo.ros2.org/status_page/ros_humble_default.html), [iron](http://repo.ros2.org/status_page/ros_iron_default.html), [jazzy](http://repo.ros2.org/status_page/ros_jazzy_default.html), and [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).
+Build/sync status can be viewed at: [humble](http://repo.ros2.org/status_page/ros_humble_default.html), [jazzy](http://repo.ros2.org/status_page/ros_jazzy_default.html), and [rolling](http://repo.ros2.org/status_page/ros_rolling_default.html).

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -7,7 +7,7 @@ from threading import Thread
 import rclpy
 from action_msgs.msg import GoalStatus
 from example_interfaces.action._fibonacci import Fibonacci_FeedbackMessage
-from rclpy.executors import SingleThreadedExecutor
+from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from rosbridge_library.capabilities.action_feedback import ActionFeedback
@@ -25,7 +25,7 @@ from rosbridge_library.protocol import Protocol
 class TestActionCapabilities(unittest.TestCase):
     def setUp(self):
         rclpy.init()
-        self.executor = SingleThreadedExecutor()
+        self.executor = MultiThreadedExecutor()
         self.node = Node("test_action_capabilities")
         self.executor.add_node(self.node)
 
@@ -295,7 +295,6 @@ class TestActionCapabilities(unittest.TestCase):
         self.assertEqual(self.received_message["values"]["sequence"], [])
         self.assertEqual(self.received_message["status"], GoalStatus.STATUS_CANCELED)
 
-    @unittest.skip("Currently raises an exception not catchable by unittest, need to fix this")
     def test_unadvertise_action(self):
         # Advertise the action
         action_path = "/fibonacci_action_4"
@@ -340,8 +339,6 @@ class TestActionCapabilities(unittest.TestCase):
         self.assertTrue("id" in self.received_message)
 
         # Now unadvertise the action
-        # TODO: This raises an exception, likely because of the following rclpy issue:
-        # https://github.com/ros2/rclpy/issues/1098
         unadvertise_msg = loads(dumps({"op": "unadvertise_action", "action": action_path}))
         self.received_message = None
         self.unadvertise.unadvertise_action(unadvertise_msg)

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -97,9 +97,6 @@ class TestActionCapabilities(unittest.TestCase):
         )
         self.advertise.advertise_action(advertise_msg)
 
-    @unittest.skip(
-        reason="Currently fails in Iron due to https://github.com/ros2/rclpy/issues/1195. Unskip when Iron is EOL in Nov 2024."
-    )
     def test_execute_advertised_action(self):
         # Advertise the action
         action_path = "/fibonacci_action_2"
@@ -205,9 +202,6 @@ class TestActionCapabilities(unittest.TestCase):
         self.assertEqual(self.received_message["values"]["sequence"], [0, 1, 1, 2, 3, 5])
         self.assertEqual(self.received_message["status"], GoalStatus.STATUS_SUCCEEDED)
 
-    @unittest.skip(
-        reason="Currently fails in due to https://github.com/ros2/rclpy/issues/1195, need to fix this"
-    )
     def test_cancel_advertised_action(self):
         # Advertise the action
         action_path = "/fibonacci_action_3"


### PR DESCRIPTION
**Public API Changes**
None

**Description**
This PR removes support for ROS 2 Iron now that it's EOL.

Additionally, this lets us re-enable some unit tests that were previously failing on Iron.

<!-- Link relevant GitHub issues -->
