### PR TITLE
Add timeout option to call_service messages

### DIFF
--- a/ROSBRIDGE_PROTOCOL.md
+++ b/ROSBRIDGE_PROTOCOL.md
@@ -436,7 +436,8 @@ Calls a ROS service.
   "service": <string>,
   (optional) "args": <list<json>>,
   (optional) "fragment_size": <int>,
-  (optional) "compression": <string>
+  (optional) "compression": <string>,
+  (optional) "timeout": <float>
 }
 ```
 
@@ -449,6 +450,7 @@ Calls a ROS service.
     before it is fragmented
  * **compression** – an optional string to specify the compression scheme to be
     used on messages. Valid values are "none" and "png"
+ * **timeout** – the time, in seconds, to wait for a response from the server
 
 
 Stops advertising an external ROS service server

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -81,6 +81,7 @@ class CallService(Capability):
         fragment_size = message.get("fragment_size", None)
         compression = message.get("compression", "none")
         args = message.get("args", [])
+        timeout = message.get("timeout", 5.0)
 
         if CallService.services_glob is not None and CallService.services_glob:
             self.protocol.log(
@@ -112,7 +113,14 @@ class CallService(Capability):
         e_cb = partial(self._failure, cid, service)
 
         # Run service caller in the same thread.
-        ServiceCaller(trim_servicename(service), args, s_cb, e_cb, self.protocol.node_handle).run()
+        ServiceCaller(
+            trim_servicename(service),
+            args,
+            timeout,
+            s_cb,
+            e_cb,
+            self.protocol.node_handle,
+        ).run()
 
     def _success(self, cid, service, fragment_size, compression, message):
         outgoing_message = {

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -52,6 +52,12 @@ class CallService(Capability):
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
+        self.default_timeout = (
+            protocol.node_handle.get_parameter("default_call_service_timeout")
+            .get_parameter_value()
+            .double_value
+        )
+
         # Register the operations that this capability provides
         call_services_in_new_thread = (
             protocol.node_handle.get_parameter("call_services_in_new_thread")
@@ -81,7 +87,7 @@ class CallService(Capability):
         fragment_size = message.get("fragment_size", None)
         compression = message.get("compression", "none")
         args = message.get("args", [])
-        timeout = message.get("timeout", 5.0)
+        timeout = message.get("timeout", self.default_timeout)
 
         if CallService.services_glob is not None and CallService.services_glob:
             self.protocol.log(

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -30,11 +30,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import time
 from threading import Thread, Condition
 from typing import Any, Callable, Optional
 
-import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.node import Node

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from threading import Condition, Thread
+from threading import Event, Thread
 from typing import Any, Callable, Optional
 
 from rclpy.callback_groups import ReentrantCallbackGroup
@@ -155,30 +155,27 @@ def call_service(
         raise InvalidServiceException(service)
 
     future = client.call_async(inst)
-    condition = Condition()
+    event = Event()
 
     def future_done_callback():
-        with condition:
-            condition.notify_all()
+        event.set()
 
-    future.add_done_callback(lambda future: future_done_callback())
+    future.add_done_callback(lambda _: future_done_callback())
 
-    with condition:
-        if not condition.wait_for(
-            lambda: future.done(),
-            timeout=(server_response_timeout if server_response_timeout > 0 else None),
-        ):
-            future.cancel()
-            node_handle.destroy_client(client)
-            raise Exception("Timeout exceeded while waiting for service response")
+    if not event.wait(timeout=(server_response_timeout if server_response_timeout > 0 else None)):
+        future.cancel()
+        node_handle.destroy_client(client)
+        raise Exception("Timeout exceeded while waiting for service response")
+
+    node_handle.destroy_client(client)
 
     result = future.result()
 
-    node_handle.destroy_client(client)
     if result is not None:
         # Turn the response into JSON and pass to the callback
         json_response = extract_values(result)
     else:
-        raise Exception("Service call returned None")
+        exception = future.exception()
+        raise Exception("Service call exception: " + str(exception))
 
     return json_response

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -58,6 +58,7 @@ class ServiceCaller(Thread):
         self,
         service: str,
         args: dict,
+        timeout: float,
         success_callback: Callable[[str, str, int, bool, Any], None],
         error_callback: Callable[[str, str, Exception], None],
         node_handle: Node,
@@ -71,6 +72,7 @@ class ServiceCaller(Thread):
         ordered list, or a dict of name-value pairs.  Anything else will be
         treated as though no arguments were provided (which is still valid for
         some kinds of service)
+        timeout -- the time, in seconds, to wait for a response from the server
         success_callback -- a callback to call with the JSON result of the
         service call
         error_callback   -- a callback to call if an error occurs.  The
@@ -81,6 +83,7 @@ class ServiceCaller(Thread):
         self.daemon = True
         self.service = service
         self.args = args
+        self.timeout = timeout
         self.success = success_callback
         self.error = error_callback
         self.node_handle = node_handle
@@ -88,7 +91,14 @@ class ServiceCaller(Thread):
     def run(self) -> None:
         try:
             # Call the service and pass the result to the success handler
-            self.success(call_service(self.node_handle, self.service, args=self.args))
+            self.success(
+                call_service(
+                    self.node_handle,
+                    self.service,
+                    args=self.args,
+                    server_response_timeout=self.timeout,
+                )
+            )
         except Exception as e:
             # On error, just pass the exception to the error handler
             self.error(e)
@@ -114,7 +124,8 @@ def call_service(
     node_handle: Node,
     service: str,
     args: Optional[dict] = None,
-    server_timeout_time: float = 1.0,
+    server_ready_timeout: float = 1.0,
+    server_response_timeout: float = 5.0,
     sleep_time: float = 0.001,
 ) -> dict:
     # Given the service name, fetch the type and class of the service,
@@ -141,13 +152,22 @@ def call_service(
         service_class, service, callback_group=ReentrantCallbackGroup()
     )
 
-    if not client.wait_for_service(server_timeout_time):
+    if not client.wait_for_service(server_ready_timeout):
         node_handle.destroy_client(client)
         raise InvalidServiceException(service)
 
     future = client.call_async(inst)
-    while rclpy.ok() and not future.done():
+    start_time = time.monotonic()
+    while (
+        rclpy.ok() and not future.done() and time.monotonic() - start_time < server_response_timeout
+    ):
         time.sleep(sleep_time)
+
+    if not future.done():
+        future.cancel()
+        node_handle.destroy_client(client)
+        raise Exception("Timeout exceeded while waiting for service response")
+
     result = future.result()
 
     node_handle.destroy_client(client)
@@ -155,6 +175,6 @@ def call_service(
         # Turn the response into JSON and pass to the callback
         json_response = extract_values(result)
     else:
-        raise Exception(result)
+        raise Exception("Service call returned None")
 
     return json_response

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from threading import Thread, Condition
+from threading import Condition, Thread
 from typing import Any, Callable, Optional
 
 from rclpy.callback_groups import ReentrantCallbackGroup

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import time
-from threading import Thread
+from threading import Thread, Condition
 from typing import Any, Callable, Optional
 
 import rclpy
@@ -72,7 +72,8 @@ class ServiceCaller(Thread):
         ordered list, or a dict of name-value pairs.  Anything else will be
         treated as though no arguments were provided (which is still valid for
         some kinds of service)
-        timeout -- the time, in seconds, to wait for a response from the server
+        timeout          -- the time, in seconds, to wait for a response from the server.
+                            A non-positive value means no timeout.
         success_callback -- a callback to call with the JSON result of the
         service call
         error_callback   -- a callback to call if an error occurs.  The
@@ -126,7 +127,6 @@ def call_service(
     args: Optional[dict] = None,
     server_ready_timeout: float = 1.0,
     server_response_timeout: float = 5.0,
-    sleep_time: float = 0.001,
 ) -> dict:
     # Given the service name, fetch the type and class of the service,
     # and a request instance
@@ -157,16 +157,22 @@ def call_service(
         raise InvalidServiceException(service)
 
     future = client.call_async(inst)
-    start_time = time.monotonic()
-    while (
-        rclpy.ok() and not future.done() and time.monotonic() - start_time < server_response_timeout
-    ):
-        time.sleep(sleep_time)
+    condition = Condition()
 
-    if not future.done():
-        future.cancel()
-        node_handle.destroy_client(client)
-        raise Exception("Timeout exceeded while waiting for service response")
+    def future_done_callback():
+        with condition:
+            condition.notify_all()
+
+    future.add_done_callback(lambda future: future_done_callback())
+
+    with condition:
+        if not condition.wait_for(
+            lambda: future.done(),
+            timeout=(server_response_timeout if server_response_timeout > 0 else None),
+        ):
+            future.cancel()
+            node_handle.destroy_client(client)
+            raise Exception("Timeout exceeded while waiting for service response")
 
     result = future.result()
 

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -40,6 +40,7 @@ class TestCallService(unittest.TestCase):
         self.executor.add_node(self.node)
 
         self.node.declare_parameter("call_services_in_new_thread", False)
+        self.node.declare_parameter("default_call_service_timeout", 5.0)
         self.node.declare_parameter("send_action_goals_in_new_thread", False)
 
         # Create service servers with a separate callback group

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -24,6 +24,13 @@ class TestCallService(unittest.TestCase):
         response.message = "called trigger service successfully"
         return response
 
+    def trigger_long_cb(self, request, response):
+        """Helper callback function for a long running test service with no arguments."""
+        time.sleep(0.5)
+        response.success = True
+        response.message = "called trigger service successfully"
+        return response
+
     def set_bool_cb(self, request, response):
         """Helper callback function for a test service with arguments."""
         response.success = request.data
@@ -51,6 +58,12 @@ class TestCallService(unittest.TestCase):
             self.trigger_cb,
             callback_group=self.cb_group,
         )
+        self.trigger_long_srv = self.node.create_service(
+            Trigger,
+            self.node.get_name() + "/trigger_long",
+            self.trigger_long_cb,
+            callback_group=self.cb_group,
+        )
         self.set_bool_srv = self.node.create_service(
             SetBool,
             self.node.get_name() + "/set_bool",
@@ -63,8 +76,9 @@ class TestCallService(unittest.TestCase):
 
     def tearDown(self):
         self.executor.remove_node(self.node)
-        self.node.destroy_node()
         self.executor.shutdown()
+        self.exec_thread.join()
+        self.node.destroy_node()
         rclpy.shutdown()
 
     def test_missing_arguments(self):
@@ -99,12 +113,6 @@ class TestCallService(unittest.TestCase):
 
         s.call_service(send_msg)
 
-        timeout = 1.0
-        start = time.time()
-        while time.time() - start < timeout:
-            if received["arrived"]:
-                break
-
         self.assertTrue(received["arrived"])
         values = received["msg"]["values"]
         self.assertEqual(values["success"], True)
@@ -135,12 +143,6 @@ class TestCallService(unittest.TestCase):
         proto.send = cb
 
         s.call_service(send_msg)
-
-        timeout = 1.0
-        start = time.time()
-        while time.time() - start < timeout:
-            if received["arrived"]:
-                break
 
         self.assertTrue(received["arrived"])
         values = received["msg"]["values"]
@@ -175,11 +177,45 @@ class TestCallService(unittest.TestCase):
 
         s.call_service(send_msg)
 
-        timeout = 1.0
-        start = time.time()
-        while time.time() - start < timeout:
-            if received["arrived"]:
-                break
+        self.assertTrue(received["arrived"])
+        self.assertFalse(received["msg"]["result"])
+
+    def test_call_service_timeout(self):
+
+        client = self.node.create_client(Trigger, self.trigger_long_srv.srv_name)
+        assert client.wait_for_service(1.0)
+
+        proto = Protocol("test_call_service_timeout", self.node)
+        s = CallService(proto)
+        send_msg = loads(
+            dumps({"op": "call_service", "service": self.trigger_long_srv.srv_name, "timeout": 2.0})
+        )
+
+        received = {"msg": None, "arrived": False}
+
+        def cb(msg, cid=None, compression="none"):
+            print("Received message")
+            received["msg"] = msg
+            received["arrived"] = True
+
+        proto.send = cb
+
+        s.call_service(send_msg)
+
+        self.assertTrue(received["arrived"])
+        self.assertTrue(received["msg"]["result"])
+        values = received["msg"]["values"]
+        self.assertEqual(values["success"], True)
+        self.assertEqual(values["message"], "called trigger service successfully")
+
+        send_msg = loads(
+            dumps({"op": "call_service", "service": self.trigger_long_srv.srv_name, "timeout": 0.1})
+        )
+        received = {"msg": None, "arrived": False}
+
+        s.call_service(send_msg)
 
         self.assertTrue(received["arrived"])
         self.assertFalse(received["msg"]["result"])
+        values = received["msg"]["values"]
+        self.assertEqual(values, "Timeout exceeded while waiting for service response")

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -113,12 +113,10 @@ class TestServiceCapabilities(unittest.TestCase):
         )
         Thread(target=self.call_service.call_service, args=(call_msg,)).start()
 
-        loop_iterations = 0
+        start_time = time.monotonic()
         while self.received_message is None:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            time.sleep(0.1)
-            loop_iterations += 1
-            if loop_iterations > 4:
+            if time.monotonic() - start_time > 0.3:
                 self.fail("Timed out waiting for service call message.")
 
         self.assertFalse(self.received_message is None)
@@ -141,12 +139,10 @@ class TestServiceCapabilities(unittest.TestCase):
         self.received_message = None
         self.response.service_response(response_msg)
 
-        loop_iterations = 0
+        start_time = time.monotonic()
         while self.received_message is None:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            time.sleep(0.5)
-            loop_iterations += 1
-            if loop_iterations > 4:
+            if time.monotonic() - start_time > 0.3:
                 self.fail("Timed out waiting for service response message.")
 
         self.assertFalse(self.received_message is None)
@@ -182,12 +178,10 @@ class TestServiceCapabilities(unittest.TestCase):
         self.received_message = None
         Thread(target=self.call_service.call_service, args=(call_msg,)).start()
 
-        loop_iterations = 0
+        start_time = time.monotonic()
         while self.received_message is None:
             rclpy.spin_once(self.node, timeout_sec=0.1)
-            time.sleep(0.5)
-            loop_iterations += 1
-            if loop_iterations > 3:
+            if time.monotonic() - start_time > 0.3:
                 self.fail("Timed out waiting for service call message.")
 
         self.assertFalse(self.received_message is None)
@@ -203,12 +197,10 @@ class TestServiceCapabilities(unittest.TestCase):
         self.unadvertise.unadvertise_service(unadvertise_msg)
 
         with self.assertRaises(RuntimeError) as context:
-            loop_iterations = 0
+            start_time = time.monotonic()
             while self.received_message is None:
                 rclpy.spin_once(self.node, timeout_sec=0.1)
-                time.sleep(0.5)
-                loop_iterations += 1
-                if loop_iterations > 3:
+                if time.monotonic() - start_time > 0.3:
                     self.fail("Timed out waiting for unadvertise service message.")
 
             self.assertTrue(f"Service {service_path} was unadvertised" in context.exception)

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -150,6 +150,62 @@ class TestServiceCapabilities(unittest.TestCase):
         self.assertEqual(self.received_message["op"], "service_response")
         self.assertTrue(self.received_message["result"])
 
+    def test_call_advertised_service_with_timeout(self):
+        # Advertise the service
+        service_path = "/set_bool_3"
+        advertise_msg = loads(
+            dumps(
+                {
+                    "op": "advertise_service",
+                    "type": "std_srvs/SetBool",
+                    "service": service_path,
+                }
+            )
+        )
+        self.received_message = None
+        self.advertise.advertise_service(advertise_msg)
+
+        # Call the advertised service using rosbridge
+        self.received_message = None
+        call_msg = loads(
+            dumps(
+                {
+                    "op": "call_service",
+                    "id": "foo",
+                    "service": service_path,
+                    "args": {"data": True},
+                    "timeout": 0.5,
+                }
+            )
+        )
+        Thread(target=self.call_service.call_service, args=(call_msg,)).start()
+
+        start_time = time.monotonic()
+        while self.received_message is None:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if time.monotonic() - start_time > 0.3:
+                self.fail("Timed out waiting for service call message.")
+
+        self.assertFalse(self.received_message is None)
+        self.assertTrue("op" in self.received_message)
+        self.assertEqual(self.received_message["op"], "call_service")
+        self.assertTrue("id" in self.received_message)
+
+        self.received_message = None
+
+        start_time = time.monotonic()
+        while self.received_message is None:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if time.monotonic() - start_time > 1.0:
+                self.fail("Timed out waiting for service response message.")
+
+        self.assertFalse(self.received_message is None)
+        self.assertEqual(self.received_message["op"], "service_response")
+        self.assertFalse(self.received_message["result"])
+        self.assertEqual(
+            self.received_message["values"], "Timeout exceeded while waiting for service response"
+        )
+
     def test_unadvertise_with_live_request(self):
         # Advertise the service
         service_path = "/set_bool_3"

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -23,6 +23,7 @@ class TestServiceCapabilities(unittest.TestCase):
         self.node = Node("test_service_capabilities")
 
         self.node.declare_parameter("call_services_in_new_thread", False)
+        self.node.declare_parameter("default_call_service_timeout", 5.0)
         self.node.declare_parameter("send_action_goals_in_new_thread", False)
 
         self.proto = Protocol(self._testMethodName, self.node)

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -118,7 +118,7 @@ class TestServiceCapabilities(unittest.TestCase):
             rclpy.spin_once(self.node, timeout_sec=0.1)
             time.sleep(0.1)
             loop_iterations += 1
-            if loop_iterations > 3:
+            if loop_iterations > 4:
                 self.fail("Timed out waiting for service call message.")
 
         self.assertFalse(self.received_message is None)
@@ -146,7 +146,7 @@ class TestServiceCapabilities(unittest.TestCase):
             rclpy.spin_once(self.node, timeout_sec=0.1)
             time.sleep(0.5)
             loop_iterations += 1
-            if loop_iterations > 3:
+            if loop_iterations > 4:
                 self.fail("Timed out waiting for service response message.")
 
         self.assertFalse(self.received_message is None)

--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -52,6 +52,7 @@ class ServiceTester:
         thread = services.ServiceCaller(
             self.name,
             gen,
+            5.0,
             self.success,
             self.error,
             self.node,
@@ -201,6 +202,7 @@ class TestServices(unittest.TestCase):
         services.ServiceCaller(
             self.node.get_name() + "/list_parameters",
             None,
+            5.0,
             success,
             error,
             self.node,

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -17,6 +17,7 @@
 
   <arg name="use_compression" default="false" />
   <arg name="call_services_in_new_thread" default="false" />
+  <arg name="default_call_service_timeout" default="5.0" />
   <arg name="send_action_goals_in_new_thread" default="false" />
 
   <arg name="topics_glob" default="" />
@@ -42,6 +43,7 @@
       <param name="unregister_timeout" value="$(var unregister_timeout)"/>
       <param name="use_compression" value="$(var use_compression)"/>
       <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
+      <param name="default_call_service_timeout" value="$(var default_call_service_timeout)"/>
       <param name="send_action_goals_in_new_thread" value="$(var send_action_goals_in_new_thread)"/>
 
       <param name="topics_glob" value="$(var topics_glob)"/>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -178,6 +178,10 @@ class RosbridgeWebsocketNode(Node):
             "call_services_in_new_thread", False
         ).value
 
+        RosbridgeWebSocket.default_call_service_timeout = self.declare_parameter(
+            "default_call_service_timeout", 5.0
+        ).value
+
         RosbridgeWebSocket.send_action_goals_in_new_thread = self.declare_parameter(
             "send_action_goals_in_new_thread", False
         ).value

--- a/rosbridge_server/test/websocket/call_service.test.py
+++ b/rosbridge_server/test/websocket/call_service.test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import time
 import unittest
 
 from rclpy.callback_groups import ReentrantCallbackGroup
@@ -53,5 +54,57 @@ class TestCallService(unittest.TestCase):
         self.assertEqual(responses[0]["service"], "/test_service")
         self.assertEqual(responses[0]["values"], {"success": True, "message": "Hello, world!"})
         self.assertEqual(responses[0]["result"], True)
+
+        node.destroy_service(service)
+
+        def service_long_cb(req, res):
+            time.sleep(0.2)
+            self.assertTrue(req.data)
+            res.success = True
+            res.message = "Hello, world!"
+            return res
+
+        service = node.create_service(
+            SetBool, "/test_service_long", service_long_cb, callback_group=ReentrantCallbackGroup()
+        )
+
+        responses_future, ws_client.message_handler = expect_messages(
+            2, "WebSocket", node.get_logger()
+        )
+        responses_future.add_done_callback(lambda _: node.executor.wake())
+
+        ws_client.sendJson(
+            {
+                "op": "call_service",
+                "type": "std_srvs/SetBool",
+                "service": "/test_service_long",
+                "args": {"data": True},
+                "timeout": 0.1,
+            }
+        )
+
+        ws_client.sendJson(
+            {
+                "op": "call_service",
+                "type": "std_srvs/SetBool",
+                "service": "/test_service_long",
+                "args": {"data": True},
+                "timeout": 0.5,
+            }
+        )
+
+        responses = await responses_future
+        self.assertEqual(len(responses), 2)
+        self.assertEqual(responses[0]["op"], "service_response")
+        self.assertEqual(responses[0]["service"], "/test_service_long")
+        self.assertEqual(
+            responses[0]["values"], "Timeout exceeded while waiting for service response"
+        )
+        self.assertEqual(responses[0]["result"], False)
+
+        self.assertEqual(responses[1]["op"], "service_response")
+        self.assertEqual(responses[1]["service"], "/test_service_long")
+        self.assertEqual(responses[1]["values"], {"success": True, "message": "Hello, world!"})
+        self.assertEqual(responses[1]["result"], True)
 
         node.destroy_service(service)


### PR DESCRIPTION
**Public API Changes**
Adds `timeout` option to `call_service` messages

**Description**
If during calling a service, the Service Server dies, the ServiceCaller will get stuck waiting for response. This also makes the whole protocol stuck if `call_services_in_new_threads` option is not set.

This PR adds a response timeout parameter to ServiceCaller and adds an optional `timeout` option to `call_service` messages with a default value of 5 seconds.

If the API change gets accepted I will finish this PR by adding tests that cover this feature