### PR TITLE
Set subscriber depth to max from publishers

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -120,6 +120,8 @@ class MultiSubscriber:
         )
 
         infos = node_handle.get_publishers_info_by_topic(topic)
+        if infos:
+            qos.depth = max([10, max(pub.qos_profile.depth for pub in infos)])
         if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
             qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
             qos.reliability = ReliabilityPolicy.RELIABLE


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Set the max depth of a subscriber to the maximum max depth of all publishers. Currently, if a publisher has a depth higher than 10 the messages will be lost. 