### PR TITLE
Fix randomly failing subscribe unsubscribe test

### DIFF
--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -93,6 +93,7 @@ class TestMultiSubscriber(unittest.TestCase):
         self.assertEqual(len(multi.new_subscriptions), 0)
 
         multi.unregister()
+        time.sleep(0.1)
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
     def test_subscribe_receive_json(self):


### PR DESCRIPTION
This test keeps randomly failing in Github actions and it's starting to drive me nuts