### PR TITLE
Default subscriber QOS to BestEffort, account for TRANSIENT_LOCAL

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -106,18 +106,23 @@ class MultiSubscriber:
         # incompatible. Here we make a "best effort" attempt to match existing
         # publishers for the requested topic. This is not perfect because more
         # publishers may come online after our subscriber is set up, but we try
-        # to provide sane defaults. For more information, see:
+        # to provide sane defaults.
+        # For this reason we use volatile durability and best effort reliability
+        # to prioritize topic compatibility when the publisher policy is not known.
+        # For more information, see:
         # - https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
         # - https://github.com/RobotWebTools/rosbridge_suite/issues/551
+        # - https://github.com/RobotWebTools/rosbridge_suite/issues/769
         qos = QoSProfile(
             depth=10,
             durability=DurabilityPolicy.VOLATILE,
-            reliability=ReliabilityPolicy.RELIABLE,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
         )
 
         infos = node_handle.get_publishers_info_by_topic(topic)
         if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
             qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+            qos.reliability = ReliabilityPolicy.RELIABLE
         if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
             qos.reliability = ReliabilityPolicy.BEST_EFFORT
 

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -120,7 +120,10 @@ class MultiSubscriber:
         )
 
         infos = node_handle.get_publishers_info_by_topic(topic)
-        if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
+
+        if len(infos) > 0 and all(
+            pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos
+        ):
             qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
             qos.reliability = ReliabilityPolicy.RELIABLE
         if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
@@ -182,10 +185,14 @@ class MultiSubscriber:
             # which adds the new callback to the subscriptions dictionary.
             self.new_subscriptions.update({client_id: callback})
             infos = self.node_handle.get_publishers_info_by_topic(self.topic)
-            if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
+
+            if len(infos) > 0 and all(
+                pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos
+            ):
                 self.qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
             if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
                 self.qos.reliability = ReliabilityPolicy.BEST_EFFORT
+
             if self.new_subscriber is None:
                 self.new_subscriber = self.node_handle.create_subscription(
                     self.msg_class,


### PR DESCRIPTION
This is a backport of #991 and #1023. 