### PR TITLE
fix: rosbridge_websocket cooperative shutdown

### DIFF
--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -339,10 +339,13 @@ def main(args=None):
     rclpy.init(args=args)
     node = RosbridgeWebsocketNode()
 
-    executor = rclpy.executors.MultiThreadedExecutor()
+    executor = rclpy.executors.SingleThreadedExecutor()
     executor.add_node(node)
 
     def spin_ros():
+        if not rclpy.ok():
+            shutdown_hook()
+            return
         executor.spin_once(timeout_sec=0.01)
         if not rclpy.ok():
             shutdown_hook()

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -347,8 +347,6 @@ def main(args=None):
             shutdown_hook()
             return
         executor.spin_once(timeout_sec=0.01)
-        if not rclpy.ok():
-            shutdown_hook()
 
     spin_callback = PeriodicCallback(spin_ros, 1)
     spin_callback.start()
@@ -358,8 +356,8 @@ def main(args=None):
         rclpy.shutdown()
     except KeyboardInterrupt:
         print("Exiting due to SIGINT")
-        spin_callback.stop()
     finally:
+        spin_callback.stop()
         shutdown_hook()  # shutdown hook to stop the server
 
 

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -339,7 +339,7 @@ def main(args=None):
     rclpy.init(args=args)
     node = RosbridgeWebsocketNode()
 
-    executor = rclpy.executors.SingleThreadedExecutor()
+    executor = rclpy.executors.MultiThreadedExecutor()
     executor.add_node(node)
 
     def spin_ros():
@@ -355,6 +355,7 @@ def main(args=None):
         rclpy.shutdown()
     except KeyboardInterrupt:
         print("Exiting due to SIGINT")
+        spin_callback.stop()
     finally:
         shutdown_hook()  # shutdown hook to stop the server
 


### PR DESCRIPTION
**Public API Changes**
None

**Description**
We use this package in a systemctl
When we do `systemctl ... stop <our.service>`, a common thing blocking shutdown is this process
We can work around it, and locally do `systemctl ... stop --force` but this patch isn't global and not ideal

I tested some local changes to this code to make it cooperate, without any obvious regressions

<!-- Link relevant GitHub issues -->

I made no issues, but maybe one exists or I can make one for tracking
