### PR TITLE
Fix array-like parameter serialization in rosbridge get_param

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -31,6 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import array
 import fnmatch
 from json import dumps, loads
 
@@ -163,6 +164,12 @@ async def get_param(node_name: str, name: str, params_glob: str) -> str:
     node_name = get_absolute_node_name(node_name)
     pvalue = await _get_param(node_name, name)
     value = getattr(pvalue, _parameter_type_mapping[pvalue.type])
+
+    # Convert array types to lists for JSON serialization
+    if hasattr(value, "tolist"):  # This will catch numpy arrays and Python arrays
+        value = value.tolist()
+    elif isinstance(value, array.array):
+        value = list(value)
 
     return dumps(value)
 

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -31,7 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import array
 import fnmatch
 from json import dumps, loads
 

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -168,8 +168,6 @@ async def get_param(node_name: str, name: str, params_glob: str) -> str:
     # Convert array types to lists for JSON serialization
     if hasattr(value, "tolist"):  # This will catch numpy arrays and Python arrays
         value = value.tolist()
-    elif isinstance(value, array.array):
-        value = list(value)
 
     return dumps(value)
 


### PR DESCRIPTION
This PR enhances the parameter value handling in the get_param function to ensure proper JSON serialization of array-like data types. Previously, when retrieving parameters that contained array-like values (such as numpy arrays, Python arrays, or simple numeric values that should be treated as single-element arrays), they might not be properly serialized to JSON format, resulting in empty strings or invalid representations.

The changes include:
- Adding proper array type detection and conversion prior to JSON serialization
- Converting objects with a tolist() method (e.g., numpy arrays) to Python lists
- Converting Python array objects to regular lists

This fix improves interoperability between ROS parameters and JSON-based web interfaces, ensuring that parameter values are consistently and correctly serialized, especially for numeric array parameters commonly used in robotics applications.


The issue can be reproduced by calling a get_param for a a vector value. Previously the value would come back as an empty string:

``` 
# Before fix - parameter retrieval via rosbridge
   $ ros2 param get /velocity_force_controller max_cartesian_velocity
   Double values are: array('d', [0.25, 0.25, 0.25, 1.5707, 1.5707, 1.5707])
   
   # But when accessed through rosbridge API:
   Value: ""
```   

After this PR, the parameter is properly converted to a JSON serializable format:

```
# After fix - parameter retrieval via rosbridge
$ ros2 param get /velocity_force_controller max_cartesian_velocity
Double values are: array('d', [0.25, 0.25, 0.25, 1.5707, 1.5707, 1.5707])

# When accessed through rosbridge API:
Value: [0.25, 0.25, 0.25, 1.5707, 1.5707, 1.5707]
```
