### PR TITLE
Add new service to retrieve the different interfaces in the ROS Network

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -48,6 +48,7 @@ from rosapi_msgs.srv import (
     GetROSVersion,
     GetTime,
     HasParam,
+    Interfaces,
     MessageDetails,
     NodeDetails,
     Nodes,
@@ -89,6 +90,7 @@ class Rosapi(Node):
             full_name = self.get_namespace() + "/" + self.get_name()
         params.init(full_name)
         self.create_service(Topics, "/rosapi/topics", self.get_topics)
+        self.create_service(Interfaces, "/rosapi/interfaces", self.get_interfaces)
         self.create_service(TopicsForType, "/rosapi/topics_for_type", self.get_topics_for_type)
         self.create_service(
             TopicsAndRawTypes,
@@ -135,6 +137,11 @@ class Rosapi(Node):
     def get_topics(self, request, response):
         """Called by the rosapi/Topics service. Returns a list of all the topics being published."""
         response.topics, response.types = proxy.get_topics_and_types(self.globs.topics)
+        return response
+
+    def get_interfaces(self, request, response):
+        """Called by the rosapi/Types service. Returns a list of all the types in the system."""
+        response.interfaces = proxy.get_interfaces()
         return response
 
     def get_topics_for_type(self, request, response):

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -31,6 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from ros2interface.api import type_completer
 from ros2node.api import (
     get_node_names,
     get_publisher_info,
@@ -58,6 +59,11 @@ def get_topics(topics_glob, include_hidden=False):
     """Returns a list of all the active topics in the ROS system"""
     topic_names = get_topic_names(node=_node, include_hidden_topics=include_hidden)
     return filter_globs(topics_glob, topic_names)
+
+
+def get_interfaces():
+    """Returns a list of all the types in the ROS system"""
+    return type_completer()
 
 
 def get_topics_and_types(topics_glob, include_hidden=False):

--- a/rosapi_msgs/CMakeLists.txt
+++ b/rosapi_msgs/CMakeLists.txt
@@ -14,6 +14,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/GetROSVersion.srv
   srv/GetTime.srv
   srv/HasParam.srv
+  srv/Interfaces.srv
   srv/MessageDetails.srv
   srv/Nodes.srv
   srv/NodeDetails.srv

--- a/rosapi_msgs/srv/Interfaces.srv
+++ b/rosapi_msgs/srv/Interfaces.srv
@@ -1,0 +1,2 @@
+---
+string[] interfaces


### PR DESCRIPTION
**Public API Changes**

- Add a service to retrieve the different interfaces in the ROS network. Returned as an array of string

**Description**

Service : `/rosapi/interfaces`
Service type: `rosapi_msgs/srv/Interfaces`

```
---
string[] interfaces
```

This addition provides a new service that complements existing rosapi services. While rosapi allows retrieving topics, services, and their types, it lacked the ability to obtain a list of all available types. This new service addresses that gap.