### PR TITLE
Change warn to warning

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -505,7 +505,7 @@ class Rosapi(Node):
         return tuple(param.split(":"))
 
     def _print_malformed_param_name_warning(self, param_name):
-        self.get_logger().warn(
+        self.get_logger().warning(
             f"Malformed parameter name: {param_name}; expecting <node_name>:<param_name>"
         )
 

--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -220,19 +220,19 @@ class PublisherManager:
                 queue_size=queue_size,
             )
         elif latch and self._publishers[topic].latched_client_id != client_id:
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 f"Client ID {client_id} attempted to register topic [{topic}] as "
                 "latched but this topic was previously registered."
             )
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 "Only a single registered latched publisher is supported at the time"
             )
         elif not latch and self._publishers[topic].latched_client_id:
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 f"New non-latched publisher registration for topic [{topic}] which is "
                 "already registered as latched. but this topic was previously registered."
             )
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 "Only a single registered latched publisher is supported at the time"
             )
 

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -402,7 +402,7 @@ class Protocol:
         if level in {"error", "err"}:
             self.node_handle.get_logger().error(stdout_formatted_msg)
         elif level in {"warning", "warn"}:
-            self.node_handle.get_logger().warn(stdout_formatted_msg)
+            self.node_handle.get_logger().warning(stdout_formatted_msg)
         elif level in {"info", "information"}:
             self.node_handle.get_logger().info(stdout_formatted_msg)
         else:

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -166,7 +166,7 @@ class RosbridgeWebsocketNode(Node):
                 self.get_logger().info(f"Rosbridge WebSocket server started on port {actual_port}")
                 connected = True
             except OSError as e:  # noqa: PERF203
-                self.get_logger().warn(
+                self.get_logger().warning(
                     f"Unable to start server: {e} Retrying in {retry_startup_delay}s."
                 )
                 time.sleep(retry_startup_delay)

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -188,13 +188,13 @@ class RosbridgeWebSocket(WebSocketHandler):
         try:
             await self.write_message(message, binary)
         except WebSocketClosedError:
-            cls.node_handle.get_logger().warn(
+            cls.node_handle.get_logger().warning(
                 "WebSocketClosedError: Tried to write to a closed websocket",
                 throttle_duration_sec=1.0,
             )
             # If we end up here, a client has disconnected before its message callback(s) could be removed.
         except StreamClosedError:
-            cls.node_handle.get_logger().warn(
+            cls.node_handle.get_logger().warning(
                 "StreamClosedError: Tried to write to a closed stream",
                 throttle_duration_sec=1.0,
             )


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Some logging calls use `.warn()` instead of  `.warning()` which throws exceptions.
