### PR TITLE
Default subscriber QOS to BestEffort, account for TRANSIENT_LOCAL

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -106,13 +106,17 @@ class MultiSubscriber:
         # incompatible. Here we make a "best effort" attempt to match existing
         # publishers for the requested topic. This is not perfect because more
         # publishers may come online after our subscriber is set up, but we try
-        # to provide sane defaults. For more information, see:
+        # to provide sane defaults.
+        # For this reason we use volatile durability and best effort reliability
+        # to prioritize topic compatibility when the publisher policy is not known.
+        # For more information, see:
         # - https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
         # - https://github.com/RobotWebTools/rosbridge_suite/issues/551
+        # - https://github.com/RobotWebTools/rosbridge_suite/issues/769
         qos = QoSProfile(
             depth=10,
             durability=DurabilityPolicy.VOLATILE,
-            reliability=ReliabilityPolicy.RELIABLE,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
         )
 
         infos = node_handle.get_publishers_info_by_topic(topic)

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -122,6 +122,7 @@ class MultiSubscriber:
         infos = node_handle.get_publishers_info_by_topic(topic)
         if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
             qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+            qos.reliability = ReliabilityPolicy.RELIABLE
         if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
             qos.reliability = ReliabilityPolicy.BEST_EFFORT
 


### PR DESCRIPTION
**Public API Changes**
Change default subscriber QosProfile from reliability=ReliabilityPolicy.RELIABLE to reliability=ReliabilityPolicy.BEST_EFFORT.

BUT if a publisher is found to have  durability = DurabilityPolicy.TRANSIENT_LOCAL, then use reliability=ReliabilityPolicy.RELIABLE


**Description**
IMO the current "sane" defaults for a subscriber are not great for unreliable links and/or large messages and are not compatible with publisher policy is not yet known.

<!-- Link relevant GitHub issues -->
Relates to https://github.com/RobotWebTools/rosbridge_suite/issues/769
