### PR TITLE
Add missing service timeout parameter to conditional launch 

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -65,6 +65,7 @@
       <param name="unregister_timeout" value="$(var unregister_timeout)"/>
       <param name="use_compression" value="$(var use_compression)"/>
       <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
+      <param name="default_call_service_timeout" value="$(var default_call_service_timeout)"/>
       <param name="send_action_goals_in_new_thread" value="$(var send_action_goals_in_new_thread)"/>
 
       <param name="topics_glob" value="$(var topics_glob)"/>


### PR DESCRIPTION
**Public API Changes**
Add a missing parameter (default_call_servie_timeout) to the rosbridge_websocket node. The parameter is added when ssl:=True but not when ssl:=False.


**Description**
Motivation behind those changes: I was using the bridge to make calls to services that take 10-20 seconds to return (request for a robot to navigate slightly long distances). I noted that regardless of my increasing the service timeout in the launch file, rosbridge was still throwing exceptions. Then I realized the parameter was not actually being passed to the rosbridge_websocket node when ssl:=False.

<!-- Link relevant GitHub issues -->
This PR addresses this issue: https://github.com/RobotWebTools/rosbridge_suite/issues/1027