### PR TITLE
Fix JSON serialization in PNG compression and fixed tests

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
+++ b/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
@@ -49,7 +49,7 @@ def encode(string):
     buff = BytesIO()
     i.save(buff, "png")
     encoded = standard_b64encode(buff.getvalue())
-    return encoded
+    return encoded.decode()
 
 
 def decode(string):

--- a/rosbridge_library/test/internal/test_compression.py
+++ b/rosbridge_library/test/internal/test_compression.py
@@ -10,10 +10,11 @@ class TestCompression(unittest.TestCase):
         string = str(bytearray(bytes_data))
         encoded = pngcompression.encode(string)
         self.assertNotEqual(string, encoded)
+        self.assertIsInstance(encoded, str)
 
     def test_compress_decompress(self):
         bytes_data = list(range(128)) * 10000
-        string = str(bytes(bytes_data))
+        string = str(bytearray(bytes_data))
         encoded = pngcompression.encode(string)
         self.assertNotEqual(string, encoded)
         decoded = pngcompression.decode(encoded)


### PR DESCRIPTION
## Fix JSON serialization in PNG compression #856 

### Problem
- `pngcompression.encode()` returns `bytes` object
- `bytes` objects are not JSON serializable  
- Causes `TypeError: Object of type bytes is not JSON serializable` when requesting robot maps via rosbridge

### Solution
**Minimal one-line change** in `encode()` function:
```python
return encoded.decode()  # Convert bytes to string
```

### Test Updates

- Fixed inconsistency between str(bytes()) and str(bytearray())
- Added assertIsInstance(encoded, str) to prevent future regressions