### PR TITLE
Add services to return Action interface details

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -44,6 +44,9 @@ from rclpy.qos import qos_profile_parameters
 from rosapi import glob_helper, objectutils, params, proxy
 from rosapi_msgs.msg import TypeDef
 from rosapi_msgs.srv import (
+    ActionFeedbackDetails,
+    ActionGoalDetails,
+    ActionResultDetails,
     DeleteParam,
     GetActionServers,
     GetParam,
@@ -129,6 +132,21 @@ class Rosapi(Node):
             ServiceResponseDetails,
             "~/service_response_details",
             self.get_service_response_details,
+        )
+        self.create_service(
+            ActionGoalDetails,
+            "~/action_goal_details",
+            self.get_action_goal_details,
+        )
+        self.create_service(
+            ActionResultDetails,
+            "~/action_result_details",
+            self.get_action_result_details,
+        )
+        self.create_service(
+            ActionFeedbackDetails,
+            "~/action_feedback_details",
+            self.get_action_feedback_details,
         )
         self.create_service(
             SetParam,
@@ -283,11 +301,37 @@ class Rosapi(Node):
         return response
 
     def get_service_response_details(self, request, response):
-        """Called by the rosapi/ServiceResponseDetails service. Given the name of a service type, returns the TypeDef
-        for the response message of that service type."""
+        """Called by the rosapi/ServiceResponseDetails service. Given the name of a service type,
+        returns the TypeDef for the response message of that service type."""
         response.typedefs = [
             dict_to_typedef(d)
             for d in objectutils.get_service_response_typedef_recursive(request.type)
+        ]
+        return response
+
+    def get_action_goal_details(self, request, response):
+        """Called by the rosapi/ActionGoalDetails service. Given the name of an action type,
+        returns the TypeDef for the goal message of that action type."""
+        response.typedefs = [
+            dict_to_typedef(d) for d in objectutils.get_action_goal_typedef_recursive(request.type)
+        ]
+        return response
+
+    def get_action_result_details(self, request, response):
+        """Called by the rosapi/ActionResultDetails service. Given the name of an action type,
+        returns the TypeDef for the result message of that action type."""
+        response.typedefs = [
+            dict_to_typedef(d)
+            for d in objectutils.get_action_result_typedef_recursive(request.type)
+        ]
+        return response
+
+    def get_action_feedback_details(self, request, response):
+        """Called by the rosapi/ActionFeedbackDetails service. Given the name of an action type,
+        returns the TypeDef for the feedback message of that action type."""
+        response.typedefs = [
+            dict_to_typedef(d)
+            for d in objectutils.get_action_feedback_typedef_recursive(request.type)
         ]
         return response
 

--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -135,6 +135,36 @@ def get_service_response_typedef_recursive(servicetype):
     return _get_subtypedefs_recursive(typedef, [])
 
 
+def get_action_goal_typedef_recursive(actiontype):
+    """Returns a list of typedef dicts for this type and all contained type fields"""
+    # Get an instance of the action goal class and get its typedef
+    instance = ros_loader.get_action_goal_instance(actiontype)
+    typedef = _get_typedef(instance)
+
+    # Return the list of sub-typedefs
+    return _get_subtypedefs_recursive(typedef, [])
+
+
+def get_action_result_typedef_recursive(actiontype):
+    """Returns a list of typedef dicts for this type and all contained type fields"""
+    # Get an instance of the action result class and get its typedef
+    instance = ros_loader.get_action_result_instance(actiontype)
+    typedef = _get_typedef(instance)
+
+    # Return the list of sub-typedefs
+    return _get_subtypedefs_recursive(typedef, [])
+
+
+def get_action_feedback_typedef_recursive(actiontype):
+    """Returns a list of typedef dicts for this type and all contained type fields"""
+    # Get an instance of the action feedback class and get its typedef
+    instance = ros_loader.get_action_feedback_instance(actiontype)
+    typedef = _get_typedef(instance)
+
+    # Return the list of sub-typedefs
+    return _get_subtypedefs_recursive(typedef, [])
+
+
 def get_typedef_full_text(ty):
     """Returns the full text (similar to `gendeps --cat`) for the specified message type"""
     try:

--- a/rosapi_msgs/CMakeLists.txt
+++ b/rosapi_msgs/CMakeLists.txt
@@ -23,6 +23,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/ServiceProviders.srv
   srv/ServiceRequestDetails.srv
   srv/ServiceResponseDetails.srv
+  srv/ActionGoalDetails.srv
+  srv/ActionResultDetails.srv
+  srv/ActionFeedbackDetails.srv
   srv/Services.srv
   srv/ServicesForType.srv
   srv/ServiceType.srv

--- a/rosapi_msgs/srv/ActionFeedbackDetails.srv
+++ b/rosapi_msgs/srv/ActionFeedbackDetails.srv
@@ -1,0 +1,3 @@
+string type
+---
+TypeDef[] typedefs

--- a/rosapi_msgs/srv/ActionGoalDetails.srv
+++ b/rosapi_msgs/srv/ActionGoalDetails.srv
@@ -1,0 +1,3 @@
+string type
+---
+TypeDef[] typedefs

--- a/rosapi_msgs/srv/ActionResultDetails.srv
+++ b/rosapi_msgs/srv/ActionResultDetails.srv
@@ -1,0 +1,3 @@
+string type
+---
+TypeDef[] typedefs


### PR DESCRIPTION
**Public API Changes**
Added the following `rosapi` services:
- `~/action_goal_details`
- `~/action_result_details`
- `~/action_feedback_details`

**Description**
Added services to `rosapi` to retrieve details on action interfaces, similar to the existing message and request services.
