### PR TITLE
Call services and send action goals in new threads by default

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -18,7 +18,7 @@
   <arg name="use_compression" default="false" />
   <arg name="call_services_in_new_thread" default="true" />
   <arg name="default_call_service_timeout" default="5.0" />
-  <arg name="send_action_goals_in_new_thread" default="false" />
+  <arg name="send_action_goals_in_new_thread" default="true" />
 
   <arg name="topics_glob" default="" />
   <arg name="services_glob" default="" />

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -16,7 +16,7 @@
   <arg name="unregister_timeout" default="10.0" />
 
   <arg name="use_compression" default="false" />
-  <arg name="call_services_in_new_thread" default="false" />
+  <arg name="call_services_in_new_thread" default="true" />
   <arg name="default_call_service_timeout" default="5.0" />
   <arg name="send_action_goals_in_new_thread" default="false" />
 

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -183,7 +183,7 @@ class RosbridgeWebsocketNode(Node):
         ).value
 
         RosbridgeWebSocket.send_action_goals_in_new_thread = self.declare_parameter(
-            "send_action_goals_in_new_thread", False
+            "send_action_goals_in_new_thread", True
         ).value
 
         # get RosbridgeProtocol parameters

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -175,7 +175,7 @@ class RosbridgeWebsocketNode(Node):
         RosbridgeWebSocket.use_compression = self.declare_parameter("use_compression", False).value
 
         RosbridgeWebSocket.call_services_in_new_thread = self.declare_parameter(
-            "call_services_in_new_thread", False
+            "call_services_in_new_thread", True
         ).value
 
         RosbridgeWebSocket.default_call_service_timeout = self.declare_parameter(


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Since we've already made some breaking changes for Jazzy, I would also like to change the default value of `call_services_in_new_thread` parameter to true. IMO it gives better out-of-box experience.