### PR TITLE
Clean up package dependencies (backport #1053)

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosapi)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -17,7 +17,7 @@
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>rosapi_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>

--- a/rosapi_msgs/CMakeLists.txt
+++ b/rosapi_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosapi_msgs)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 

--- a/rosapi_msgs/package.xml
+++ b/rosapi_msgs/package.xml
@@ -17,14 +17,12 @@
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
+  <depend>builtin_interfaces</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rosbridge_library/CMakeLists.txt
+++ b/rosbridge_library/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 project(rosbridge_library)
 
 find_package(ament_cmake_ros REQUIRED)
-find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(
@@ -11,7 +10,6 @@ ament_python_install_package(
 ament_package()
 
 if (BUILD_TESTING)
-  find_package(ament_cmake_pytest REQUIRED)
-  ament_add_pytest_test(test_capabilities "test/capabilities/")
-  ament_add_pytest_test(test_internal "test/internal/")
+  ament_add_ros_isolated_pytest_test(test_capabilities "test/capabilities/")
+  ament_add_ros_isolated_pytest_test(test_internal "test/internal/")
 endif()

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -18,26 +18,24 @@
   <maintainer email="jihoonlee.in@gmail.com">Jihoon Lee</maintainer>
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <build_depend>python3-pil</build_depend>
-  <build_depend>python3-bson</build_depend>
-
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>python3-pil</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-bson</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-pil</exec_depend>
+  <exec_depend>python3-ujson</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
-  <test_depend>rosbridge_test_msgs</test_depend>
   <test_depend>action_msgs</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>builtin_interfaces</test_depend>
+  <test_depend>control_msgs</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
   <test_depend>example_interfaces</test_depend>
-  <test_depend>control_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>nav_msgs</test_depend>
+  <test_depend>rosbridge_test_msgs</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_msgs)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 

--- a/rosbridge_msgs/package.xml
+++ b/rosbridge_msgs/package.xml
@@ -10,10 +10,11 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
+  <depend>builtin_interfaces</depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_server)
 
-find_package(ament_cmake_ros REQUIRED)
-find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(

--- a/rosbridge_server/package.xml
+++ b/rosbridge_server/package.xml
@@ -15,22 +15,23 @@
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>python3-tornado</exec_depend>
-  <exec_depend>python3-twisted</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosapi</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>rosbridge_msgs</exec_depend>
-  <exec_depend>rosapi</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
+  <test_depend>action_msgs</test_depend>
   <test_depend>example_interfaces</test_depend>
-  <test_depend>python3-autobahn</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
-  <test_depend>launch_testing</test_depend>
-  <test_depend>launch_testing_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>python3-autobahn</test_depend>
+  <test_depend>python3-twisted</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
   <test_depend>std_srvs</test_depend>
 
   <export>

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_test_msgs)
 
-find_package(ament_cmake_core REQUIRED)
-find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)

--- a/rosbridge_test_msgs/package.xml
+++ b/rosbridge_test_msgs/package.xml
@@ -17,32 +17,14 @@
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>rosidl_default_generators</build_depend>
+  <depend>action_msgs</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-
-  <test_depend>action_msgs</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>builtin_interfaces</test_depend>
-  <test_depend>diagnostic_msgs</test_depend>
-  <test_depend>example_interfaces</test_depend>
-  <test_depend>geometry_msgs</test_depend>
-  <test_depend>nav_msgs</test_depend>
-  <test_depend>sensor_msgs</test_depend>
-  <test_depend>std_msgs</test_depend>
-  <test_depend>std_srvs</test_depend>
-  <test_depend>stereo_msgs</test_depend>
-  <test_depend>tf2_msgs</test_depend>
-  <test_depend>trajectory_msgs</test_depend>
-  <test_depend>visualization_msgs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
* rosapi_msgs: fix depend tags

Removed rcl_interfaces dependency and used <depend> tag for builtin_interfaces.

* rosapi: use ament_cmake instead of ament_cmake_ros

* rosapi_msgs: use ament_cmake instead of ament_cmake_ros

* rosbridge_library: remove ament_cmake dependency and add ament_cmake_python

* rosbridge_library: run tests in ROS_DOMAIN_ID isolated environments

* rosbridge_library: remove build dependencies on PIL and bson python libraries

* rosbridge_library: add exec dependencies on ujson, numpy and rcl_interfaces

* rosbridge_library: remove rosidl_default_runtime dependency

* rosbridge_library: sort dependencies in lexicographic order

* rosbridge_msgs: use ament_cmake instead of ament_cmake_ros

* rosbridge_msgs: use depend tag for message definition dependencies

* rosbridge_server: use ament_cmake instead of ament_cmake_ros

* rosbridge_server: add ament_cmake_python dependency

* rosbridge_server: remove twisted from exec dependencies

* rosbridge_server: add std_msgs to exec dependencies

* rosbridge_server: add twisted, rcl_interfaces and action_msgs to test dependencies

* rosbridge_server: remove launch_testing and launch_testing_ros dependencies

* rosbridge_server: sort dependencies in lexicographic order

* rosbridge_test_msgs: remove test dependencies

* rosbridge_test_msgs: move rosidl_default_generators to buildtool dependencies

* rosbridge_test_msgs: remove rclpy dependency

* rosbridge_test_msgs: use depend tag for interface definition dependencies

* rosbridge_test_msgs: add action_msgs dependency

* rosbridge_test_msgs: don't find_package ament_cmake_python


