### PR TITLE
Fix infinite loop in QueueMessageHandler

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
@@ -163,6 +163,7 @@ class QueueMessageHandler(MessageHandler, Thread):
                     traceback.print_exc(file=sys.stderr)
         while self.time_remaining() == 0 and len(self.queue) > 0:
             try:
-                MessageHandler.handle_message(self, self.queue[0])
+                msg = self.queue.popleft()
+                MessageHandler.handle_message(self, msg)
             except Exception:
                 traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
**Public API Changes**
None


**Description**
It seems that when a client disconnects the following can happen:
1. [The rosbridge server calls `protocol.finish()`](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosbridge_server/src/rosbridge_server/websocket_handler.py#L111)
2. [The protocol calls `finish` on all capabilities](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosbridge_library/src/rosbridge_library/protocol.py#L287-L288)
3. [The `subscribe` capability calls `unregister` on all subscriptions](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py#L333-L334)
4. [The Subscription calls `finish` on all its message handlers](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py#L82)
5.  [The `QueueMessageHandler` tries to push all buffered messages](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py#L166) but it never pops the message from the queue so it just pushes the same message in an infinite loop.
 
This PR fixes the QueueMessageHandler finishing by adding the missing queue popping (Thanks @daisukes for this contribution).

This should fix #891 
 