### PR TITLE
Fix infinite loop in QueueMessageHandler (backport #983)

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
@@ -163,6 +163,7 @@ class QueueMessageHandler(MessageHandler, Thread):
                     traceback.print_exc(file=sys.stderr)
         while self.time_remaining() == 0 and len(self.queue) > 0:
             try:
-                MessageHandler.handle_message(self, self.queue[0])
+                msg = self.queue.popleft()
+                MessageHandler.handle_message(self, msg)
             except Exception:
                 traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
backports #983 to `humble` branch