### PR TITLE
fix: add url_path parameter in rosbridge_websocket_launch.xml (backport of #963)

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="port" default="9090" />
   <arg name="address" default="" />
+  <arg name="url_path" default="/" />
   <arg name="ssl" default="false" />
   <arg name="certfile" default=""/>
   <arg name="keyfile" default="" />
@@ -31,6 +32,7 @@
       <param name="keyfile" value="$(var keyfile)" />
       <param name="port" value="$(var port)"/>
       <param name="address" value="$(var address)"/>
+      <param name="url_path" value="$(var url_path)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>
       <param name="fragment_timeout" value="$(var fragment_timeout)"/>
       <param name="delay_between_messages" value="$(var delay_between_messages)"/>
@@ -50,6 +52,7 @@
     <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen">
       <param name="port" value="$(var port)"/>
       <param name="address" value="$(var address)"/>
+      <param name="url_path" value="$(var url_path)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>
       <param name="fragment_timeout" value="$(var fragment_timeout)"/>
       <param name="delay_between_messages" value="$(var delay_between_messages)"/>


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
Added `url_path` parameter in rosbridge_websocket_launch.xml.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
The ‵url_path‵ parameter is missing in the `ros2 launch` XML file, though it can be used in `ros2 run`.
This fix was previously PR'd in the `ros2` branch, now backported to `humble`.

Use case:

> `ros2 launch rosbridge_server rosbridge_websocket_launch.xml url_path:=/ws`

The client should connect to `ws://<ip>/ws` without problem.
Thanks!
