### PR TITLE
deal with uint8[] as binary data not string

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -132,11 +132,10 @@ def populate_instance(msg, inst):
 
 def _from_inst(inst, rostype):
     global bson_only_mode
-    # Special case for uint8[], we encode the string
+    # Special case for uint8[]
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
-            encoded = get_encoder()(inst)
-            return encoded if python2 else encoded.decode('ascii')
+            return inst
 
     # Check for time or duration
     if rostype in ros_time_types:

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -135,7 +135,7 @@ def _from_inst(inst, rostype):
     # Special case for uint8[]
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
-            return inst
+            return _to_binary_inst(inst)
 
     # Check for time or duration
     if rostype in ros_time_types:


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
returning the uint8[] as it is since this in ros depicts the image's raw data hence, it is binary not string, so no need for encoding or decoding.

<!-- Link relevant GitHub issues -->
this solves #1002
