### PR TITLE
Clean up package dependencies

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosapi)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -16,7 +16,7 @@
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="blazej@fictionlab.pl">Błażej Sowa</maintainer>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>rosapi_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>

--- a/rosapi_msgs/CMakeLists.txt
+++ b/rosapi_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosapi_msgs)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 

--- a/rosapi_msgs/package.xml
+++ b/rosapi_msgs/package.xml
@@ -20,10 +20,8 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
+  <depend>builtin_interfaces</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rosapi_msgs/package.xml
+++ b/rosapi_msgs/package.xml
@@ -16,7 +16,7 @@
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="blazej@fictionlab.pl">Błażej Sowa</maintainer>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 

--- a/rosbridge_library/CMakeLists.txt
+++ b/rosbridge_library/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 project(rosbridge_library)
 
 find_package(ament_cmake_ros REQUIRED)
-find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(

--- a/rosbridge_library/CMakeLists.txt
+++ b/rosbridge_library/CMakeLists.txt
@@ -10,9 +10,8 @@ ament_python_install_package(
 ament_package()
 
 if (BUILD_TESTING)
-  find_package(ament_cmake_pytest REQUIRED)
-  ament_add_pytest_test(test_capabilities "test/capabilities/")
-  ament_add_pytest_test(test_internal "test/internal/")
+  ament_add_ros_isolated_pytest_test(test_capabilities "test/capabilities/")
+  ament_add_ros_isolated_pytest_test(test_internal "test/internal/")
 
   find_package(ament_cmake_mypy REQUIRED)
   ament_mypy()

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -20,9 +20,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <build_depend>python3-pil</build_depend>
-  <build_depend>python3-bson</build_depend>
-
   <exec_depend>rclpy</exec_depend>
   <exec_depend>python3-pil</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -17,8 +17,8 @@
   <author email="jonathan.c.mace@gmail.com">Jonathan Mace</author>
   <maintainer email="blazej@fictionlab.pl">Błażej Sowa</maintainer>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>python3-pil</build_depend>
   <build_depend>python3-bson</build_depend>

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -22,7 +22,6 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>python3-pil</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-bson</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-ujson</exec_depend>

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -24,6 +24,9 @@
   <exec_depend>python3-pil</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-bson</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-ujson</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
 
   <test_depend>rosbridge_test_msgs</test_depend>
   <test_depend>action_msgs</test_depend>

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -31,7 +31,6 @@
   <test_depend>rosbridge_test_msgs</test_depend>
   <test_depend>action_msgs</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>builtin_interfaces</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
   <test_depend>example_interfaces</test_depend>

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -20,22 +20,22 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>python3-pil</exec_depend>
   <exec_depend>python3-bson</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-pil</exec_depend>
   <exec_depend>python3-ujson</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
-  <test_depend>rosbridge_test_msgs</test_depend>
   <test_depend>action_msgs</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>builtin_interfaces</test_depend>
+  <test_depend>control_msgs</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
   <test_depend>example_interfaces</test_depend>
-  <test_depend>control_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>nav_msgs</test_depend>
+  <test_depend>rosbridge_test_msgs</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_msgs)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -12,7 +12,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
+  <depend>builtin_interfaces</depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_server)
 
-find_package(ament_cmake_ros REQUIRED)
-find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -23,14 +23,17 @@
   <exec_depend>rosapi</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <test_depend>action_msgs</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>example_interfaces</test_depend>
   <test_depend>python3-autobahn</test_depend>
+  <test_depend>python3-twisted</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
   <test_depend>std_srvs</test_depend>
 
   <export>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -14,6 +14,7 @@
   <maintainer email="blazej@fictionlab.pl">Błażej Sowa</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>python3-tornado</exec_depend>
   <exec_depend>python3-twisted</exec_depend>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>python3-tornado</exec_depend>
-  <exec_depend>python3-twisted</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>rosbridge_msgs</exec_depend>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -30,8 +30,6 @@
   <test_depend>python3-twisted</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
-  <test_depend>launch_testing</test_depend>
-  <test_depend>launch_testing_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>std_srvs</test_depend>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>rosbridge_msgs</exec_depend>
   <exec_depend>rosapi</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>example_interfaces</test_depend>

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -18,19 +18,19 @@
 
   <exec_depend>python3-tornado</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosapi</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>rosbridge_msgs</exec_depend>
-  <exec_depend>rosapi</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>action_msgs</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>example_interfaces</test_depend>
-  <test_depend>python3-autobahn</test_depend>
-  <test_depend>python3-twisted</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>python3-autobahn</test_depend>
+  <test_depend>python3-twisted</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>std_srvs</test_depend>
 

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -14,7 +14,6 @@
   <maintainer email="blazej@fictionlab.pl">Błażej Sowa</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <exec_depend>python3-tornado</exec_depend>
   <exec_depend>python3-twisted</exec_depend>

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_test_msgs)
 
-find_package(ament_cmake_core REQUIRED)
-find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -18,13 +18,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>action_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -28,21 +28,6 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <test_depend>action_msgs</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>builtin_interfaces</test_depend>
-  <test_depend>diagnostic_msgs</test_depend>
-  <test_depend>example_interfaces</test_depend>
-  <test_depend>geometry_msgs</test_depend>
-  <test_depend>nav_msgs</test_depend>
-  <test_depend>sensor_msgs</test_depend>
-  <test_depend>std_msgs</test_depend>
-  <test_depend>std_srvs</test_depend>
-  <test_depend>stereo_msgs</test_depend>
-  <test_depend>tf2_msgs</test_depend>
-  <test_depend>trajectory_msgs</test_depend>
-  <test_depend>visualization_msgs</test_depend>
-
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -16,11 +16,11 @@
   <maintainer email="blazej@fictionlab.pl">Błażej Sowa</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -23,7 +23,6 @@
   <build_depend>geometry_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
**Public API Changes**
None


**Description**
This PR fixes some issues with the dependency declaration. Most notably:
- Adds missing dependencies and removes unused ones,
- Uses correct dependency types, for example, python code does not need build dependencies and for dependencies of rosidl interfaces we should be using the `<depend>` tags which implies `build_depend`, `exec_depend` and `build_export_depend`
- (Opinionated) Prefers `ament_cmake` over `ament_cmake_ros`. The only exception is `rosbridge_library` which is now using the `ament_add_ros_isolated_pytest_test` macro from `ament_cmake_ros`
- (Opinionated) Sorts the dependencies in lexicographic order (easier to avoid duplicates and merge multiple code changes in the future)

I split the changes into many small commits to make it easy to follow. 