### PR TITLE
Handle extra IDL slots when doing array introspection

### DIFF
--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -201,18 +201,18 @@ def _handle_array_information(instance):
     fieldtypes = []
     fieldarraylen = []
     examples = []
-    for i in range(len(instance.__slots__)):
-        name = instance.__slots__[i]
-        fieldnames.append(name)
+    for slot in instance.__slots__:
+        key = slot[1:] if slot.startswith("_") else slot
+        if key not in instance._fields_and_field_types:
+            continue
 
-        field_type, arraylen = _handle_type_and_array_len(instance, name)
+        fieldnames.append(key)
+        field_type, arraylen = _handle_type_and_array_len(instance, slot)
         fieldarraylen.append(arraylen)
 
-        field_instance = getattr(instance, name)
-        fieldtypes.append(_type_name(field_type, field_instance))
-
-        example = _handle_example(arraylen, field_type, field_instance)
-        examples.append(str(example))
+        value = getattr(instance, slot)
+        fieldtypes.append(_type_name(field_type, value))
+        examples.append(str(_handle_example(arraylen, field_type, value)))
 
     return fieldnames, fieldtypes, fieldarraylen, examples
 

--- a/rosapi/test/test_typedefs.py
+++ b/rosapi/test/test_typedefs.py
@@ -44,8 +44,9 @@ class TestUtils(unittest.TestCase):
     def test_skip_private_slots_in_array_info(self):
         # create a fake msg with one real field ('data') and one internal slot
         class MockMsg:
-            __slots__ = ['_check_fields', '_important_data']
-            _fields_and_field_types = {'important_data': 'int32'}
+            __slots__ = ["_check_fields", "_important_data"]
+            _fields_and_field_types = {"important_data": "int32"}
+
             def __init__(self):
                 self._important_data = 123
                 self._check_fields = None
@@ -55,12 +56,13 @@ class TestUtils(unittest.TestCase):
         names, types, lens, examples = objectutils._handle_array_information(inst)
 
         # should only see our single '_important_data' field
-        self.assertEqual(names, ['important_data'])
+        self.assertEqual(names, ["important_data"])
         # raw type should be 'int32' (no array)
-        self.assertEqual(types, ['int32'])
+        self.assertEqual(types, ["int32"])
         self.assertEqual(lens, [-1])
         # example should be the stringified value of 123
-        self.assertEqual(examples, ['123'])
+        self.assertEqual(examples, ["123"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rosapi/test/test_typedefs.py
+++ b/rosapi/test/test_typedefs.py
@@ -41,6 +41,26 @@ class TestUtils(unittest.TestCase):
         # should be None for an atomic
         self.assertEqual(actual_typedef, None)
 
+    def test_skip_private_slots_in_array_info(self):
+        # create a fake msg with one real field ('data') and one internal slot
+        class MockMsg:
+            __slots__ = ['_check_fields', '_important_data']
+            _fields_and_field_types = {'important_data': 'int32'}
+            def __init__(self):
+                self._important_data = 123
+                self._check_fields = None
+
+        inst = MockMsg()
+        # call the private helper directly
+        names, types, lens, examples = objectutils._handle_array_information(inst)
+
+        # should only see our single '_important_data' field
+        self.assertEqual(names, ['important_data'])
+        # raw type should be 'int32' (no array)
+        self.assertEqual(types, ['int32'])
+        self.assertEqual(lens, [-1])
+        # example should be the stringified value of 123
+        self.assertEqual(examples, ['123'])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
There's a change in the Python message generator that landed in Iron (and newer distros) that appears to breaking the array handling in rosapi. Iron’s rosidl_generator_py templates now inject extra private slots (e.g. [_check_fields](https://github.com/ros2/rosidl_python/blob/iron/rosidl_generator_py/resource/_msg.py.em#L212)) into every message’s `__slots__`. Those names don’t appear in the message’s _fields_and_field_types dict, so code that blindly walks `__slots__` will hit a KeyError.

To fix this, we skip any slot whose stripped name isn’t in _fields_and_field_types.

<!-- Link relevant GitHub issues -->
https://github.com/RobotWebTools/rosbridge_suite/issues/976