### PR TITLE
Fix IP binding of rosbridge_server

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
     connected = False
     while not connected and not rospy.is_shutdown():
         try:
-            listenWS(factory, context_factory)
+            listenWS(factory, context_factory, interface=factory.host)
             rospy.loginfo('Rosbridge WebSocket server started at {}'.format(uri))
             connected = True
         except CannotListenError as e:


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
While launching `rosbridge_server` with the `address` parameter, it can still be accessed through another interface. For example:
```
roslaunch rosbridge_server rosbridge_websocket.launch address:=192.168.1.101
```
My IP addresses:
```
enp6s0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.64.89.48  netmask 255.255.255.0  broadcast 10.64.89.255
        inet6 fe80::1f50:2efc:ac11:5e36  prefixlen 64  scopeid 0x20<link>
        ether 60:cf:84:ca:3e:c3  txqueuelen 1000  (Ethernet)
        RX packets 51493  bytes 21183271 (21.1 MB)
        RX errors 0  dropped 482  overruns 0  frame 0
        TX packets 14025  bytes 2335009 (2.3 MB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 24  

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 1484  bytes 206358 (206.3 KB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1484  bytes 206358 (206.3 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wlx6c1ff7469d01: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.1.101  netmask 255.255.255.0  broadcast 192.168.1.255
        inet6 fe80::78bd:d8a6:3e59:cb92  prefixlen 64  scopeid 0x20<link>
        ether 6c:1f:f7:46:9d:01  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
Although the output shows it is bound to the specified address:
```
... logging to ~/.ros/log/0ab8d832-532e-11f0-9099-cf231ae1cc10/roslaunch-System-Product-Name-3238.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://System-Product-Name:46291/

SUMMARY
========

PARAMETERS
 * /rosapi/params_glob: [*]
 * /rosapi/services_glob: [*]
 * /rosapi/topics_glob: [*]
 * /rosbridge_websocket/address: 192.168.1.101
 * /rosbridge_websocket/authenticate: False
 * /rosbridge_websocket/bson_only_mode: False
 * /rosbridge_websocket/delay_between_messages: 0
 * /rosbridge_websocket/fragment_timeout: 600
 * /rosbridge_websocket/max_message_size: None
 * /rosbridge_websocket/params_glob: [*]
 * /rosbridge_websocket/port: 9090
 * /rosbridge_websocket/retry_startup_delay: 5
 * /rosbridge_websocket/services_glob: [*]
 * /rosbridge_websocket/topics_glob: [*]
 * /rosbridge_websocket/unregister_timeout: 10
 * /rosbridge_websocket/use_compression: False
 * /rosbridge_websocket/websocket_external_port: None
 * /rosbridge_websocket/websocket_ping_interval: 0
 * /rosbridge_websocket/websocket_ping_timeout: 30
 * /rosdistro: noetic
 * /rosversion: 1.17.4

NODES
  /
    rosapi (rosapi/rosapi_node)
    rosbridge_websocket (rosbridge_server/rosbridge_websocket)

auto-starting new master
process[master]: started with pid [3246]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 0ab8d832-532e-11f0-9099-cf231ae1cc10
process[rosout-1]: started with pid [3256]
started core service [/rosout]
process[rosbridge_websocket-2]: started with pid [3263]
process[rosapi-3]: started with pid [3264]
[INFO] [1751011766.504863]: Rosapi started
2025-06-27 16:09:26+0800 [-] Log opened.
2025-06-27 16:09:26+0800 [-] registered capabilities (classes):
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.call_service.CallService'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.advertise.Advertise'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.publish.Publish'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.subscribe.Subscribe'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.defragmentation.Defragment'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.advertise_service.AdvertiseService'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.service_response.ServiceResponse'>
2025-06-27 16:09:26+0800 [-]  - <class 'rosbridge_library.capabilities.unadvertise_service.UnadvertiseService'>
2025-06-27 16:09:26+0800 [-] WebSocketServerFactory starting on 9090
2025-06-27 16:09:26+0800 [-] Starting factory <autobahn.twisted.websocket.WebSocketServerFactory object at 0x7fbceb286af0>
2025-06-27 16:09:26+0800 [-] [INFO] [1751011766.663466]: Rosbridge WebSocket server started at ws://192.168.1.101:9090
```
In fact, it has not taken effect at all, connections from other interface (which is `enp6s0` on my computer) are still allowed:
```
2025-06-27 16:09:27+0800 [-] dropping connection to peer tcp4:10.68.115.165:43304 with abort=False: None
2025-06-27 16:09:27+0800 [-] dropping connection to peer tcp4:10.68.115.165:43300 with abort=False: None
```
We can verify it through `netstat`:
```
sudo netstat -tulnp | grep 9090
```
```
tcp        0      0 0.0.0.0:9090            0.0.0.0:*               LISTEN      3263/python3
```
On the other hand, it even allows you to bind IP addresses that are not on the local machine:
```
roslaunch rosbridge_server rosbridge_websocket.launch address:=1.1.1.1
```
```
... logging to ~/.ros/log/2bd6ca24-532e-11f0-9099-cf231ae1cc10/roslaunch-System-Product-Name-3385.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://System-Product-Name:35595/

SUMMARY
========

PARAMETERS
 * /rosapi/params_glob: [*]
 * /rosapi/services_glob: [*]
 * /rosapi/topics_glob: [*]
 * /rosbridge_websocket/address: 1.1.1.1
 * /rosbridge_websocket/authenticate: False
 * /rosbridge_websocket/bson_only_mode: False
 * /rosbridge_websocket/delay_between_messages: 0
 * /rosbridge_websocket/fragment_timeout: 600
 * /rosbridge_websocket/max_message_size: None
 * /rosbridge_websocket/params_glob: [*]
 * /rosbridge_websocket/port: 9090
 * /rosbridge_websocket/retry_startup_delay: 5
 * /rosbridge_websocket/services_glob: [*]
 * /rosbridge_websocket/topics_glob: [*]
 * /rosbridge_websocket/unregister_timeout: 10
 * /rosbridge_websocket/use_compression: False
 * /rosbridge_websocket/websocket_external_port: None
 * /rosbridge_websocket/websocket_ping_interval: 0
 * /rosbridge_websocket/websocket_ping_timeout: 30
 * /rosdistro: noetic
 * /rosversion: 1.17.4

NODES
  /
    rosapi (rosapi/rosapi_node)
    rosbridge_websocket (rosbridge_server/rosbridge_websocket)

auto-starting new master
process[master]: started with pid [3393]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 2bd6ca24-532e-11f0-9099-cf231ae1cc10
process[rosout-1]: started with pid [3403]
started core service [/rosout]
process[rosbridge_websocket-2]: started with pid [3410]
process[rosapi-3]: started with pid [3411]
2025-06-27 16:10:22+0800 [-] Log opened.
2025-06-27 16:10:22+0800 [-] registered capabilities (classes):
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.call_service.CallService'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.advertise.Advertise'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.publish.Publish'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.subscribe.Subscribe'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.defragmentation.Defragment'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.advertise_service.AdvertiseService'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.service_response.ServiceResponse'>
2025-06-27 16:10:22+0800 [-]  - <class 'rosbridge_library.capabilities.unadvertise_service.UnadvertiseService'>
[INFO] [1751011822.181624]: Rosapi started
2025-06-27 16:10:22+0800 [-] WebSocketServerFactory starting on 9090
2025-06-27 16:10:22+0800 [-] Starting factory <autobahn.twisted.websocket.WebSocketServerFactory object at 0x7f95a22af7c0>
2025-06-27 16:10:22+0800 [-] [INFO] [1751011822.227472]: Rosbridge WebSocket server started at ws://1.1.1.1:9090
2025-06-27 16:10:23+0800 [-] dropping connection to peer tcp4:10.68.115.165:37358 with abort=False: None
2025-06-27 16:10:23+0800 [-] dropping connection to peer tcp4:10.68.115.165:37364 with abort=False: None
```
Finally I found that the root cause is no `interface` parameter is passed when calling function `listenWS`, and it work as expected after this fix. To evaluate it, simply apply the fix to `/opt/ros/noetic/lib/rosbridge_server/rosbridge_websocket`, then launch the server again, you will find that the IP binding is correct:
```
tcp        0      0 192.168.1.101:9090      0.0.0.0:*               LISTEN      3931/python3
```
And if you want to bind to `1.1.1.1` again, you will get error like this:
```
... logging to ~/.ros/log/1be9e4f0-5330-11f0-9099-cf231ae1cc10/roslaunch-System-Product-Name-4042.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://System-Product-Name:33001/

SUMMARY
========

PARAMETERS
 * /rosapi/params_glob: [*]
 * /rosapi/services_glob: [*]
 * /rosapi/topics_glob: [*]
 * /rosbridge_websocket/address: 1.1.1.1
 * /rosbridge_websocket/authenticate: False
 * /rosbridge_websocket/bson_only_mode: False
 * /rosbridge_websocket/delay_between_messages: 0
 * /rosbridge_websocket/fragment_timeout: 600
 * /rosbridge_websocket/max_message_size: None
 * /rosbridge_websocket/params_glob: [*]
 * /rosbridge_websocket/port: 9090
 * /rosbridge_websocket/retry_startup_delay: 5
 * /rosbridge_websocket/services_glob: [*]
 * /rosbridge_websocket/topics_glob: [*]
 * /rosbridge_websocket/unregister_timeout: 10
 * /rosbridge_websocket/use_compression: False
 * /rosbridge_websocket/websocket_external_port: None
 * /rosbridge_websocket/websocket_ping_interval: 0
 * /rosbridge_websocket/websocket_ping_timeout: 30
 * /rosdistro: noetic
 * /rosversion: 1.17.4

NODES
  /
    rosapi (rosapi/rosapi_node)
    rosbridge_websocket (rosbridge_server/rosbridge_websocket)

auto-starting new master
process[master]: started with pid [4050]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 1be9e4f0-5330-11f0-9099-cf231ae1cc10
process[rosout-1]: started with pid [4060]
started core service [/rosout]
process[rosbridge_websocket-2]: started with pid [4067]
process[rosapi-3]: started with pid [4068]
2025-06-27 16:24:14+0800 [-] Log opened.
2025-06-27 16:24:14+0800 [-] registered capabilities (classes):
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.call_service.CallService'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.advertise.Advertise'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.publish.Publish'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.subscribe.Subscribe'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.defragmentation.Defragment'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.advertise_service.AdvertiseService'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.service_response.ServiceResponse'>
2025-06-27 16:24:14+0800 [-]  - <class 'rosbridge_library.capabilities.unadvertise_service.UnadvertiseService'>
[INFO] [1751012654.468930]: Rosapi started
2025-06-27 16:24:14+0800 [-] [WARN] [1751012654.526506]: Unable to start server: Couldn't listen on 1.1.1.1:9090: [Errno 99] Cannot assign requested address. Retrying in 5s.
```

<!-- Link relevant GitHub issues -->
The bug was introduced in #426. This PR fixes #904.