### PR TITLE
refactor: Add type annotations to all functions and methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "rosbridge_suite"
+requires-python = ">=3.10"
+
 [tool.black]
 # We use ruff for formatting, but black formatter should be compatible with ruff.
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ select = [
 
     # flake8 extensions
     "YTT",    # flake8-2020
-    # "ANN",  # flake8-annotations, There are too many missing annotations right now (TODO)
+    "ANN",    # flake8-annotations,
     "ASYNC",  # flake8-async
     "S",      # flake8-bandit
     # "BLE",  # flake8-blind-except, Too much hassle to fix (TODO)

--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -31,9 +31,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import os
 import sys
 from json import dumps, loads
+from typing import Any
 
 import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
@@ -79,7 +82,7 @@ from rosapi_msgs.srv import (
 class Rosapi(Node):
     NAME = "rosapi"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(self.NAME)
         self.declare_parameter("topics_glob", "[*]")
         self.declare_parameter("services_glob", "[*]")
@@ -89,7 +92,7 @@ class Rosapi(Node):
         self.register_services()
 
     # Initialises the ROS node
-    def register_services(self):
+    def register_services(self) -> None:
         proxy.init(self)
 
         timeout_sec = self.get_parameter("params_timeout").value
@@ -187,10 +190,10 @@ class Rosapi(Node):
         self.create_service(GetTime, "~/get_time", self.get_time)
         self.create_service(GetROSVersion, "~/get_ros_version", self.get_ros_version)
 
-    def get_globs(self):
+    def get_globs(self) -> glob_helper.Globs:
         return glob_helper.get_globs(self)
 
-    def get_topics(self, _request, response):
+    def get_topics(self, _request: Topics.Request, response: Topics.Response) -> Topics.Response:
         """
         Return a list of all the topics being published.
 
@@ -199,7 +202,9 @@ class Rosapi(Node):
         response.topics, response.types = proxy.get_topics_and_types(self.globs.topics)
         return response
 
-    def get_interfaces(self, _request, response):
+    def get_interfaces(
+        self, _request: Interfaces.Request, response: Interfaces.Response
+    ) -> Interfaces.Response:
         """
         Return a list of all the interfaces in the system.
 
@@ -208,7 +213,9 @@ class Rosapi(Node):
         response.interfaces = proxy.get_interfaces()
         return response
 
-    def get_topics_for_type(self, request, response):
+    def get_topics_for_type(
+        self, request: TopicsForType.Request, response: TopicsForType.Response
+    ) -> TopicsForType.Response:
         """
         Return a list of all the topics that are publishing a given type.
 
@@ -217,7 +224,9 @@ class Rosapi(Node):
         response.topics = proxy.get_topics_for_type(request.type, self.globs.topics)
         return response
 
-    def get_topics_and_raw_types(self, _request, response):
+    def get_topics_and_raw_types(
+        self, _request: TopicsAndRawTypes.Request, response: TopicsAndRawTypes.Response
+    ) -> TopicsAndRawTypes.Response:
         """
         Return a list of all the topics being published, and their raw types.
 
@@ -231,7 +240,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_services(self, _request, response):
+    def get_services(
+        self, _request: Services.Request, response: Services.Response
+    ) -> Services.Response:
         """
         Return a list of all the services being advertised.
 
@@ -240,7 +251,9 @@ class Rosapi(Node):
         response.services = proxy.get_services(self.globs.services)
         return response
 
-    def get_services_for_type(self, request, response):
+    def get_services_for_type(
+        self, request: ServicesForType.Request, response: ServicesForType.Response
+    ) -> ServicesForType.Response:
         """
         Return a list of all the services that are publishing a given type.
 
@@ -249,7 +262,7 @@ class Rosapi(Node):
         response.services = proxy.get_services_for_type(request.type, self.globs.services)
         return response
 
-    def get_nodes(self, _request, response):
+    def get_nodes(self, _request: Nodes.Request, response: Nodes.Response) -> Nodes.Response:
         """
         Return a list of all the nodes that are registered.
 
@@ -258,7 +271,9 @@ class Rosapi(Node):
         response.nodes = proxy.get_nodes()
         return response
 
-    def get_node_details(self, request, response):
+    def get_node_details(
+        self, request: NodeDetails.Request, response: NodeDetails.Response
+    ) -> NodeDetails.Response:
         """
         Return a node description.
 
@@ -271,7 +286,9 @@ class Rosapi(Node):
         ) = proxy.get_node_info(request.node)
         return response
 
-    def get_action_servers(self, _request, response):
+    def get_action_servers(
+        self, _request: GetActionServers.Request, response: GetActionServers.Response
+    ) -> GetActionServers.Response:
         """
         Return a list of action servers based on actions standard topics.
 
@@ -281,7 +298,9 @@ class Rosapi(Node):
         response.action_servers = proxy.filter_action_servers(topics)
         return response
 
-    def get_topic_type(self, request, response):
+    def get_topic_type(
+        self, request: TopicType.Request, response: TopicType.Response
+    ) -> TopicType.Response:
         """
         Given the name of a topic, return the name of the type of that topic.
 
@@ -294,7 +313,9 @@ class Rosapi(Node):
         response.type = proxy.get_topic_type(request.topic, self.globs.topics)
         return response
 
-    def get_service_type(self, request, response):
+    def get_service_type(
+        self, request: ServiceType.Request, response: ServiceType.Response
+    ) -> ServiceType.Response:
         """
         Given the name of a service, return the type of that service.
 
@@ -307,7 +328,9 @@ class Rosapi(Node):
         response.type = proxy.get_service_type(request.service, self.globs.services)
         return response
 
-    def get_publishers(self, request, response):
+    def get_publishers(
+        self, request: Publishers.Request, response: Publishers.Response
+    ) -> Publishers.Response:
         """
         Given the name of a topic, return a list of node names that are publishing on that topic.
 
@@ -316,7 +339,9 @@ class Rosapi(Node):
         response.publishers = proxy.get_publishers(request.topic, self.globs.topics)
         return response
 
-    def get_subscribers(self, request, response):
+    def get_subscribers(
+        self, request: Subscribers.Request, response: Subscribers.Response
+    ) -> Subscribers.Response:
         """
         Given the name of a topic, return a list of node names that are subscribing to that topic.
 
@@ -325,7 +350,9 @@ class Rosapi(Node):
         response.subscribers = proxy.get_subscribers(request.topic, self.globs.topics)
         return response
 
-    def get_service_providers(self, request, response):
+    def get_service_providers(
+        self, request: ServiceProviders.Request, response: ServiceProviders.Response
+    ) -> ServiceProviders.Response:
         """
         Given the name of a topic, returns a list of node names that are advertising that service type.
 
@@ -334,7 +361,9 @@ class Rosapi(Node):
         response.providers = proxy.get_service_providers(request.service, self.globs.services)
         return response
 
-    def get_service_node(self, request, response):
+    def get_service_node(
+        self, request: ServiceNode.Request, response: ServiceNode.Response
+    ) -> ServiceNode.Response:
         """
         Given the name of a service, returns the name of the node that is providing that service.
 
@@ -343,7 +372,9 @@ class Rosapi(Node):
         response.node = proxy.get_service_node(request.service, self.globs.services)
         return response
 
-    def get_message_details(self, request, response):
+    def get_message_details(
+        self, request: MessageDetails.Request, response: MessageDetails.Response
+    ) -> MessageDetails.Response:
         """
         Given the name of a message type, return the TypeDef for that type.
 
@@ -354,7 +385,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_service_request_details(self, request, response):
+    def get_service_request_details(
+        self, request: ServiceRequestDetails.Request, response: ServiceRequestDetails.Response
+    ) -> ServiceRequestDetails.Response:
         """
         Given the name of a service type, return the TypeDef for the request message of that service type.
 
@@ -366,7 +399,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_service_response_details(self, request, response):
+    def get_service_response_details(
+        self, request: ServiceResponseDetails.Request, response: ServiceResponseDetails.Response
+    ) -> ServiceResponseDetails.Response:
         """
         Given the name of a service type, return the TypeDef for the response message of that service type.
 
@@ -378,7 +413,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_action_goal_details(self, request, response):
+    def get_action_goal_details(
+        self, request: ActionGoalDetails.Request, response: ActionGoalDetails.Response
+    ) -> ActionGoalDetails.Response:
         """
         Given the name of an action type, return the TypeDef for the goal message of that action type.
 
@@ -389,7 +426,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_action_result_details(self, request, response):
+    def get_action_result_details(
+        self, request: ActionResultDetails.Request, response: ActionResultDetails.Response
+    ) -> ActionResultDetails.Response:
         """
         Given the name of an action type, return the TypeDef for the result message of that action type.
 
@@ -401,7 +440,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_action_feedback_details(self, request, response):
+    def get_action_feedback_details(
+        self, request: ActionFeedbackDetails.Request, response: ActionFeedbackDetails.Response
+    ) -> ActionFeedbackDetails.Response:
         """
         Given the name of an action type, return the TypeDef for the feedback message of that action type.
 
@@ -413,7 +454,9 @@ class Rosapi(Node):
         ]
         return response
 
-    def get_action_type(self, request, response):
+    def get_action_type(
+        self, request: ActionType.Request, response: ActionType.Response
+    ) -> ActionType.Response:
         """
         Given the name of an action, return its type.
 
@@ -424,7 +467,9 @@ class Rosapi(Node):
         response.type = proxy.get_action_type(request.action)
         return response
 
-    async def set_param(self, request, response):
+    async def set_param(
+        self, request: SetParam.Request, response: SetParam.Response
+    ) -> SetParam.Response:
         try:
             node_name, param_name = self._get_node_and_param_name(request.name)
         except ValueError:
@@ -440,7 +485,9 @@ class Rosapi(Node):
 
         return response
 
-    async def get_param(self, request, response):
+    async def get_param(
+        self, request: GetParam.Request, response: GetParam.Response
+    ) -> GetParam.Response:
         try:
             node_name, param_name = self._get_node_and_param_name(request.name)
         except ValueError:
@@ -467,7 +514,9 @@ class Rosapi(Node):
 
         return response
 
-    async def has_param(self, request, response):
+    async def has_param(
+        self, request: HasParam.Request, response: HasParam.Response
+    ) -> HasParam.Response:
         try:
             node_name, param_name = self._get_node_and_param_name(request.name)
         except ValueError:
@@ -477,7 +526,9 @@ class Rosapi(Node):
 
         return response
 
-    async def delete_param(self, request, response):
+    async def delete_param(
+        self, request: DeleteParam.Request, response: DeleteParam.Response
+    ) -> DeleteParam.Response:
         try:
             node_name, param_name = self._get_node_and_param_name(request.name)
         except ValueError:
@@ -493,29 +544,33 @@ class Rosapi(Node):
 
         return response
 
-    async def get_param_names(self, _request, response):
+    async def get_param_names(
+        self, _request: GetParamNames.Request, response: GetParamNames.Response
+    ) -> GetParamNames.Response:
         response.names = await params.get_param_names(self.globs.params)
         return response
 
-    def get_time(self, _request, response):
+    def get_time(self, _request: GetTime.Request, response: GetTime.Response) -> GetTime.Response:
         response.time = Clock(clock_type=ClockType.ROS_TIME).now().to_msg()
         return response
 
-    def _get_node_and_param_name(self, param):
+    def _get_node_and_param_name(self, param: str) -> tuple[str, str]:
         return tuple(param.split(":"))
 
-    def _print_malformed_param_name_warning(self, param_name):
+    def _print_malformed_param_name_warning(self, param_name: str) -> None:
         self.get_logger().warn(
             f"Malformed parameter name: {param_name}; expecting <node_name>:<param_name>"
         )
 
-    def get_ros_version(self, _request, response):
+    def get_ros_version(
+        self, _request: GetROSVersion.Request, response: GetROSVersion.Response
+    ) -> GetROSVersion.Response:
         response.version = 2
         response.distro = str(os.environ["ROS_DISTRO"])
         return response
 
 
-def dict_to_typedef(typedefdict):
+def dict_to_typedef(typedefdict: dict[str, Any]) -> TypeDef:
     typedef = TypeDef()
     typedef.type = typedefdict["type"]
     typedef.fieldnames = typedefdict["fieldnames"]
@@ -527,7 +582,7 @@ def dict_to_typedef(typedefdict):
     return typedef
 
 
-def main(args=None):
+def main(args: list[str] | None = None) -> None:
     if args is None:
         args = sys.argv
 

--- a/rosapi/src/rosapi/async_helper.py
+++ b/rosapi/src/rosapi/async_helper.py
@@ -34,16 +34,16 @@ from rclpy.node import Node
 from rclpy.task import Future
 
 
-async def futures_wait_for(node: Node, futures: list[Future], timeout_sec: float):
+async def futures_wait_for(node: Node, futures: list[Future], timeout_sec: float) -> None:
     """Await a list of futures with a timeout."""
     first_done_future: Future = Future()
 
-    def timeout_callback():
+    def timeout_callback() -> None:
         first_done_future.set_result(None)
 
     timer = node.create_timer(timeout_sec, timeout_callback)
 
-    def future_done_callback(_arg):
+    def future_done_callback(_arg: Future) -> None:
         if all(future.done() for future in futures):
             first_done_future.set_result(None)
 
@@ -56,11 +56,11 @@ async def futures_wait_for(node: Node, futures: list[Future], timeout_sec: float
     timer.destroy()
 
 
-async def async_sleep(node: Node, delay_sec: float):
+async def async_sleep(node: Node, delay_sec: float) -> None:
     """Block the coroutine for a given time."""
     sleep_future: Future = Future()
 
-    def timeout_callback():
+    def timeout_callback() -> None:
         sleep_future.set_result(None)
 
     timer = node.create_timer(delay_sec, timeout_callback)

--- a/rosapi/src/rosapi/async_helper.py
+++ b/rosapi/src/rosapi/async_helper.py
@@ -30,8 +30,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from rclpy.node import Node
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from rclpy.task import Future
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
 
 
 async def futures_wait_for(node: Node, futures: list[Future], timeout_sec: float) -> None:

--- a/rosapi/src/rosapi/glob_helper.py
+++ b/rosapi/src/rosapi/glob_helper.py
@@ -1,22 +1,28 @@
+from __future__ import annotations
+
 import fnmatch
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from rcl_interfaces.msg import ParameterType
 
+if TYPE_CHECKING:
+    from rclpy.node import Node
+
 
 class Globs(NamedTuple):
-    topics: list
-    services: list
-    params: list
+    topics: list[str]
+    services: list[str]
+    params: list[str]
 
 
-def get_globs(node):
-    def get_param(parameter_name):
-        parameter_value = node.get_parameter(parameter_name).get_parameter_value()
-        if parameter_value.type == ParameterType.PARAMETER_STRING:
-            parameter_value = parameter_value.string_value
-        else:
-            parameter_value = ""
+def get_globs(node: Node) -> Globs:
+    def get_param(parameter_name: str) -> list[str]:
+        parameter = node.get_parameter(parameter_name).get_parameter_value()
+
+        parameter_value = ""
+        if parameter.type == ParameterType.PARAMETER_STRING:
+            parameter_value = parameter.string_value
+
         # strips array delimiters in case of an array style value
         return [
             element.strip().strip("'")
@@ -30,14 +36,14 @@ def get_globs(node):
     return Globs(topics_glob, services_glob, params_glob)
 
 
-def filter_globs(globs, full_list):
+def filter_globs(globs: list[str] | None, full_list: list[str]) -> list[str]:
     # If the globs are empty (weren't defined in the params), return the full list
     if globs is not None and len(globs) > 0:
         return list(filter(lambda x: any_match(x, globs), full_list))
     return full_list
 
 
-def any_match(query, globs):
+def any_match(query: str, globs: list[str] | None) -> bool:
     return (
         globs is None or len(globs) == 0 or any(fnmatch.fnmatch(str(query), glob) for glob in globs)
     )

--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -35,13 +35,11 @@ from __future__ import annotations
 import inspect
 import logging
 import re
-from typing import TYPE_CHECKING, Any, TypeVar
-
-if TYPE_CHECKING:
-    from rosbridge_library.internal.type_support import ROSMessage
+from typing import Any, TypeVar
 
 from rosapi.stringify_field_types import stringify_field_types
 from rosbridge_library.internal import ros_loader
+from rosbridge_library.internal.type_support import ROSMessage
 
 logger = logging.getLogger(__name__)
 
@@ -354,7 +352,7 @@ def _get_subtypedefs_recursive(
     return typedefs
 
 
-def _type_name(type_name: str, instance: Any) -> str:  # noqa: ANN401
+def _type_name(type_name: str, instance: object) -> str:
     """Get the fully qualified type name for a given type and instance."""
     # The fully qualified type of atomic and special types is just their original name
     if type_name in atomics or type_name in specials:
@@ -366,6 +364,7 @@ def _type_name(type_name: str, instance: Any) -> str:  # noqa: ANN401
         return type_name
 
     # Otherwise, the type will come from the module and class name of the instance
+    assert isinstance(instance, ROSMessage)
     return _type_name_from_instance(instance)
 
 

--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -30,9 +30,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import inspect
 import logging
 import re
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from rosbridge_library.internal.type_support import ROSMessage
 
 from rosapi.stringify_field_types import stringify_field_types
 from rosbridge_library.internal import ros_loader
@@ -62,7 +68,7 @@ atomics = [
 specials = ["time", "duration"]
 
 
-def get_typedef(type_name):
+def get_typedef(type_name: str) -> dict | None:
     """
     Get the typedef for a message type.
 
@@ -99,27 +105,27 @@ def get_typedef(type_name):
         return None
 
 
-def get_service_request_typedef(servicetype):
+def get_service_request_typedef(servicetype: str) -> dict | None:
     """Return a typedef dict for the service request class for the specified service type."""
     # Get an instance of the service request class and return its typedef
     instance = ros_loader.get_service_request_instance(servicetype)
     return _get_typedef(instance)
 
 
-def get_service_response_typedef(servicetype):
+def get_service_response_typedef(servicetype: str) -> dict | None:
     """Return a typedef dict for the service response class for the specified service type."""
     # Get an instance of the service response class and return its typedef
     instance = ros_loader.get_service_response_instance(servicetype)
     return _get_typedef(instance)
 
 
-def get_typedef_recursive(type_name):
+def get_typedef_recursive(type_name: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
     # Just go straight into the recursive method
     return _get_typedefs_recursive(type_name, [])
 
 
-def get_service_request_typedef_recursive(servicetype):
+def get_service_request_typedef_recursive(servicetype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
     # Get an instance of the service request class and get its typedef
     instance = ros_loader.get_service_request_instance(servicetype)
@@ -129,7 +135,7 @@ def get_service_request_typedef_recursive(servicetype):
     return _get_subtypedefs_recursive(typedef, [])
 
 
-def get_service_response_typedef_recursive(servicetype):
+def get_service_response_typedef_recursive(servicetype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
     # Get an instance of the service response class and get its typedef
     instance = ros_loader.get_service_response_instance(servicetype)
@@ -139,7 +145,7 @@ def get_service_response_typedef_recursive(servicetype):
     return _get_subtypedefs_recursive(typedef, [])
 
 
-def get_action_goal_typedef_recursive(actiontype):
+def get_action_goal_typedef_recursive(actiontype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
     # Get an instance of the action goal class and get its typedef
     instance = ros_loader.get_action_goal_instance(actiontype)
@@ -149,7 +155,7 @@ def get_action_goal_typedef_recursive(actiontype):
     return _get_subtypedefs_recursive(typedef, [])
 
 
-def get_action_result_typedef_recursive(actiontype):
+def get_action_result_typedef_recursive(actiontype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
     # Get an instance of the action result class and get its typedef
     instance = ros_loader.get_action_result_instance(actiontype)
@@ -159,7 +165,7 @@ def get_action_result_typedef_recursive(actiontype):
     return _get_subtypedefs_recursive(typedef, [])
 
 
-def get_action_feedback_typedef_recursive(actiontype):
+def get_action_feedback_typedef_recursive(actiontype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
     # Get an instance of the action feedback class and get its typedef
     instance = ros_loader.get_action_feedback_instance(actiontype)
@@ -169,7 +175,7 @@ def get_action_feedback_typedef_recursive(actiontype):
     return _get_subtypedefs_recursive(typedef, [])
 
 
-def get_typedef_full_text(ty):
+def get_typedef_full_text(ty: str) -> str:
     """Return the full text (similar to `gendeps --cat`) for the specified message type."""
     try:
         return stringify_field_types(ty)
@@ -177,7 +183,7 @@ def get_typedef_full_text(ty):
         return f"# failed to get full definition text for {ty}: {e!s}"
 
 
-def _get_typedef(instance):
+def _get_typedef(instance: ROSMessage) -> dict | None:
     """Get a typedef dict for the specified instance."""
     if _valid_instance(instance):
         fieldnames, fieldtypes, fieldarraylen, examples = _handle_array_information(instance)
@@ -188,7 +194,7 @@ def _get_typedef(instance):
     return None
 
 
-def _valid_instance(instance):
+def _valid_instance(instance: ROSMessage) -> bool:
     """
     Check if instance is valid.
 
@@ -201,7 +207,9 @@ def _valid_instance(instance):
     )
 
 
-def _handle_array_information(instance):
+def _handle_array_information(
+    instance: ROSMessage,
+) -> tuple[list[str], list[str], list[int], list[str]]:
     """
     Handle extraction of array information.
 
@@ -211,6 +219,7 @@ def _handle_array_information(instance):
     fieldtypes = []
     fieldarraylen = []
     examples = []
+    slot: str
     for slot in instance.__slots__:
         key = slot.removeprefix("_")
         if key not in instance._fields_and_field_types:
@@ -227,7 +236,7 @@ def _handle_array_information(instance):
     return fieldnames, fieldtypes, fieldarraylen, examples
 
 
-def _handle_type_and_array_len(instance, name):
+def _handle_type_and_array_len(instance: ROSMessage, name: str) -> tuple[str, int]:
     """Extract field type and determine its length if it's an array."""
     # Get original field type using instance's _fields_and_field_types property
     field_type = instance._fields_and_field_types[name[1:]]
@@ -252,18 +261,19 @@ def _handle_type_and_array_len(instance, name):
     return field_type, arraylen
 
 
-def _handle_example(arraylen, field_type, field_instance):
+T = TypeVar("T")
+
+
+def _handle_example(arraylen: int, field_type: str, field_instance: T) -> T | list | dict:
     """Determine the example of a field instance, whether it's an array or atomic type."""
     if arraylen >= 0:
-        example = []
-    elif field_type not in atomics:
-        example = {}
-    else:
-        example = field_instance
-    return example
+        return []
+    if field_type not in atomics:
+        return {}
+    return field_instance
 
 
-def _handle_constant_information(instance):
+def _handle_constant_information(instance: ROSMessage) -> tuple[list[str], list[str]]:
     """Handle extraction of constants information including constant names and values."""
     constnames = []
     constvalues = []
@@ -280,8 +290,14 @@ def _handle_constant_information(instance):
 
 
 def _build_typedef_dictionary(
-    instance, fieldnames, fieldtypes, fieldarraylen, examples, constnames, constvalues
-):
+    instance: ROSMessage,
+    fieldnames: list[str],
+    fieldtypes: list[str],
+    fieldarraylen: list[int],
+    examples: list[str],
+    constnames: list[str],
+    constvalues: list[str],
+) -> dict[str, Any]:
     """Build the typedef dictionary from multiple inputs collected from instance."""
     return {
         "type": _type_name_from_instance(instance),
@@ -294,7 +310,7 @@ def _build_typedef_dictionary(
     }
 
 
-def _get_special_typedef(type_name):
+def _get_special_typedef(type_name: str) -> dict[str, Any] | None:
     example = None
     if type_name in {"time", "duration"}:
         example = {
@@ -309,7 +325,7 @@ def _get_special_typedef(type_name):
     return example
 
 
-def _get_typedefs_recursive(type_name, typesseen):
+def _get_typedefs_recursive(type_name: str, typesseen: list[str]) -> list[dict[str, str]]:
     """Return the type def for this type as well as the type defs for any fields within the type."""
     if type_name in typesseen:
         # Don't put a type if it's already been seen
@@ -324,7 +340,9 @@ def _get_typedefs_recursive(type_name, typesseen):
     return _get_subtypedefs_recursive(typedef, typesseen)
 
 
-def _get_subtypedefs_recursive(typedef, typesseen):
+def _get_subtypedefs_recursive(
+    typedef: dict[str, str] | None, typesseen: list[str]
+) -> list[dict[str, str]]:
     if typedef is None:
         return []
 
@@ -336,7 +354,7 @@ def _get_subtypedefs_recursive(typedef, typesseen):
     return typedefs
 
 
-def _type_name(type_name, instance):
+def _type_name(type_name: str, instance: Any) -> str:  # noqa: ANN401
     """Get the fully qualified type name for a given type and instance."""
     # The fully qualified type of atomic and special types is just their original name
     if type_name in atomics or type_name in specials:
@@ -351,6 +369,6 @@ def _type_name(type_name, instance):
     return _type_name_from_instance(instance)
 
 
-def _type_name_from_instance(instance):
+def _type_name_from_instance(instance: ROSMessage) -> str:
     mod = instance.__module__
     return mod[0 : mod.find(".")] + "/" + instance.__class__.__name__

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -88,7 +88,7 @@ def init(node: Node, timeout_sec: float = DEFAULT_PARAM_TIMEOUT_SEC) -> None:
     global _node, _timeout_sec
     _node = node
 
-    if not isinstance(timeout_sec, (int, float)) or timeout_sec <= 0:
+    if not isinstance(timeout_sec, int | float) or timeout_sec <= 0:
         msg = "Parameter timeout must be a positive number"
         raise ValueError(msg)
     _timeout_sec = timeout_sec

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -73,7 +73,7 @@ _parameter_type_mapping = [
 ]
 
 
-def init(node: Node, timeout_sec: float = DEFAULT_PARAM_TIMEOUT_SEC):
+def init(node: Node, timeout_sec: float = DEFAULT_PARAM_TIMEOUT_SEC) -> None:
     """
     Initialize params module with a rclpy.node.Node for further use.
 
@@ -94,7 +94,7 @@ def init(node: Node, timeout_sec: float = DEFAULT_PARAM_TIMEOUT_SEC):
     _timeout_sec = timeout_sec
 
 
-async def set_param(node_name: str, name: str, value: str, params_glob: list[str]):
+async def set_param(node_name: str, name: str, value: str, params_glob: list[str]) -> None:
     """Set a parameter in a given node."""
     if params_glob and not any(fnmatch.fnmatch(str(name), glob) for glob in params_glob):
         # If the glob list is not empty and there are no glob matches,
@@ -117,7 +117,9 @@ async def set_param(node_name: str, name: str, value: str, params_glob: list[str
     await _set_param(node_name, name, value)
 
 
-async def _set_param(node_name: str, name: str, value: str, parameter_type=None):
+async def _set_param(
+    node_name: str, name: str, value: str | None, parameter_type: int | None = None
+) -> None:
     """
     Set a parameter in a given node.
 
@@ -129,11 +131,13 @@ async def _set_param(node_name: str, name: str, value: str, parameter_type=None)
     parameter = Parameter()
     parameter.name = name
     if parameter_type is None:
+        assert value is not None
         parameter.value = get_parameter_value(string_value=value)
     else:
         parameter.value = ParameterValue()
         parameter.value.type = parameter_type
         if parameter_type != ParameterType.PARAMETER_NOT_SET:
+            assert value is not None
             setattr(parameter.value, _parameter_type_mapping[parameter_type], loads(value))
 
     assert _node is not None
@@ -232,7 +236,7 @@ async def _get_param(node_name: str, name: str) -> ParameterValue:
     return result.values[0]
 
 
-async def has_param(node_name: str, name: str, params_glob: str) -> bool:
+async def has_param(node_name: str, name: str, params_glob: list[str]) -> bool:
     """Check whether a given node has a parameter or not."""
     if params_glob and not any(fnmatch.fnmatch(str(name), glob) for glob in params_glob):
         # If the glob list is not empty and there are no glob matches,
@@ -249,7 +253,7 @@ async def has_param(node_name: str, name: str, params_glob: str) -> bool:
     return 0 < pvalue.type < len(_parameter_type_mapping)
 
 
-async def delete_param(node_name, name, params_glob):
+async def delete_param(node_name: str, name: str, params_glob: list[str]) -> None:
     """Delete a parameter in a given node."""
     if params_glob and not any(fnmatch.fnmatch(str(name), glob) for glob in params_glob):
         # If the glob list is not empty and there are no glob matches,

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -141,8 +141,8 @@ async def _set_param(
             setattr(parameter.value, _parameter_type_mapping[parameter_type], loads(value))
 
     assert _node is not None
-    client: Client = _node.create_client(
-        SetParameters,
+    client: Client[SetParameters.Request, SetParameters.Response] = _node.create_client(
+        SetParameters,  # type: ignore[arg-type]
         f"{node_name}/set_parameters",
         callback_group=MutuallyExclusiveCallbackGroup(),
     )
@@ -169,8 +169,9 @@ async def _set_param(
     result = future.result()
 
     assert result is not None
-    if not result.results[0].successful:
-        raise Exception(result.results[0].reason)
+    param_results = next(iter(result.results))
+    if param_results.successful:
+        raise Exception(param_results.reason)
 
 
 async def get_param(node_name: str, name: str, params_glob: str) -> str:
@@ -201,8 +202,8 @@ async def _get_param(node_name: str, name: str) -> ParameterValue:
     Internal helper function for get_param.
     """
     assert _node is not None
-    client: Client = _node.create_client(
-        GetParameters,
+    client: Client[GetParameters.Request, GetParameters.Response] = _node.create_client(
+        GetParameters,  # type: ignore[arg-type]
         f"{node_name}/get_parameters",
         callback_group=MutuallyExclusiveCallbackGroup(),
     )
@@ -233,7 +234,7 @@ async def _get_param(node_name: str, name: str) -> ParameterValue:
         msg = f"Parameter {name} not found"
         raise Exception(msg)
 
-    return result.values[0]
+    return next(iter(result.values))
 
 
 async def has_param(node_name: str, name: str, params_glob: list[str]) -> bool:
@@ -277,8 +278,8 @@ async def get_param_names(params_glob: str | None) -> list[str]:
         if node_name == _node.get_fully_qualified_name():
             continue
 
-        client: Client = _node.create_client(
-            ListParameters,
+        client: Client[ListParameters.Request, ListParameters.Response] = _node.create_client(
+            ListParameters,  # type: ignore[arg-type]
             f"{node_name}/list_parameters",
             callback_group=MutuallyExclusiveCallbackGroup(),
         )

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -271,7 +271,7 @@ async def get_param_names(params_glob: str | None) -> list[str]:
 
     nodes = [get_absolute_node_name(node) for node in get_nodes()]
 
-    futures: list[tuple[str, Future]] = []
+    futures: list[tuple[str, Future[ListParameters.Response]]] = []
     clients = []
     for node_name in nodes:
         if node_name == _node.get_fully_qualified_name():

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -32,7 +32,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from ros2action.api import get_action_names_and_types
 from ros2interface.api import type_completer
@@ -48,6 +48,8 @@ from ros2topic.api import get_topic_names, get_topic_names_and_types
 from .glob_helper import any_match, filter_globs
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rclpy.node import Node
 
 _node: Node | None = None

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -30,6 +30,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
 from ros2action.api import get_action_names_and_types
 from ros2interface.api import type_completer
 from ros2node.api import (
@@ -43,10 +47,13 @@ from ros2topic.api import get_topic_names, get_topic_names_and_types
 
 from .glob_helper import any_match, filter_globs
 
-_node = None
+if TYPE_CHECKING:
+    from rclpy.node import Node
+
+_node: Node | None = None
 
 
-def init(node):
+def init(node: Node) -> None:
     """
     Initialize proxy module with a rclpy.node.Node for further use.
 
@@ -59,24 +66,28 @@ def init(node):
     _node = node
 
 
-def get_topics(topics_glob, include_hidden=False):
+def get_topics(topics_glob: list[str], include_hidden: bool = False) -> list[str]:
     """Return a list of all the active topics in the ROS system."""
     topic_names = get_topic_names(node=_node, include_hidden_topics=include_hidden)
     return filter_globs(topics_glob, topic_names)
 
 
-def get_interfaces():
+def get_interfaces() -> list[str]:
     """Return a list of all the types in the ROS system."""
     return type_completer()
 
 
-def get_topics_and_types(topics_glob, include_hidden=False):
+def get_topics_and_types(
+    topics_glob: list[str], include_hidden: bool = False
+) -> tuple[list[str], list[str]]:
     return get_publications_and_types(
         topics_glob, get_topic_names_and_types, include_hidden_topics=include_hidden
     )
 
 
-def get_topics_for_type(topic_type, topics_glob, include_hidden=False):
+def get_topics_for_type(
+    topic_type: str, topics_glob: list[str], include_hidden: bool = False
+) -> list[str]:
     topic_names_and_types = get_topic_names_and_types(
         node=_node, include_hidden_topics=include_hidden
     )
@@ -85,14 +96,16 @@ def get_topics_for_type(topic_type, topics_glob, include_hidden=False):
     return filter_globs(topics_glob, topics_for_type)
 
 
-def get_services(services_glob, include_hidden=False):
+def get_services(services_glob: list[str], include_hidden: bool = False) -> list[str]:
     """Return a list of all the services advertised in the ROS system."""
     # Filter the list of services by whether they are public before returning.
     service_names = get_service_names(node=_node, include_hidden_services=include_hidden)
     return filter_globs(services_glob, service_names)
 
 
-def get_services_and_types(services_glob, include_hidden=False):
+def get_services_and_types(
+    services_glob: list[str], include_hidden: bool = False
+) -> tuple[list[str], list[str]]:
     return get_publications_and_types(
         services_glob,
         get_service_names_and_types,
@@ -100,7 +113,9 @@ def get_services_and_types(services_glob, include_hidden=False):
     )
 
 
-def get_services_for_type(service_type, services_glob, include_hidden=False):
+def get_services_for_type(
+    service_type: str, services_glob: list[str], include_hidden: bool = False
+) -> list[str]:
     """Return a list of services as specific service type."""
     # Filter the list of services by whether they are public before returning.
     services_names_and_types = get_service_names_and_types(
@@ -113,7 +128,11 @@ def get_services_for_type(service_type, services_glob, include_hidden=False):
     return filter_globs(services_glob, services_for_type)
 
 
-def get_publications_and_types(glob, getter_function, **include_hidden_publications):
+def get_publications_and_types(
+    glob: list[str],
+    getter_function: Callable,
+    **include_hidden_publications: bool,
+) -> tuple[list[str], list[str]]:
     """
     Get a list of topic or service publications and their types.
 
@@ -138,13 +157,15 @@ def get_publications_and_types(glob, getter_function, **include_hidden_publicati
     return filtered_publications, filtered_publication_types
 
 
-def get_nodes(include_hidden=False):
+def get_nodes(include_hidden: bool = False) -> list[str]:
     """Return a list of all the nodes registered in the ROS system."""
     node_names = get_node_names(node=_node, include_hidden_nodes=include_hidden)
     return [node_name.full_name for node_name in node_names]
 
 
-def get_node_info(node_name, include_hidden=False):
+def get_node_info(
+    node_name: str, include_hidden: bool = False
+) -> tuple[list[str], list[str], list[str]] | None:
     node_names = get_node_names(node=_node, include_hidden_nodes=include_hidden)
     if node_name in [n.full_name for n in node_names]:
         # Only the name of each item is required as output.
@@ -156,31 +177,31 @@ def get_node_info(node_name, include_hidden=False):
     return None
 
 
-def get_node_publications(node_name):
+def get_node_publications(node_name: str) -> list[str]:
     """Return a list of topic names that are being published by the specified node."""
     publishers = get_publisher_info(node=_node, remote_node_name=node_name)
     return [publisher.name for publisher in publishers]
 
 
-def get_node_subscriptions(node_name):
+def get_node_subscriptions(node_name: str) -> list[str]:
     """Return a list of topic names that are being subscribed by the specified node."""
     subscribers = get_subscriber_info(node=_node, remote_node_name=node_name)
     return [subscriber.name for subscriber in subscribers]
 
 
-def get_node_services(node_name):
+def get_node_services(node_name: str) -> list[str]:
     """Return a list of service names that are being hosted by the specified node."""
     services = get_service_server_info(node=_node, remote_node_name=node_name)
     return [service.name for service in services]
 
 
-def get_node_service_types(node_name):
+def get_node_service_types(node_name: str) -> list[str]:
     """Return a list of service types that are being hosted by the specified node."""
     services = get_service_server_info(node=_node, remote_node_name=node_name)
     return [service.types[0] for service in services]
 
 
-def get_topic_type(topic, topics_glob):
+def get_topic_type(topic: str, topics_glob: list[str]) -> str:
     """Return the type of the specified ROS topic."""
     # Note: this doesn't consider hidden topics.
     topics, types = get_topics_and_types(topics_glob)
@@ -191,7 +212,7 @@ def get_topic_type(topic, topics_glob):
         return ""
 
 
-def filter_action_servers(topics):
+def filter_action_servers(topics: list[str]) -> list[str]:
     """Return a list of action servers."""
     # Note(@jubeira): filtering by topic should be enough; services can be taken into account as well.
     action_servers = []
@@ -220,7 +241,7 @@ def filter_action_servers(topics):
     return action_servers
 
 
-def get_service_type(service, services_glob):
+def get_service_type(service: str, services_glob: list[str]) -> str:
     """Return the type of the specified ROS service,."""
     # Note: this doesn't consider hidden services.
     services, types = get_services_and_types(services_glob)
@@ -231,7 +252,9 @@ def get_service_type(service, services_glob):
         return ""
 
 
-def get_channel_info(channel, channels_glob, getter_function, include_hidden=False):
+def get_channel_info(
+    channel: str, channels_glob: list[str], getter_function: Callable, include_hidden: bool = False
+) -> list[str]:
     """
     Return a list of node names that are publishing on a specified channel.
 
@@ -259,21 +282,23 @@ def get_channel_info(channel, channels_glob, getter_function, include_hidden=Fal
     return []
 
 
-def get_publishers(topic, topics_glob, include_hidden=False):
+def get_publishers(topic: str, topics_glob: list[str], include_hidden: bool = False) -> list[str]:
     """Return a list of node names that are publishing the specified topic."""
     return get_channel_info(
         topic, topics_glob, get_node_publications, include_hidden=include_hidden
     )
 
 
-def get_subscribers(topic, topics_glob, include_hidden=False):
+def get_subscribers(topic: str, topics_glob: list[str], include_hidden: bool = False) -> list[str]:
     """Return a list of node names that are subscribing to the specified topic."""
     return get_channel_info(
         topic, topics_glob, get_node_subscriptions, include_hidden=include_hidden
     )
 
 
-def get_service_providers(queried_type, services_glob, include_hidden=False):
+def get_service_providers(
+    queried_type: str, services_glob: list[str], include_hidden: bool = False
+) -> list[str]:
     """Return a list of node names that are advertising a service with the specified type."""
     return get_channel_info(
         queried_type,
@@ -283,7 +308,9 @@ def get_service_providers(queried_type, services_glob, include_hidden=False):
     )
 
 
-def get_service_node(queried_type, services_glob, include_hidden=False):
+def get_service_node(
+    queried_type: str, services_glob: list[str], include_hidden: bool = False
+) -> str:
     """Return the name of the node that is providing the given service, or empty string."""
     node_name = get_channel_info(
         queried_type, services_glob, get_node_services, include_hidden=include_hidden
@@ -293,13 +320,13 @@ def get_service_node(queried_type, services_glob, include_hidden=False):
     return ""
 
 
-def get_action_type(action_name, include_hidden=False):
+def get_action_type(action_name: str) -> str:
     """
     Return the type of the specified ROS action.
 
     If the action does not exist, an empty string is returned.
     """
-    names_and_types = get_action_names_and_types(node=_node, include_hidden_actions=include_hidden)
+    names_and_types = get_action_names_and_types(node=_node)
 
     for name, types in names_and_types:
         if name == action_name and types:

--- a/rosapi/src/rosapi/stringify_field_types.py
+++ b/rosapi/src/rosapi/stringify_field_types.py
@@ -4,7 +4,7 @@ from rosidl_adapter.parser import parse_message_string
 from rosidl_runtime_py import get_interface_path
 
 
-def stringify_field_types(root_type):
+def stringify_field_types(root_type: str) -> str:
     definition = ""
     seen_types = set()
     deps = [root_type]

--- a/rosapi/src/rosapi/stringify_field_types.py
+++ b/rosapi/src/rosapi/stringify_field_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from rosidl_adapter.parser import parse_message_string

--- a/rosapi/test/test_stringify_field_types.py
+++ b/rosapi/test/test_stringify_field_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import unittest
 

--- a/rosapi/test/test_typedefs.py
+++ b/rosapi/test/test_typedefs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 from typing import ClassVar
 

--- a/rosapi/test/test_typedefs.py
+++ b/rosapi/test/test_typedefs.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from rosapi import objectutils
 
@@ -17,7 +17,7 @@ class TestUtils(unittest.TestCase):
         global ros_loader
         ros_loader = self.original_ros_loader
 
-    def _mock_get_message_instance(self, type_name: str) -> Any:
+    def _mock_get_message_instance(self, type_name: str) -> object:
         class MockInstance:
             __slots__ = ["_" + type_name]
             _fields_and_field_types: ClassVar = {type_name: type_name}
@@ -47,7 +47,7 @@ class TestUtils(unittest.TestCase):
             __slots__ = ["_check_fields", "_important_data"]
             _fields_and_field_types: ClassVar = {"important_data": "int32"}
 
-            def __init__(self):
+            def __init__(self) -> None:
                 self._important_data = 123
                 self._check_fields = None
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/action_feedback.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/action_feedback.py
@@ -30,11 +30,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion, ros_loader
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class ActionFeedback(Capability):

--- a/rosbridge_library/src/rosbridge_library/capabilities/action_feedback.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/action_feedback.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from typing import Any
+
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion, ros_loader
 from rosbridge_library.protocol import Protocol
@@ -54,12 +56,12 @@ class ActionFeedback(Capability):
         self.basic_type_check(message, self.action_feedback_msg_fields)
 
         # check for the action
-        action_name = message["action"]
+        action_name: str = message["action"]
         if action_name in self.protocol.external_action_list:
             action_handler = self.protocol.external_action_list[action_name]
             # parse the message
-            goal_id = message["id"]
-            values = message["values"]
+            goal_id: str = message["id"]
+            values: dict[str, Any] = message["values"]
             # create a message instance
             feedback = ros_loader.get_action_feedback_instance(action_handler.action_type)
             message_conversion.populate_instance(values, feedback)

--- a/rosbridge_library/src/rosbridge_library/capabilities/action_result.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/action_result.py
@@ -30,11 +30,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion, ros_loader
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class ActionResult(Capability):

--- a/rosbridge_library/src/rosbridge_library/capabilities/action_result.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/action_result.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from typing import Any
+
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion, ros_loader
 from rosbridge_library.protocol import Protocol
@@ -56,14 +58,14 @@ class ActionResult(Capability):
         self.basic_type_check(message, self.action_result_msg_fields)
 
         # check for the action
-        action_name = message["action"]
+        action_name: str = message["action"]
         if action_name in self.protocol.external_action_list:
             action_handler = self.protocol.external_action_list[action_name]
-            goal_id = message["id"]
+            goal_id: str = message["id"]
             if message["result"]:
                 # parse the message
-                values = message["values"]
-                status = message["status"]
+                values: dict[str, Any] = message["values"]
+                status: int = message["status"]
                 # create a message instance
                 result = ros_loader.get_action_result_instance(action_handler.action_type)
                 message_conversion.populate_instance(values, result)

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -31,10 +31,18 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import fnmatch
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.publishers import manager
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
+
+    from rosbridge_library.protocol import Protocol
 
 
 class Registration:
@@ -46,17 +54,21 @@ class Registration:
     at the appropriate moments
     """
 
-    def __init__(self, client_id, topic, node_handle):
+    DUMMY_ADV_ID = "dummy_adv_id"
+
+    def __init__(self, client_id: str, topic: str, node_handle: Node) -> None:
         # Initialise variables
         self.client_id = client_id
         self.topic = topic
-        self.clients = {}
+        self.clients: dict[str, bool] = {}
         self.node_handle = node_handle
 
-    def unregister(self):
+    def unregister(self) -> None:
         manager.unregister(self.client_id, self.topic)
 
-    def register_advertisement(self, msg_type, adv_id=None, latch=False, queue_size=100):
+    def register_advertisement(
+        self, msg_type: str, adv_id: str | None = None, latch: bool = False, queue_size: int = 100
+    ) -> None:
         # Register with the publisher manager, propagating any exception
         manager.register(
             self.client_id,
@@ -67,15 +79,19 @@ class Registration:
             queue_size=queue_size,
         )
 
-        self.clients[adv_id] = True
+        if adv_id is not None:
+            self.clients[adv_id] = True
+        else:
+            # If no adv_id is provided, use a dummy one
+            self.clients[Registration.DUMMY_ADV_ID] = True
 
-    def unregister_advertisement(self, adv_id=None):
+    def unregister_advertisement(self, adv_id: str | None = None) -> None:
         if adv_id is None:
             self.clients.clear()
         elif adv_id in self.clients:
             del self.clients[adv_id]
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return len(self.clients) == 0
 
 
@@ -85,7 +101,7 @@ class Advertise(Capability):
 
     topics_glob = None
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
@@ -93,15 +109,14 @@ class Advertise(Capability):
         protocol.register_operation("advertise", self.advertise)
         protocol.register_operation("unadvertise", self.unadvertise)
 
-        # Initialize class variables
-        self._registrations = {}
+        self._registrations: dict[str, Registration] = {}
 
         if protocol.parameters and "unregister_timeout" in protocol.parameters:
             manager.unregister_timeout = protocol.parameters.get("unregister_timeout")
 
-    def advertise(self, message):
+    def advertise(self, message: dict[str, Any]) -> None:
         # Pull out the ID
-        aid = message.get("id", None)
+        aid = message.get("id")
 
         self.basic_type_check(message, self.advertise_msg_fields)
         topic = message["topic"]
@@ -137,9 +152,9 @@ class Advertise(Capability):
         # Register, propagating any exceptions
         self._registrations[topic].register_advertisement(msg_type, aid, latch, queue_size)
 
-    def unadvertise(self, message):
+    def unadvertise(self, message: dict[str, Any]) -> None:
         # Pull out the ID
-        aid = message.get("id", None)
+        aid = message.get("id")
 
         self.basic_type_check(message, self.unadvertise_msg_fields)
         topic = message["topic"]
@@ -174,7 +189,7 @@ class Advertise(Capability):
             self._registrations[topic].unregister()
             del self._registrations[topic]
 
-    def finish(self):
+    def finish(self) -> None:
         for registration in self._registrations.values():
             registration.unregister()
         self._registrations.clear()

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -119,10 +119,10 @@ class Advertise(Capability):
         aid = message.get("id")
 
         self.basic_type_check(message, self.advertise_msg_fields)
-        topic = message["topic"]
-        msg_type = message["type"]
-        latch = message.get("latch", False)
-        queue_size = message.get("queue_size", 100)
+        topic: str = message["topic"]
+        msg_type: str = message["type"]
+        latch: bool = message.get("latch", False)
+        queue_size: int = message.get("queue_size", 100)
 
         if Advertise.topics_glob is not None and Advertise.topics_glob:
             self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
@@ -154,10 +154,10 @@ class Advertise(Capability):
 
     def unadvertise(self, message: dict[str, Any]) -> None:
         # Pull out the ID
-        aid = message.get("id")
+        aid: str | None = message.get("id")
 
         self.basic_type_check(message, self.unadvertise_msg_fields)
-        topic = message["topic"]
+        topic: str = message["topic"]
 
         if Advertise.topics_glob is not None and Advertise.topics_glob:
             self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -99,7 +99,7 @@ class Advertise(Capability):
     advertise_msg_fields = ((True, "topic", str), (True, "type", str))
     unadvertise_msg_fields = ((True, "topic", str),)
 
-    topics_glob = None
+    topics_glob: list[str] | None = None
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import fnmatch
-from typing import Any
+from typing import Generic
 
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionServer
@@ -42,31 +42,41 @@ from rclpy.task import Future
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion
 from rosbridge_library.internal.ros_loader import get_action_class
+from rosbridge_library.internal.type_support import (
+    ROSActionFeedbackT,
+    ROSActionGoalT,
+    ROSActionResultT,
+    ROSMessage,
+)
 from rosbridge_library.protocol import Protocol
 
 
-class AdvertisedActionHandler:
+class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
     id_counter = 1
 
     def __init__(
         self, action_name: str, action_type: str, protocol: Protocol, sleep_time: float = 0.001
     ) -> None:
         self.goal_futures: dict[str, Future] = {}
-        self.goal_handles: dict[str, Any] = {}
-        self.goal_statuses: dict[str, GoalStatus] = {}
+        self.goal_handles: dict[
+            str, ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
+        ] = {}
+        self.goal_statuses: dict[str, int] = {}
 
         self.action_name = action_name
         self.action_type = action_type
         self.protocol = protocol
         self.sleep_time = sleep_time
         # setup the action
-        self.action_server = ActionServer(
-            protocol.node_handle,
-            get_action_class(action_type),
-            action_name,
-            self.execute_callback,
-            cancel_callback=self.cancel_callback,
-            callback_group=ReentrantCallbackGroup(),  # https://github.com/ros2/rclpy/issues/834#issuecomment-961331870
+        self.action_server: ActionServer[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = (
+            ActionServer(
+                protocol.node_handle,
+                get_action_class(action_type),
+                action_name,
+                self.execute_callback,  # type: ignore[arg-type]  # rclpy type hint does not support coroutines
+                cancel_callback=self.cancel_callback,  # type: ignore[arg-type]  # rclpy type hint is incorrect
+                callback_group=ReentrantCallbackGroup(),  # https://github.com/ros2/rclpy/issues/834#issuecomment-961331870
+            )
         )
 
     def next_id(self) -> int:
@@ -74,7 +84,9 @@ class AdvertisedActionHandler:
         self.id_counter += 1
         return next_id_value
 
-    async def execute_callback(self, goal: Any) -> Any:
+    async def execute_callback(
+        self, goal: ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
+    ) -> ROSActionResultT:
         """
         Execute action goal.
 
@@ -102,7 +114,7 @@ class AdvertisedActionHandler:
                 else:
                     goal.abort()
 
-        future: Future = Future()
+        future: Future[ROSActionResultT] = Future()
         future.add_done_callback(done_callback)
         self.goal_handles[goal_id] = goal
         self.goal_futures[goal_id] = future
@@ -119,19 +131,23 @@ class AdvertisedActionHandler:
         self.protocol.send(goal_message)
 
         try:
-            return await future
+            result = await future
+            assert result is not None, "Action result cannot be None"
+            return result
         finally:
             del self.goal_futures[goal_id]
             del self.goal_handles[goal_id]
 
-    def cancel_callback(self, cancel_request: ServerGoalHandle) -> CancelResponse:
+    def cancel_callback(
+        self, goal: ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
+    ) -> CancelResponse:
         """
         Cancel action goal.
 
         ActionServer callback for canceling an action goal.
         """
         for goal_id, goal_handle in self.goal_handles.items():
-            if cancel_request.goal_id == goal_handle.goal_id:
+            if goal.goal_id == goal_handle.goal_id:
                 self.protocol.log("warning", f"Canceling action {goal_id}")
                 cancel_message = {
                     "op": "cancel_action_goal",
@@ -141,18 +157,18 @@ class AdvertisedActionHandler:
                 self.protocol.send(cancel_message)
         return CancelResponse.ACCEPT
 
-    def handle_feedback(self, goal_id: str, feedback: Any) -> None:
+    def handle_feedback(self, goal_id: str, feedback: ROSActionFeedbackT) -> None:
         """
         Handle action feedback.
 
         Called by the ActionFeedback capability to handle action feedback from the external client.
         """
         if goal_id in self.goal_handles:
-            self.goal_handles[goal_id].publish_feedback(feedback)
+            self.goal_handles[goal_id].publish_feedback(feedback)  # type: ignore[arg-type]
         else:
             self.protocol.log("warning", f"Received action feedback for unrecognized id: {goal_id}")
 
-    def handle_result(self, goal_id: str, result: dict, status: int) -> None:
+    def handle_result(self, goal_id: str, result: ROSActionResultT, status: int) -> None:
         """
         Handle action result.
 
@@ -248,6 +264,8 @@ class AdvertiseAction(Capability):
 
         # setup and store the action information
         action_type = message["type"]
-        action_handler = AdvertisedActionHandler(action_name, action_type, self.protocol)
+        action_handler: AdvertisedActionHandler[ROSMessage, ROSMessage, ROSMessage] = (
+            AdvertisedActionHandler(action_name, action_type, self.protocol)
+        )
         self.protocol.external_action_list[action_name] = action_handler
         self.protocol.log("info", f"Advertised action {action_name}")

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -30,8 +30,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import fnmatch
-from typing import Generic, cast
+from typing import TYPE_CHECKING, Generic, cast
 
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionServer
@@ -48,7 +50,9 @@ from rosbridge_library.internal.type_support import (
     ROSActionResultT,
     ROSMessage,
 )
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import fnmatch
-from typing import Generic
+from typing import Generic, cast
 
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionServer
@@ -57,7 +57,7 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
     def __init__(
         self, action_name: str, action_type: str, protocol: Protocol, sleep_time: float = 0.001
     ) -> None:
-        self.goal_futures: dict[str, Future] = {}
+        self.goal_futures: dict[str, Future[ROSActionResultT]] = {}
         self.goal_handles: dict[
             str, ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
         ] = {}
@@ -95,12 +95,14 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
         # generate a unique ID
         goal_id = f"action_goal:{self.action_name}:{self.next_id()}"
 
-        def done_callback(fut: Future) -> None:
+        def done_callback(fut: Future[ROSActionResultT]) -> None:
             if fut.cancelled():
                 goal.abort()
                 self.protocol.log("info", f"Aborted goal {goal_id}")
                 # Send an empty result to avoid stack traces
-                fut.set_result(get_action_class(self.action_type).Result())
+                fut.set_result(
+                    cast("ROSActionResultT", get_action_class(self.action_type).Result())
+                )
             else:
                 if goal_id not in self.goal_statuses:
                     goal.abort()

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -230,7 +230,7 @@ class AdvertiseAction(Capability):
         self.basic_type_check(message, self.advertise_action_msg_fields)
 
         # parse the incoming message
-        action_name = message["action"]
+        action_name: str = message["action"]
 
         if AdvertiseAction.actions_glob is not None and AdvertiseAction.actions_glob:
             self.protocol.log(
@@ -265,7 +265,7 @@ class AdvertiseAction(Capability):
             del self.protocol.external_action_list[action_name]
 
         # setup and store the action information
-        action_type = message["type"]
+        action_type: str = message["type"]
         action_handler: AdvertisedActionHandler[ROSMessage, ROSMessage, ROSMessage] = (
             AdvertisedActionHandler(action_name, action_type, self.protocol)
         )

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
@@ -117,7 +117,7 @@ class AdvertiseService(Capability):
         self.basic_type_check(message, self.advertise_service_msg_fields)
 
         # parse the incoming message
-        service_name = message["service"]
+        service_name: str = message["service"]
 
         if AdvertiseService.services_glob is not None and AdvertiseService.services_glob:
             self.protocol.log(
@@ -152,7 +152,7 @@ class AdvertiseService(Capability):
             del self.protocol.external_service_list[service_name]
 
         # setup and store the service information
-        service_type = message["type"]
+        service_type: str = message["type"]
         service_handler: AdvertisedServiceHandler[ROSMessage, ROSMessage] = (
             AdvertisedServiceHandler(service_name, service_type, self.protocol)
         )

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
@@ -1,39 +1,53 @@
 import fnmatch
+from typing import TYPE_CHECKING, Any, Generic
 
-import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.task import Future
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion
 from rosbridge_library.internal.ros_loader import get_service_class
+from rosbridge_library.internal.type_support import (
+    ROSMessage,
+    ROSServiceRequestT,
+    ROSServiceResponseT,
+)
+from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rclpy.service import Service
 
 
-class AdvertisedServiceHandler:
+class AdvertisedServiceHandler(Generic[ROSServiceRequestT, ROSServiceResponseT]):
     id_counter = 1
 
-    def __init__(self, service_name, service_type, protocol):
-        self.request_futures = {}
+    def __init__(self, service_name: str, service_type: str, protocol: Protocol) -> None:
+        self.request_futures: dict[str, Future[ROSServiceResponseT]] = {}
         self.service_name = service_name
         self.service_type = service_type
         self.protocol = protocol
         # setup the service
-        self.service_handle = protocol.node_handle.create_service(
-            get_service_class(service_type),
-            service_name,
-            self.handle_request,
-            callback_group=ReentrantCallbackGroup(),  # https://github.com/ros2/rclpy/issues/834#issuecomment-961331870
+        self.service_handle: Service[ROSServiceRequestT, ROSServiceResponseT] = (
+            protocol.node_handle.create_service(
+                get_service_class(service_type),
+                service_name,
+                self.handle_request,  # type: ignore[arg-type]  # rclpy type hint does not support coroutines
+                callback_group=ReentrantCallbackGroup(),  # https://github.com/ros2/rclpy/issues/834#issuecomment-961331870
+            )
         )
 
-    def next_id(self):
+    def next_id(self) -> int:
         next_id_value = self.id_counter
         self.id_counter += 1
         return next_id_value
 
-    async def handle_request(self, req, _res):
+    async def handle_request(
+        self, req: ROSServiceRequestT, _res: ROSServiceResponseT
+    ) -> ROSServiceResponseT:
         # generate a unique ID
         request_id = f"service_request:{self.service_name}:{self.next_id()}"
 
-        future = rclpy.task.Future()
+        future: Future[ROSServiceResponseT] = Future()
         self.request_futures[request_id] = future
 
         # build a request to send to the external client
@@ -46,11 +60,13 @@ class AdvertisedServiceHandler:
         self.protocol.send(request_message)
 
         try:
-            return await future
+            result = await future
+            assert result is not None, "Service response cannot be None"
+            return result
         finally:
             del self.request_futures[request_id]
 
-    def handle_response(self, request_id, res):
+    def handle_response(self, request_id: str, res: ROSServiceResponseT) -> None:
         """
         Handle service response.
 
@@ -63,7 +79,7 @@ class AdvertisedServiceHandler:
                 "warning", f"Received service response for unrecognized id: {request_id}"
             )
 
-    def graceful_shutdown(self):
+    def graceful_shutdown(self) -> None:
         """
         Signal the AdvertisedServiceHandler to shutdown.
 
@@ -89,14 +105,14 @@ class AdvertiseService(Capability):
 
     advertise_service_msg_fields = ((True, "service", str), (True, "type", str))
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
         # Register the operations that this capability provides
         protocol.register_operation("advertise_service", self.advertise_service)
 
-    def advertise_service(self, message):
+    def advertise_service(self, message: dict[str, Any]) -> None:
         # Typecheck the args
         self.basic_type_check(message, self.advertise_service_msg_fields)
 
@@ -137,6 +153,8 @@ class AdvertiseService(Capability):
 
         # setup and store the service information
         service_type = message["type"]
-        service_handler = AdvertisedServiceHandler(service_name, service_type, self.protocol)
+        service_handler: AdvertisedServiceHandler[ROSMessage, ROSMessage] = (
+            AdvertisedServiceHandler(service_name, service_type, self.protocol)
+        )
         self.protocol.external_service_list[service_name] = service_handler
         self.protocol.log("info", f"Advertised service {service_name}")

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import fnmatch
 from typing import TYPE_CHECKING, Any, Generic
 
@@ -12,10 +14,11 @@ from rosbridge_library.internal.type_support import (
     ROSServiceRequestT,
     ROSServiceResponseT,
 )
-from rosbridge_library.protocol import Protocol
 
 if TYPE_CHECKING:
     from rclpy.service import Service
+
+    from rosbridge_library.protocol import Protocol
 
 
 class AdvertisedServiceHandler(Generic[ROSServiceRequestT, ROSServiceResponseT]):
@@ -101,7 +104,7 @@ class AdvertisedServiceHandler(Generic[ROSServiceRequestT, ROSServiceResponseT])
 
 
 class AdvertiseService(Capability):
-    services_glob = None
+    services_glob: list[str] | None = None
 
     advertise_service_msg_fields = ((True, "service", str), (True, "type", str))
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -30,12 +30,18 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import fnmatch
 from functools import partial
 from threading import Thread
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.services import ServiceCaller
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class CallService(Capability):
@@ -47,7 +53,7 @@ class CallService(Capability):
 
     services_glob = None
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
@@ -74,16 +80,16 @@ class CallService(Capability):
             protocol.node_handle.get_logger().info("Calling services in existing thread")
             protocol.register_operation("call_service", self.call_service)
 
-    def call_service(self, message):
+    def call_service(self, message: dict[str, Any]) -> None:
         # Pull out the ID
-        cid = message.get("id", None)
+        cid = message.get("id")
 
         # Typecheck the args
         self.basic_type_check(message, self.call_service_msg_fields)
 
         # Extract the args
         service = message["service"]
-        fragment_size = message.get("fragment_size", None)
+        fragment_size = message.get("fragment_size")
         compression = message.get("compression", "none")
         args = message.get("args", [])
         timeout = message.get("timeout", self.default_timeout)
@@ -127,7 +133,14 @@ class CallService(Capability):
             self.protocol.node_handle,
         ).run()
 
-    def _success(self, cid, service, _fragment_size, _compression, message):
+    def _success(
+        self,
+        cid: str | None,
+        service: str,
+        _fragment_size: int,
+        _compression: str,
+        message: dict[str, Any],
+    ) -> None:
         outgoing_message = {
             "op": "service_response",
             "service": service,
@@ -139,7 +152,7 @@ class CallService(Capability):
         # TODO: fragmentation, compression
         self.protocol.send(outgoing_message)
 
-    def _failure(self, cid, service, exc):
+    def _failure(self, cid: str | None, service: str, exc: Exception) -> None:
         self.protocol.log("error", f"call_service {type(exc).__name__}: {exc!s}", cid)
         # send response with result: false
         outgoing_message = {
@@ -153,13 +166,13 @@ class CallService(Capability):
         self.protocol.send(outgoing_message)
 
 
-def trim_servicename(service):
+def trim_servicename(service: str) -> str:
     if "#" in service:
         return service[: service.find("#")]
     return service
 
 
-def extract_id(service, cid):
+def extract_id(service: str, cid: str | None) -> str | None:
     if cid is not None:
         return cid
     if "#" in service:

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -51,7 +51,7 @@ class CallService(Capability):
         (False, "compression", str),
     )
 
-    services_glob = None
+    services_glob: list[str] | None = None
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor

--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -82,17 +82,17 @@ class CallService(Capability):
 
     def call_service(self, message: dict[str, Any]) -> None:
         # Pull out the ID
-        cid = message.get("id")
+        cid: str | None = message.get("id")
 
         # Typecheck the args
         self.basic_type_check(message, self.call_service_msg_fields)
 
         # Extract the args
-        service = message["service"]
-        fragment_size = message.get("fragment_size")
-        compression = message.get("compression", "none")
-        args = message.get("args", [])
-        timeout = message.get("timeout", self.default_timeout)
+        service: str = message["service"]
+        fragment_size: int | None = message.get("fragment_size")
+        compression: str = message.get("compression", "none")
+        args: list | dict[str, Any] = message.get("args", [])
+        timeout: float = message.get("timeout", self.default_timeout)
 
         if CallService.services_glob is not None and CallService.services_glob:
             self.protocol.log(
@@ -137,7 +137,7 @@ class CallService(Capability):
         self,
         cid: str | None,
         service: str,
-        _fragment_size: int,
+        _fragment_size: int | None,
         _compression: str,
         message: dict[str, Any],
     ) -> None:

--- a/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
@@ -1,5 +1,5 @@
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.protocol import Protocol
@@ -8,18 +8,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-class ReceivedFragments:
-    """Singleton class to hold lists of received fragments in one 'global' object."""
-
-    class __impl:
-        """Implementation of the singleton interface."""
-
-        def spam(self) -> int:
-            """Test method, return singleton id."""
-            return id(self)
-
-    __instance = None
-    # List of defragmentation instances
+class Defragment(Capability):
+    # Dictionary of defragmentation instances
     # Format:
     # {
     #   <<message1_ID>> : {
@@ -30,20 +20,9 @@ class ReceivedFragments:
     #       <<fragment2ID>>: <<fragment2_data>>,
     #       ...
     #     }
-    # },
-    # ...
-    lists: dict[str, dict]
+    # }
+    lists: ClassVar[dict[str, dict]] = {}
 
-    def __init__(self) -> None:
-        """Create singleton instance."""
-        if ReceivedFragments.__instance is None:
-            ReceivedFragments.__instance = ReceivedFragments.__impl()
-            self.lists: dict[str, Any] = {}
-
-        self.__dict__["_ReceivedFragments__instance"] = ReceivedFragments.__instance
-
-
-class Defragment(Capability):
     fragment_timeout = 600
     opcode = "fragment"
 
@@ -56,7 +35,7 @@ class Defragment(Capability):
 
         protocol.register_operation(self.opcode, self.defragment)
 
-        self.received_fragments = ReceivedFragments().lists
+        self.received_fragments = Defragment.lists
 
     # defragment() does:
     #   1) take any incoming message with op-code "fragment"

--- a/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
@@ -1,7 +1,11 @@
-import threading
 import time
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
+from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class ReceivedFragments:
@@ -10,7 +14,7 @@ class ReceivedFragments:
     class __impl:
         """Implementation of the singleton interface."""
 
-        def spam(self):
+        def spam(self) -> int:
             """Test method, return singleton id."""
             return id(self)
 
@@ -30,33 +34,21 @@ class ReceivedFragments:
     # ...
     lists: dict[str, dict]
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create singleton instance."""
         if ReceivedFragments.__instance is None:
             ReceivedFragments.__instance = ReceivedFragments.__impl()
-            self.lists = {}
+            self.lists: dict[str, Any] = {}
 
         self.__dict__["_ReceivedFragments__instance"] = ReceivedFragments.__instance
 
-    def __getattr__(self, attr):
-        """Delegate access to implementation."""
-        return getattr(self.__instance, attr)
 
-    def __setattr__(self, attr, value):
-        """Delegate access to implementation."""
-        return setattr(self.__instance, attr, value)
-
-
-class Defragment(Capability, threading.Thread):
+class Defragment(Capability):
     fragment_timeout = 600
     opcode = "fragment"
 
-    protocol = None
-
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         Capability.__init__(self, protocol)
-
-        self.protocol = protocol
 
         # populate parameters
         if self.protocol.parameters is not None:
@@ -65,7 +57,6 @@ class Defragment(Capability, threading.Thread):
         protocol.register_operation(self.opcode, self.defragment)
 
         self.received_fragments = ReceivedFragments().lists
-        threading.Thread.__init__(self)
 
     # defragment() does:
     #   1) take any incoming message with op-code "fragment"
@@ -84,52 +75,53 @@ class Defragment(Capability, threading.Thread):
     #       (protocol.incoming is checking message fields by itself, so no need to do this before
     #       passing the reconstructed message to protocol)
     #   4.c) remove the fragment list to free up memory
-    def defragment(self, message):
+    def defragment(self, message: dict[str, Any]) -> None:
         now = time.monotonic()
 
-        if self.received_fragments is not None:
-            for frag_id in self.received_fragments:
-                time_diff = now - self.received_fragments[frag_id]["timestamp_last_append"]
-                if (
-                    time_diff > self.fragment_timeout
-                    and not self.received_fragments[frag_id]["is_reconstructing"]
-                ):
-                    log_msg = ["fragment list ", str(frag_id), " timed out.."]
+        msg_id: str | None = message.get("id")
+        if msg_id is None:
+            self.protocol.log("error", "received invalid fragment! No message ID found.")
+            return
 
-                    if message["id"] != frag_id:
-                        log_msg.append(" -> removing it..")
-                        del self.received_fragments[frag_id]
-                    else:
-                        log_msg.extend([" -> but we're just about to add fragment #"])
-                        log_msg.extend([str(message.get("num")), " of "])
-                        log_msg.extend([str(self.received_fragments[message.get("id")]["total"])])
-                        log_msg.extend([" ..keeping the list"])
-                    self.protocol.log("warning", "".join(log_msg))
+        for frag_id in self.received_fragments:
+            time_diff = now - self.received_fragments[frag_id]["timestamp_last_append"]
+            if (
+                time_diff > self.fragment_timeout
+                and not self.received_fragments[frag_id]["is_reconstructing"]
+            ):
+                log_msg = [f"fragment list {frag_id} timed out.."]
 
-        msg_opcode = message.get("op")
-        msg_id = message.get("id")
-        msg_num = message.get("num")
-        msg_total = message.get("total")
-        msg_data = message.get("data")
+                if msg_id != frag_id:
+                    log_msg.append(" -> removing it..")
+                    del self.received_fragments[frag_id]
+                else:
+                    log_msg.append(
+                        f" -> but we're just about to add fragment #{message.get('num')}"
+                        f" of {self.received_fragments[msg_id]['total']} ..keeping the list"
+                    )
+                self.protocol.log("warning", "".join(log_msg))
+
+        msg_opcode: str | None = message.get("op")
+        msg_num: int | None = message.get("num")
+        msg_total: int | None = message.get("total")
+        msg_data: Sequence | None = message.get("data")
 
         # Abort if any message field is missing
-        if None in (msg_opcode, msg_id, msg_num, msg_total, msg_data):
+        if msg_opcode is None or msg_num is None or msg_total is None or msg_data is None:
             self.protocol.log("error", "received invalid fragment!")
             return
 
-        log_msg = "fragment for messageID: " + str(msg_id) + " received."
-        self.protocol.log("debug", log_msg)
+        self.protocol.log("debug", "fragment for messageID: " + str(msg_id) + " received.")
 
         # Create fragment container if none exists yet
         if msg_id not in self.received_fragments:
             self.received_fragments[msg_id] = {
                 "is_reconstructing": False,
-                "total": message["total"],
+                "total": msg_total,
                 "timestamp_last_append": now,
                 "fragment_list": {},
             }
-            log_msg = "opened new fragment list for messageID " + str(msg_id)
-            self.protocol.log("debug", log_msg)
+            self.protocol.log("debug", "opened new fragment list for messageID " + str(msg_id))
 
         # print "received fragments:", len(self.received_fragments[msg_id]["fragment_list"].keys())
 
@@ -141,19 +133,13 @@ class Defragment(Capability, threading.Thread):
         ):
             self.received_fragments[msg_id]["fragment_list"][msg_num] = msg_data
             self.received_fragments[msg_id]["timestamp_last_append"] = now
-            log_msg = ["appended fragment #" + str(msg_num)]
-            log_msg.extend(
-                [
-                    " (total: ",
-                    str(msg_total),
-                    ") to fragment list for messageID ",
-                    str(msg_id),
-                ]
+
+            self.protocol.log(
+                "debug",
+                f"appended fragment #{msg_num} (total: {msg_total}) to fragment list for messageID {msg_id}",
             )
-            self.protocol.log("debug", "".join(log_msg))
         else:
-            log_msg = "error while trying to append fragment " + str(msg_num)
-            self.protocol.log("error", log_msg)
+            self.protocol.log("error", "error while trying to append fragment " + str(msg_num))
             return
 
         received_all_fragments = False
@@ -162,50 +148,40 @@ class Defragment(Capability, threading.Thread):
 
         # Make sure total number of fragments received
         if existing_fragments == announced_total:
-            log_msg = ["enough/all fragments for messageID " + str(msg_id) + " received"]
-            log_msg.extend([" [", str(existing_fragments), "]"])
-            log_msg = "".join(log_msg)
-            self.protocol.log("debug", log_msg)
+            self.protocol.log(
+                "debug",
+                f"enough/all fragments for messageID {msg_id} received [ {existing_fragments} ]",
+            )
             # Check each fragment matches up
             received_all_fragments = True
             for i in range(announced_total):
                 if i not in self.received_fragments[msg_id]["fragment_list"]:
                     received_all_fragments = False
-                    log_msg = "fragment #" + str(i)
-                    log_msg += " for messageID " + str(msg_id) + " is missing! "
-                    self.protocol.log("error", log_msg)
+                    self.protocol.log("error", f"fragment #{i} for messageID {msg_id} is missing!")
 
         self.received_fragments[msg_id]["is_reconstructing"] = received_all_fragments
 
         if received_all_fragments:
-            log_msg = "reconstructing original message " + str(msg_id)
-            self.protocol.log("debug", log_msg)
+            self.protocol.log("debug", f"reconstructing original message {msg_id}")
 
             # Reconstruct the message
             reconstructed_msg = "".join(self.received_fragments[msg_id]["fragment_list"].values())
 
-            log_msg = ["reconstructed original message:\n"]
-            log_msg.append(reconstructed_msg)
-            log_msg = "".join(log_msg)
-            self.protocol.log("debug", log_msg)
+            self.protocol.log("debug", f"reconstructed original message:\n{reconstructed_msg}")
 
             duration = time.monotonic() - now
 
             # Pass the reconstructed message to rosbridge
             self.protocol.incoming(reconstructed_msg)
-            log_msg = ["reconstructed message (ID:" + str(msg_id) + ") from "]
-            log_msg.extend([str(msg_total), " fragments. "])
-            # cannot access msg.data if message is a service_response or else!
-            # log_msg += "[message length: " + str(len(str(json.loads(reconstructed_msg)["msg"]["data"]))) +"]"
-            log_msg.extend(["[duration: ", str(duration), " s]"])
-            log_msg = "".join(log_msg)
-            self.protocol.log("info", log_msg)
+
+            self.protocol.log(
+                "info",
+                f"reconstructed messsage (ID: {msg_id}) from {msg_total} fragments. [duration: {duration} s]",
+            )
 
             # Remove fragmentation container
             del self.received_fragments[msg_id]
-            log_msg = "removed fragment list for messageID " + str(msg_id)
-            self.protocol.log("debug", log_msg)
+            self.protocol.log("debug", f"removed fragment list for messageID {msg_id}")
 
-    def finish(self):
-        self.received_fragments = None
+    def finish(self) -> None:
         self.protocol.unregister_operation("fragment")

--- a/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
@@ -155,7 +155,7 @@ class Defragment(Capability):
 
             self.protocol.log(
                 "info",
-                f"reconstructed messsage (ID: {msg_id}) from {msg_total} fragments. [duration: {duration} s]",
+                f"reconstructed message (ID: {msg_id}) from {msg_total} fragments. [duration: {duration} s]",
             )
 
             # Remove fragmentation container

--- a/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/defragmentation.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import time
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from rosbridge_library.capability import Capability
-from rosbridge_library.protocol import Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from rosbridge_library.protocol import Protocol
 
 
 class Defragment(Capability):

--- a/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
@@ -30,9 +30,17 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import math
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
+
+    from rosbridge_library.protocol import Protocol
 
 
 class Fragmentation(Capability):
@@ -45,11 +53,13 @@ class Fragmentation(Capability):
 
     fragmentation_seed = 0
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
-    def fragment(self, message, fragment_size, mid=None):
+    def fragment(
+        self, message: dict[str, Any], fragment_size: int, mid: str | None = None
+    ) -> Iterable[dict[str, Any]]:
         """
         Fragment a message into smaller parts.
 
@@ -67,11 +77,11 @@ class Fragmentation(Capability):
         :param mid: (optional) if provided, the fragment messages will be given this id.
             Otherwise an id will be auto-generated.
 
-        :return: A generator of message dict objects representing the fragments
+        :return: Am iterable of ROSBridge messages, either a single message or multiple fragments.
         """
         # All fragmented messages need an ID so they can be reconstructed
         if mid is None:
-            mid = self.fragmentation_seed
+            mid = str(self.fragmentation_seed)
             self.fragmentation_seed = self.fragmentation_seed + 1
 
         serialized = self.protocol.serialize(message, mid)
@@ -101,16 +111,20 @@ class Fragmentation(Capability):
 
         return self._fragment_generator(serialized, fragment_size, mid)
 
-    def _fragment_generator(self, msg, size, mid):
+    def _fragment_generator(
+        self, msg: Sequence, size: int, mid: str
+    ) -> Generator[dict[str, Any], None, None]:
         """Return a generator of fragment messages."""
-        total = ((len(msg) - 1) / size) + 1
+        total = ((len(msg) - 1) // size) + 1
         n = 0
         for i in range(0, len(msg), size):
             fragment = msg[i : i + size]
             yield self._create_fragment(fragment, n, total, mid)
             n = n + 1
 
-    def _create_fragment(self, fragment, num, total, mid):
+    def _create_fragment(
+        self, fragment: Sequence, num: int, total: int, mid: str
+    ) -> dict[str, Any]:
         """
         Create a fragment message.
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
@@ -58,8 +58,8 @@ class Fragmentation(Capability):
         Capability.__init__(self, protocol)
 
     def fragment(
-        self, message: dict[str, Any], fragment_size: int, mid: str | None = None
-    ) -> Iterable[dict[str, Any]]:
+        self, message: dict[str, Any] | bytes, fragment_size: int, mid: str | None = None
+    ) -> Iterable[dict[str, Any] | bytes]:
         """
         Fragment a message into smaller parts.
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
@@ -77,7 +77,7 @@ class Fragmentation(Capability):
         :param mid: (optional) if provided, the fragment messages will be given this id.
             Otherwise an id will be auto-generated.
 
-        :return: Am iterable of ROSBridge messages, either a single message or multiple fragments.
+        :return: An iterable of ROSBridge messages, either a single message or multiple fragments.
         """
         # All fragmented messages need an ID so they can be reconstructed
         if mid is None:

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -60,9 +60,9 @@ class Publish(Capability):
     def publish(self, message: dict[str, Any]) -> None:
         # Do basic type checking
         self.basic_type_check(message, self.publish_msg_fields)
-        topic = message["topic"]
-        latch = message.get("latch", False)
-        queue_size = message.get("queue_size", 100)
+        topic: str = message["topic"]
+        latch: bool = message.get("latch", False)
+        queue_size: int = message.get("queue_size", 100)
 
         if Publish.topics_glob is not None and Publish.topics_glob:
             self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
@@ -95,7 +95,7 @@ class Publish(Capability):
         self._published[topic] = True
 
         # Get the message if one was provided
-        msg = message.get("msg", {})
+        msg: dict[str, Any] = message.get("msg", {})
 
         # Publish the message
         manager.publish(

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -31,18 +31,22 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import fnmatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.publishers import manager
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class Publish(Capability):
     publish_msg_fields = ((True, "topic", str),)
 
-    topics_glob = None
+    topics_glob: list[str] | None = None
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -32,9 +32,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import fnmatch
+from typing import Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.publishers import manager
+from rosbridge_library.protocol import Protocol
 
 
 class Publish(Capability):
@@ -42,7 +44,7 @@ class Publish(Capability):
 
     topics_glob = None
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
@@ -50,12 +52,12 @@ class Publish(Capability):
         protocol.register_operation("publish", self.publish)
 
         # Save the topics that are published on for the purposes of unregistering
-        self._published = {}
+        self._published: dict[str, bool] = {}
 
         if protocol.parameters and "unregister_timeout" in protocol.parameters:
             manager.unregister_timeout = protocol.parameters.get("unregister_timeout")
 
-    def publish(self, message):
+    def publish(self, message: dict[str, Any]) -> None:
         # Do basic type checking
         self.basic_type_check(message, self.publish_msg_fields)
         topic = message["topic"]
@@ -105,7 +107,7 @@ class Publish(Capability):
             queue_size=queue_size,
         )
 
-    def finish(self):
+    def finish(self) -> None:
         client_id = self.protocol.client_id
         for topic in self._published:
             manager.unregister(client_id, topic)

--- a/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import fnmatch
 from functools import partial
 from threading import Thread
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from action_msgs.msg import GoalStatus
 
@@ -94,17 +94,17 @@ class SendActionGoal(Capability):
 
     def send_action_goal(self, message: dict) -> None:
         # Pull out the ID
-        cid = message.get("id")
+        cid: str | None = message.get("id")
 
         # Typecheck the args
         self.basic_type_check(message, self.send_action_goal_msg_fields)
 
         # Extract the args
-        action = message["action"]
-        action_type = message["action_type"]
-        fragment_size = message.get("fragment_size")
-        compression = message.get("compression", "none")
-        args = message.get("args", [])
+        action: str = message["action"]
+        action_type: str = message["action_type"]
+        fragment_size: int | None = message.get("fragment_size")
+        compression: str = message.get("compression", "none")
+        args: list | dict[str, Any] = message.get("args", [])
 
         if SendActionGoal.actions_glob is not None and SendActionGoal.actions_glob:
             self.protocol.log("debug", f"Action security glob enabled, checking action: {action}")
@@ -174,7 +174,7 @@ class SendActionGoal(Capability):
                 client_handler.send_goal_helper.cancel_goal()
 
     def _success(
-        self, cid: str | None, action: str, _fragment_size: int, _compression: bool, message: dict
+        self, cid: str | None, action: str, _fragment_size: int | None, _compression: str, message: dict
     ) -> None:
         outgoing_message = {
             "op": "action_result",

--- a/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import fnmatch
 from functools import partial
 from threading import Thread
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from action_msgs.msg import GoalStatus
 
@@ -44,6 +44,9 @@ from rosbridge_library.internal.actions import ActionClientHandler
 from rosbridge_library.internal.message_conversion import extract_values
 
 if TYPE_CHECKING:
+    from rclpy.type_support import FeedbackMessage
+
+    from rosbridge_library.internal.type_support import ROSMessage
     from rosbridge_library.protocol import Protocol
 
 
@@ -132,8 +135,16 @@ class SendActionGoal(Capability):
         f_cb = partial(self._feedback, cid, action) if message.get("feedback", False) else None
 
         # Run action client handler in the same thread.
-        client_handler = ActionClientHandler(
-            trim_action_name(action), action_type, args, s_cb, e_cb, f_cb, self.protocol.node_handle
+        client_handler: ActionClientHandler[ROSMessage, ROSMessage, ROSMessage] = (
+            ActionClientHandler(
+                trim_action_name(action),
+                action_type,
+                args,
+                s_cb,
+                e_cb,
+                f_cb,
+                self.protocol.node_handle,
+            )
         )
 
         if cid is not None:
@@ -191,7 +202,7 @@ class SendActionGoal(Capability):
             outgoing_message["id"] = cid
         self.protocol.send(outgoing_message)
 
-    def _feedback(self, cid: str | None, action: str, message: Any) -> None:
+    def _feedback(self, cid: str | None, action: str, message: FeedbackMessage[ROSMessage]) -> None:
         outgoing_message = {
             "op": "action_feedback",
             "action": action,

--- a/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
@@ -174,7 +174,12 @@ class SendActionGoal(Capability):
                 client_handler.send_goal_helper.cancel_goal()
 
     def _success(
-        self, cid: str | None, action: str, _fragment_size: int | None, _compression: str, message: dict
+        self,
+        cid: str | None,
+        action: str,
+        _fragment_size: int | None,
+        _compression: str,
+        message: dict,
     ) -> None:
         outgoing_message = {
             "op": "action_result",

--- a/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion, ros_loader
+from rosbridge_library.protocol import Protocol
 
 
 class ServiceResponse(Capability):
@@ -10,14 +13,14 @@ class ServiceResponse(Capability):
         (True, "result", bool),
     )
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
         # Register the operations that this capability provides
         protocol.register_operation("service_response", self.service_response)
 
-    def service_response(self, message):
+    def service_response(self, message: dict[str, Any]) -> None:
         # Typecheck the args
         self.basic_type_check(message, self.service_response_msg_fields)
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
@@ -1,8 +1,12 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion, ros_loader
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class ServiceResponse(Capability):

--- a/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/service_response.py
@@ -25,12 +25,12 @@ class ServiceResponse(Capability):
         self.basic_type_check(message, self.service_response_msg_fields)
 
         # check for the service
-        service_name = message["service"]
+        service_name: str = message["service"]
         if service_name in self.protocol.external_service_list:
             service_handler = self.protocol.external_service_list[service_name]
             # parse the message
-            request_id = message["id"]
-            values = message["values"]
+            request_id: str = message["id"]
+            values: dict[str, Any] = message["values"]
             # create a message instance
             resp = ros_loader.get_service_response_instance(service_handler.service_type)
             message_conversion.populate_instance(values, resp)

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -30,14 +30,25 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import fnmatch
 from functools import partial
 from threading import Lock
+from typing import TYPE_CHECKING, Any, Callable, Generic
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.pngcompression import encode as encode_png
 from rosbridge_library.internal.subscribers import manager
 from rosbridge_library.internal.subscription_modifiers import MessageHandler
+from rosbridge_library.internal.type_support import ROSMessageT
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
+
+    from rosbridge_library.internal.outgoing_message import OutgoingMessage
+    from rosbridge_library.protocol import Protocol
+
 
 try:
     from ujson import dumps as encode_json  # type: ignore[import-untyped]
@@ -48,14 +59,22 @@ except ImportError:
         from json import dumps as encode_json
 
 
-class Subscription:
+class Subscription(Generic[ROSMessageT]):
     """
     Keeps track of the clients multiple calls to subscribe.
 
     Chooses the most appropriate settings to send messages.
     """
 
-    def __init__(self, client_id, topic, publish, node_handle):
+    clients: dict[str, dict[str, Any]]
+
+    def __init__(
+        self,
+        client_id: str,
+        topic: str,
+        publish: Callable[[OutgoingMessage[ROSMessageT], int | None, str], None],
+        node_handle: Node,
+    ) -> None:
         """
         Create a subscription.
 
@@ -74,11 +93,13 @@ class Subscription:
 
         self.clients = {}
 
-        self.handler = MessageHandler(None, self._publish)
+        self.handler: MessageHandler[OutgoingMessage[ROSMessageT]] = MessageHandler(
+            None, self._publish
+        )
         self.handler_lock = Lock()
         self.update_params()
 
-    def unregister(self):
+    def unregister(self) -> None:
         """Unsubscribe this subscription and clean up resources."""
         manager.unsubscribe(self.client_id, self.topic)
         with self.handler_lock:
@@ -87,13 +108,13 @@ class Subscription:
 
     def subscribe(
         self,
-        sid=None,
-        msg_type=None,
-        throttle_rate=0,
-        queue_length=0,
-        fragment_size=None,
-        compression="none",
-    ):
+        sid: str,
+        msg_type: str | None = None,
+        throttle_rate: int = 0,
+        queue_length: int = 0,
+        fragment_size: int | None = None,
+        compression: str = "none",
+    ) -> None:
         """
         Add another client's subscription request.
 
@@ -135,7 +156,7 @@ class Subscription:
             raw=raw,
         )
 
-    def unsubscribe(self, sid=None):
+    def unsubscribe(self, sid: str | None = None) -> None:
         """
         Unsubscribe this particular client's subscription.
 
@@ -149,11 +170,11 @@ class Subscription:
         if not self.is_empty():
             self.update_params()
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """Return True if there are no subscriptions currently."""
         return len(self.clients) == 0
 
-    def _publish(self, message):
+    def _publish(self, message: OutgoingMessage[ROSMessageT]) -> None:
         """
         Publish a message to the subscribed clients.
 
@@ -162,7 +183,7 @@ class Subscription:
         """
         self.publish(message, self.fragment_size, self.compression)
 
-    def on_msg(self, msg):
+    def on_msg(self, msg: OutgoingMessage[ROSMessageT]) -> None:
         """
         Handle incoming messages.
 
@@ -175,7 +196,7 @@ class Subscription:
         with self.handler_lock:
             self.handler.handle_message(msg)
 
-    def update_params(self):
+    def update_params(self) -> None:
         """
         Update the parameters of the message handler based on current subscriptions.
 
@@ -189,7 +210,7 @@ class Subscription:
             self.compression = "none"
             return
 
-        def f(fieldname):
+        def f(fieldname: str) -> list[Any]:
             return [x[fieldname] for x in self.clients.values()]
 
         self.throttle_rate = min(f("throttle_rate"))
@@ -222,11 +243,11 @@ class Subscribe(Capability):
         (False, "queue_length", int),
         (False, "compression", str),
     )
-    unsubscribe_msg_fields = (True, "topic", str)
+    unsubscribe_msg_fields = ((True, "topic", str),)
 
     topics_glob = None
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
@@ -234,11 +255,11 @@ class Subscribe(Capability):
         protocol.register_operation("subscribe", self.subscribe)
         protocol.register_operation("unsubscribe", self.unsubscribe)
 
-        self._subscriptions = {}
+        self._subscriptions: dict[str, Subscription] = {}
 
-    def subscribe(self, msg):
+    def subscribe(self, msg: dict[str, Any]) -> None:
         # Pull out the ID
-        sid = msg.get("id", None)
+        sid = msg.get("id")
 
         # Check the args
         self.basic_type_check(msg, self.subscribe_msg_fields)
@@ -276,9 +297,9 @@ class Subscribe(Capability):
         # Register the subscriber
         subscribe_args = {
             "sid": sid,
-            "msg_type": msg.get("type", None),
+            "msg_type": msg.get("type"),
             "throttle_rate": msg.get("throttle_rate", 0),
-            "fragment_size": msg.get("fragment_size", None),
+            "fragment_size": msg.get("fragment_size"),
             "queue_length": msg.get("queue_length", 0),
             "compression": msg.get("compression", "none"),
         }
@@ -286,9 +307,9 @@ class Subscribe(Capability):
 
         self.protocol.log("info", f"Subscribed to {topic}")
 
-    def unsubscribe(self, msg):
+    def unsubscribe(self, msg: dict[str, Any]) -> None:
         # Pull out the ID
-        sid = msg.get("id", None)
+        sid = msg.get("id")
 
         self.basic_type_check(msg, self.unsubscribe_msg_fields)
 
@@ -304,7 +325,13 @@ class Subscribe(Capability):
 
         self.protocol.log("info", f"Unsubscribed from {topic}")
 
-    def publish(self, topic, message, fragment_size=None, compression="none"):  # noqa: ARG002
+    def publish(
+        self,
+        topic: str,
+        message: OutgoingMessage,
+        fragment_size: int | None = None,  # noqa: ARG002
+        compression: str = "none",
+    ) -> None:
         """
         Publish a message to the client.
 
@@ -317,27 +344,29 @@ class Subscribe(Capability):
         """
         # TODO: fragmentation, proper ids
 
-        outgoing_msg = {"op": "publish", "topic": topic}
+        outgoing_msg: dict[str, Any] | bytes = {}
+        outgoing_msg_raw: dict[str, Any] = {"op": "publish", "topic": topic}
         if compression == "png":
-            outgoing_msg["msg"] = message.get_json_values()
-            outgoing_msg_dumped = encode_json(outgoing_msg)
+            outgoing_msg_raw["msg"] = message.get_json_values()
+            outgoing_msg_dumped: str = encode_json(outgoing_msg_raw)
             outgoing_msg = {"op": "png", "data": encode_png(outgoing_msg_dumped)}
         elif compression == "cbor":
-            outgoing_msg = message.get_cbor(outgoing_msg)
+            outgoing_msg = message.get_cbor(outgoing_msg_raw)
         elif compression == "cbor-raw":
             (secs, nsecs) = self.protocol.node_handle.get_clock().now().seconds_nanoseconds()
-            outgoing_msg["msg"] = {
+            outgoing_msg_raw["msg"] = {
                 "secs": secs,
                 "nsecs": nsecs,
                 "bytes": message.message,
             }
-            outgoing_msg = message.get_cbor_raw(outgoing_msg)
+            outgoing_msg = message.get_cbor_raw(outgoing_msg_raw)
         else:
-            outgoing_msg["msg"] = message.get_json_values()
+            outgoing_msg_raw["msg"] = message.get_json_values()
+            outgoing_msg = outgoing_msg_raw
 
         self.protocol.send(outgoing_msg, compression=compression)
 
-    def finish(self):
+    def finish(self) -> None:
         for subscription in self._subscriptions.values():
             subscription.unregister()
         self._subscriptions.clear()

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -72,7 +72,7 @@ class Subscription(Generic[ROSMessageT]):
         self,
         client_id: str,
         topic: str,
-        publish: Callable[[OutgoingMessage[ROSMessageT], int | None, str], None],
+        publish: Callable[[OutgoingMessage[ROSMessageT], int | None, str], None] | None,
         node_handle: Node,
     ) -> None:
         """
@@ -181,7 +181,8 @@ class Subscription(Generic[ROSMessageT]):
         Internal method to propagate published messages to the registered
         publish callback.
         """
-        self.publish(message, self.fragment_size, self.compression)
+        if self.publish is not None:
+            self.publish(message, self.fragment_size, self.compression)
 
     def on_msg(self, msg: OutgoingMessage[ROSMessageT]) -> None:
         """

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -259,13 +259,13 @@ class Subscribe(Capability):
 
     def subscribe(self, msg: dict[str, Any]) -> None:
         # Pull out the ID
-        sid = msg.get("id")
+        sid: str | None = msg.get("id")
 
         # Check the args
         self.basic_type_check(msg, self.subscribe_msg_fields)
 
         # Make the subscription
-        topic = msg["topic"]
+        topic: str = msg["topic"]
 
         if Subscribe.topics_glob is not None and Subscribe.topics_glob:
             self.protocol.log("debug", "Topic security glob enabled, checking topic: " + topic)
@@ -309,11 +309,11 @@ class Subscribe(Capability):
 
     def unsubscribe(self, msg: dict[str, Any]) -> None:
         # Pull out the ID
-        sid = msg.get("id")
+        sid: str | None = msg.get("id")
 
         self.basic_type_check(msg, self.unsubscribe_msg_fields)
 
-        topic = msg["topic"]
+        topic: str = msg["topic"]
 
         if topic not in self._subscriptions:
             return

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import fnmatch
 from functools import partial
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Callable, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.pngcompression import encode as encode_png
@@ -44,6 +44,8 @@ from rosbridge_library.internal.subscription_modifiers import MessageHandler
 from rosbridge_library.internal.type_support import ROSMessageT
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rclpy.node import Node
 
     from rosbridge_library.internal.outgoing_message import OutgoingMessage

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -246,7 +246,7 @@ class Subscribe(Capability):
     )
     unsubscribe_msg_fields = ((True, "topic", str),)
 
-    topics_glob = None
+    topics_glob: list[str] | None = None
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor

--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -56,7 +56,7 @@ except ImportError:
     try:
         from simplejson import dumps as encode_json  # type: ignore[import-untyped]
     except ImportError:
-        from json import dumps as encode_json
+        from json import dumps as encode_json  # type: ignore[assignment]
 
 
 class Subscription(Generic[ROSMessageT]):

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_action.py
@@ -30,15 +30,19 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import fnmatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class UnadvertiseAction(Capability):
-    actions_glob = None
+    actions_glob: list[str] | None = None
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_action.py
@@ -31,6 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import fnmatch
+from typing import Any
 
 from rosbridge_library.capability import Capability
 from rosbridge_library.protocol import Protocol
@@ -46,7 +47,7 @@ class UnadvertiseAction(Capability):
         # Register the operations that this capability provides
         protocol.register_operation("unadvertise_action", self.unadvertise_action)
 
-    def unadvertise_action(self, message: dict) -> None:
+    def unadvertise_action(self, message: dict[str, Any]) -> None:
         # parse the message
         action_name = message["action"]
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_action.py
@@ -49,7 +49,7 @@ class UnadvertiseAction(Capability):
 
     def unadvertise_action(self, message: dict[str, Any]) -> None:
         # parse the message
-        action_name = message["action"]
+        action_name: str = message["action"]
 
         if UnadvertiseAction.actions_glob is not None and UnadvertiseAction.actions_glob:
             self.protocol.log(

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
@@ -1,6 +1,8 @@
 import fnmatch
+from typing import Any
 
 from rosbridge_library.capability import Capability
+from rosbridge_library.protocol import Protocol
 
 
 class UnadvertiseService(Capability):
@@ -8,14 +10,14 @@ class UnadvertiseService(Capability):
 
     services_glob = None
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
         Capability.__init__(self, protocol)
 
         # Register the operations that this capability provides
         protocol.register_operation("unadvertise_service", self.unadvertise_service)
 
-    def unadvertise_service(self, message):
+    def unadvertise_service(self, message: dict[str, Any]) -> None:
         # parse the message
         service_name = message["service"]
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
@@ -19,7 +19,7 @@ class UnadvertiseService(Capability):
 
     def unadvertise_service(self, message: dict[str, Any]) -> None:
         # parse the message
-        service_name = message["service"]
+        service_name: str = message["service"]
 
         if UnadvertiseService.services_glob is not None and UnadvertiseService.services_glob:
             self.protocol.log(

--- a/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/unadvertise_service.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import fnmatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capability import Capability
-from rosbridge_library.protocol import Protocol
+
+if TYPE_CHECKING:
+    from rosbridge_library.protocol import Protocol
 
 
 class UnadvertiseService(Capability):
     # unadvertise_service_msg_fields = [(True, "service", (str, unicode))]
 
-    services_glob = None
+    services_glob: list[str] | None = None
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor

--- a/rosbridge_library/src/rosbridge_library/capability.py
+++ b/rosbridge_library/src/rosbridge_library/capability.py
@@ -30,10 +30,19 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from rosbridge_library.internal.exceptions import (
     InvalidArgumentException,
     MissingArgumentException,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from rosbridge_library.protocol import Protocol
 
 
 class Capability:
@@ -49,7 +58,7 @@ class Capability:
     Protocol.send() is available to send messages back to the client.
     """
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: Protocol) -> None:
         """
         Abstract class constructor.
 
@@ -59,7 +68,7 @@ class Capability:
         """
         self.protocol = protocol
 
-    def handle_message(self, message):
+    def handle_message(self, message: dict[str, Any]) -> None:
         """
         Handle an incoming message.
 
@@ -68,23 +77,25 @@ class Capability:
         :param message: The incoming message, deserialized into a dictionary
         """
 
-    def finish(self):
+    def finish(self) -> None:
         """
         Notify this capability that the client is finished.
 
         Tells the capability that it's time to free up resources.
         """
 
-    def basic_type_check(self, msg, types_info):
+    def basic_type_check(
+        self, msg: dict[str, Any], types_info: Sequence[tuple[bool, str, type | tuple[type, ...]]]
+    ) -> None:
         """
         Perform basic typechecking on fields in msg.
 
         :param msg: A message, deserialized into a dictionary
-        :param types_info: A list of tuples (mandatory, fieldname, fieldtype) where
+        :param types_info: A sequence of tuples (mandatory, fieldname, fieldtype) where
 
             - mandatory - boolean, is the field mandatory
             - fieldname - the name of the field in the message
-            - fieldtypes - the expected python type of the field or list of types
+            - fieldtypes - the expected python type of the field or tuple of types
 
         :raises MissingArgumentException: If a field is mandatory but not present in the message
         :raises InvalidArgumentException: If a field is present but not of the type specified by
@@ -92,8 +103,8 @@ class Capability:
         """
         for mandatory, fieldname, fieldtypes in types_info:
             if mandatory and fieldname not in msg:
-                msg = f"Expected a {fieldname} field but none was found."
-                raise MissingArgumentException(msg)
+                err_msg = f"Expected a {fieldname} field but none was found."
+                raise MissingArgumentException(err_msg)
             if fieldname in msg:
                 current_fieldtypes = fieldtypes
                 if not isinstance(current_fieldtypes, tuple):
@@ -103,8 +114,8 @@ class Capability:
                     if isinstance(msg[fieldname], typ):
                         valid = True
                 if not valid:
-                    msg = (
+                    err_msg = (
                         f"Expected field {fieldname} to be one of {current_fieldtypes}. "
                         f"Invalid value: {msg[fieldname]}"
                     )
-                    raise InvalidArgumentException(msg)
+                    raise InvalidArgumentException(err_msg)

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -72,8 +72,8 @@ class ActionClientHandler(Thread, Generic[ROSActionGoalT, ROSActionResultT, ROSA
         self,
         action: str,
         action_type: str,
-        args: dict,
-        success_callback: Callable[[dict], None],
+        args: list | dict[str, Any] | None,
+        success_callback: Callable[[dict[str, Any]], None],
         error_callback: Callable[[Exception], None],
         feedback_callback: Callable[[FeedbackMessage[ROSActionFeedbackT]], None] | None,
         node_handle: Node,
@@ -123,7 +123,7 @@ class ActionClientHandler(Thread, Generic[ROSActionGoalT, ROSActionResultT, ROSA
             self.error(e)
 
 
-def args_to_action_goal_instance(inst: ROSMessage, args: list | dict | None) -> None:
+def args_to_action_goal_instance(inst: ROSMessage, args: list | dict[str, Any] | None) -> None:
     """
     Populate an action goal instance with the provided args.
 
@@ -178,7 +178,7 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
         node_handle: Node,
         action: str,
         action_type: str,
-        args: dict | None = None,
+        args: list | dict[str, Any] | None = None,
         feedback_cb: Callable[[FeedbackMessage[ROSActionFeedbackT]], None] | None = None,
     ) -> dict[str, Any]:
         # Given the action name and type, fetch a request instance

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import time
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Generic, cast
 
 from rclpy.action import ActionClient
 from rclpy.expand_topic_name import expand_topic_name
@@ -46,18 +46,28 @@ from rosbridge_library.internal.ros_loader import (
     get_action_class,
     get_action_goal_instance,
 )
+from rosbridge_library.internal.type_support import (
+    ROSActionFeedbackT,
+    ROSActionGoalT,
+    ROSActionResultT,
+)
 
 if TYPE_CHECKING:
+    from action_msgs.srv import CancelGoal
+    from rclpy.action.client import ClientGoalHandle
     from rclpy.node import Node
     from rclpy.task import Future
+    from rclpy.type_support import FeedbackMessage, GetResultServiceResponse
+
+    from rosbridge_library.internal.type_support import ROSMessage
 
 
 class InvalidActionException(Exception):
-    def __init__(self, action_name) -> None:
+    def __init__(self, action_name: str) -> None:
         Exception.__init__(self, f"Action {action_name} does not exist")
 
 
-class ActionClientHandler(Thread):
+class ActionClientHandler(Thread, Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
     def __init__(
         self,
         action: str,
@@ -65,7 +75,7 @@ class ActionClientHandler(Thread):
         args: dict,
         success_callback: Callable[[dict], None],
         error_callback: Callable[[Exception], None],
-        feedback_callback: Callable[[dict], None] | None,
+        feedback_callback: Callable[[FeedbackMessage[ROSActionFeedbackT]], None] | None,
         node_handle: Node,
     ) -> None:
         """
@@ -92,7 +102,9 @@ class ActionClientHandler(Thread):
         self.error = error_callback
         self.feedback = feedback_callback
         self.node_handle = node_handle
-        self.send_goal_helper = SendGoal()
+        self.send_goal_helper: SendGoal[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = (
+            SendGoal()
+        )
 
     def run(self) -> None:
         try:
@@ -111,7 +123,7 @@ class ActionClientHandler(Thread):
             self.error(e)
 
 
-def args_to_action_goal_instance(inst: Any, args: list | dict | None) -> Any:
+def args_to_action_goal_instance(inst: ROSMessage, args: list | dict | None) -> None:
     """
     Populate an action goal instance with the provided args.
 
@@ -129,28 +141,36 @@ def args_to_action_goal_instance(inst: Any, args: list | dict | None) -> Any:
     populate_instance(msg, inst)
 
 
-class SendGoal:
+class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
     """Helper class to send action goals."""
+
+    result: GetResultServiceResponse[ROSActionResultT] | None = None
 
     def __init__(self, server_timeout_time: float = 1.0, sleep_time: float = 0.001) -> None:
         self.server_timeout_time = server_timeout_time
         self.sleep_time = sleep_time
-        self.goal_handle = None
+        self.goal_handle: (
+            ClientGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] | None
+        ) = None
         self.goal_canceled = False
 
-    def get_result_cb(self, future: Future) -> None:
+    def get_result_cb(self, future: Future[GetResultServiceResponse[ROSActionResultT]]) -> None:
         self.result = future.result()
 
-    def goal_response_cb(self, future: Future) -> None:
+    def goal_response_cb(
+        self, future: Future[ClientGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]]
+    ) -> None:
         self.goal_handle = future.result()
         assert self.goal_handle is not None
         if not self.goal_handle.accepted:
             msg = "Action goal was rejected"
             raise Exception(msg)
-        result_future = self.goal_handle.get_result_async()
+        result_future: Future[GetResultServiceResponse[ROSActionResultT]] = (
+            self.goal_handle.get_result_async()
+        )
         result_future.add_done_callback(self.get_result_cb)
 
-    def goal_cancel_cb(self, _: Future) -> None:
+    def goal_cancel_cb(self, _: Future[CancelGoal.Response]) -> None:
         self.goal_canceled = True
 
     def send_goal(
@@ -159,20 +179,22 @@ class SendGoal:
         action: str,
         action_type: str,
         args: dict | None = None,
-        feedback_cb: Callable[[dict], None] | None = None,
-    ) -> dict:
+        feedback_cb: Callable[[FeedbackMessage[ROSActionFeedbackT]], None] | None = None,
+    ) -> dict[str, Any]:
         # Given the action name and type, fetch a request instance
         action_name = expand_topic_name(action, node_handle.get_name(), node_handle.get_namespace())
         action_class = get_action_class(action_type)
-        inst = get_action_goal_instance(action_type)
+        inst = cast("ROSActionGoalT", get_action_goal_instance(action_type))
 
         # Populate the instance with the provided args
         args_to_action_goal_instance(inst, args)
 
         self.result = None
-        client: ActionClient = ActionClient(node_handle, action_class, action_name)
+        client: ActionClient[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = ActionClient(
+            node_handle, action_class, action_name
+        )
         client.wait_for_server(timeout_sec=self.server_timeout_time)
-        send_goal_future = client.send_goal_async(inst, feedback_callback=feedback_cb)
+        send_goal_future = client.send_goal_async(inst, feedback_callback=feedback_cb)  # type: ignore[arg-type]
         send_goal_future.add_done_callback(self.goal_response_cb)
 
         while self.result is None:

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import time
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable, Generic, cast
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 from rclpy.action import ActionClient
 from rclpy.expand_topic_name import expand_topic_name
@@ -53,6 +53,8 @@ from rosbridge_library.internal.type_support import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from action_msgs.srv import CancelGoal
     from rclpy.action.client import ClientGoalHandle
     from rclpy.node import Node
@@ -133,7 +135,7 @@ def args_to_action_goal_instance(inst: ROSMessage, args: list | dict[str, Any] |
     """
     msg = {}
     if isinstance(args, list):
-        msg = dict(zip(inst.get_fields_and_field_types().keys(), args))
+        msg = dict(zip(inst.get_fields_and_field_types().keys(), args, strict=False))
     elif isinstance(args, dict):
         msg = args
 

--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import struct
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 try:
     from cbor import Tag
 except ImportError:
     from rosbridge_library.util.cbor import Tag
 
-from rosbridge_library.internal.type_support import ROSMessage
+if TYPE_CHECKING:
+    from rosbridge_library.internal.type_support import ROSMessage
 
 LIST_TYPES = [list, tuple]
 INT_TYPES = [

--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -1,10 +1,12 @@
 import struct
+from typing import Any
 
 try:
     from cbor import Tag
 except ImportError:
     from rosbridge_library.util.cbor import Tag
 
+from rosbridge_library.internal.type_support import ROSMessage
 
 LIST_TYPES = [list, tuple]
 INT_TYPES = [
@@ -43,7 +45,7 @@ TAGGED_ARRAY_FORMATS = {
 }
 
 
-def extract_cbor_values(msg):
+def extract_cbor_values(msg: ROSMessage) -> dict[str, Any]:
     """
     Extract a dictionary of CBOR-friendly values from a ROS message.
 
@@ -51,7 +53,7 @@ def extract_cbor_values(msg):
 
     Typed arrays will be tagged and packed into byte arrays.
     """
-    out = {}
+    out: dict[str, Any] = {}
     for slot, slot_type in msg.get_fields_and_field_types().items():
         val = getattr(msg, slot)
 

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -245,7 +245,7 @@ def _from_inst(
 
     # Check for primitive types
     if rostype in ros_primitive_types:
-        assert isinstance(inst, primitive_types | bytes), "Expected primitive type instance"
+        assert isinstance(inst, (*primitive_types, bytes)), "Expected primitive type instance"
         return _from_primitive_inst(inst, rostype)
 
     # Check if it's a list or tuple
@@ -310,7 +310,7 @@ def _from_object_inst(inst: ROSMessage, _rostype: str) -> dict:
 
 
 def _to_inst(
-    msg: dict[str, Any] | Sequence | str | float | bool,
+    msg: dict[str, Any] | Sequence | PrimitiveType,
     rostype: str,
     roottype: str,
     clock: Clock | None = None,

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -342,7 +342,7 @@ def _to_inst(
         return _to_primitive_inst(msg, rostype, roottype, stack)
 
     # Check whether we're dealing with a list type
-    if inst is not None and isinstance(inst, list | np.ndarray | array.array):
+    if inst is not None and isinstance(inst, list_types):
         assert isinstance(msg, list_types)
         return _to_list_inst(msg, rostype, roottype, clock, inst, stack)
 

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -151,7 +151,7 @@ def get_encoder() -> Callable[[ListType], bytes]:
 
 
 class InvalidMessageException(Exception):
-    def __init__(self, inst: object) -> None:
+    def __init__(self, inst: Any) -> None:  # noqa: ANN401
         Exception.__init__(
             self,
             f"Unable to extract message values from {type(inst).__name__} instance",

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -38,7 +38,7 @@ import re
 import sys
 from base64 import standard_b64decode, standard_b64encode
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from builtin_interfaces.msg import Duration as DurationMsg
@@ -52,6 +52,8 @@ from rosbridge_library.internal.type_support import ROSMessage
 from rosbridge_library.util import bson
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rclpy.node import Node
 
 
@@ -238,12 +240,12 @@ def _from_inst(
 
     # Check for time or duration
     if rostype in ros_time_types:
-        assert isinstance(inst, (TimeMsg, DurationMsg)), "Expected Time or Duration instance"
+        assert isinstance(inst, TimeMsg | DurationMsg), "Expected Time or Duration instance"
         return {"sec": inst.sec, "nanosec": inst.nanosec}
 
     # Check for primitive types
     if rostype in ros_primitive_types:
-        assert isinstance(inst, (primitive_types, bytes)), "Expected primitive type instance"
+        assert isinstance(inst, primitive_types | bytes), "Expected primitive type instance"
         return _from_primitive_inst(inst, rostype)
 
     # Check if it's a list or tuple
@@ -328,8 +330,8 @@ def _to_inst(
 
     # Check the type for time or rostime
     if rostype in ros_time_types:
-        assert isinstance(msg, (dict, str)), "Expected dict or str for time or duration msg"
-        assert inst is None or isinstance(inst, (TimeMsg, DurationMsg)), (
+        assert isinstance(msg, dict | str), "Expected dict or str for time or duration msg"
+        assert inst is None or isinstance(inst, TimeMsg | DurationMsg), (
             "Expected Time or Duration instance"
         )
         return _to_time_inst(msg, rostype, clock, inst)
@@ -340,7 +342,7 @@ def _to_inst(
         return _to_primitive_inst(msg, rostype, roottype, stack)
 
     # Check whether we're dealing with a list type
-    if inst is not None and isinstance(inst, (list, np.ndarray, array.array)):
+    if inst is not None and isinstance(inst, list | np.ndarray | array.array):
         assert isinstance(msg, list_types), "Expected a list msg"
         return _to_list_inst(msg, rostype, roottype, clock, inst, stack)
 

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -234,18 +234,18 @@ def _from_inst(
     # Special case for uint8[], we encode the string
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
-            assert isinstance(inst, list_types), "Expected a list type instance"
+            assert isinstance(inst, list_types)
             encoded = get_encoder()(inst)
             return encoded.decode("ascii")
 
     # Check for time or duration
     if rostype in ros_time_types:
-        assert isinstance(inst, TimeMsg | DurationMsg), "Expected Time or Duration instance"
+        assert isinstance(inst, TimeMsg | DurationMsg)
         return {"sec": inst.sec, "nanosec": inst.nanosec}
 
     # Check for primitive types
     if rostype in ros_primitive_types:
-        assert isinstance(inst, (*primitive_types, bytes)), "Expected primitive type instance"
+        assert isinstance(inst, (*primitive_types, bytes))
         return _from_primitive_inst(inst, rostype)
 
     # Check if it's a list or tuple
@@ -253,7 +253,7 @@ def _from_inst(
         return _from_list_inst(inst, rostype)
 
     # Assume it's otherwise a full ros msg object
-    assert isinstance(inst, ROSMessage), "Expected ROSMessage instance"
+    assert isinstance(inst, ROSMessage)
     return _from_object_inst(inst, rostype)
 
 
@@ -263,14 +263,14 @@ def _from_primitive_inst(inst: PrimitiveType | bytes, rostype: str) -> Primitive
 
     # JSON does not support Inf and NaN. They are mapped to None and encoded as null
     if rostype in type_map["float"]:
-        assert isinstance(inst, float), "Expected float"
+        assert isinstance(inst, float)
         if math.isnan(inst) or math.isinf(inst):
             return None
 
     # octet is translated to byte array with length 1
     # JSON does not support byte array. They are converted to int
     if rostype == "octet":
-        assert isinstance(inst, bytes), "Expected bytes for octet"
+        assert isinstance(inst, bytes)
         return int.from_bytes(inst, "little")
 
     return inst
@@ -330,7 +330,7 @@ def _to_inst(
 
     # Check the type for time or rostime
     if rostype in ros_time_types:
-        assert isinstance(msg, dict | str), "Expected dict or str for time or duration msg"
+        assert isinstance(msg, dict | str)
         assert inst is None or isinstance(inst, TimeMsg | DurationMsg), (
             "Expected Time or Duration instance"
         )
@@ -338,20 +338,20 @@ def _to_inst(
 
     # Check to see whether this is a primitive type
     if rostype in ros_primitive_types:
-        assert isinstance(msg, primitive_types), "Expected primitive type msg"
+        assert isinstance(msg, primitive_types)
         return _to_primitive_inst(msg, rostype, roottype, stack)
 
     # Check whether we're dealing with a list type
     if inst is not None and isinstance(inst, list | np.ndarray | array.array):
-        assert isinstance(msg, list_types), "Expected a list msg"
+        assert isinstance(msg, list_types)
         return _to_list_inst(msg, rostype, roottype, clock, inst, stack)
 
     # Otherwise, the type has to be a full ros msg type, so msg must be a dict
     if inst is None:
         inst = ros_loader.get_message_instance(rostype)
 
-    assert isinstance(msg, dict), "Expected a dict msg"
-    assert isinstance(inst, ROSMessage), "Expected ROSMessage instance"
+    assert isinstance(msg, dict)
+    assert isinstance(inst, ROSMessage)
     return _to_object_inst(msg, rostype, roottype, clock, inst, stack)
 
 
@@ -473,7 +473,7 @@ def _to_object_inst(
 
     # Substitute the correct time if we're an std_msgs/Header
     if rostype in ros_header_types:
-        assert isinstance(inst, HeaderMsg), "Expected std_msgs/msg/Header instance"
+        assert isinstance(inst, HeaderMsg)
         inst.stamp = clock.now().to_msg()
 
     inst_fields: dict[str, str] = inst.get_fields_and_field_types()

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import numpy as np
 from builtin_interfaces.msg import Duration as DurationMsg
 from builtin_interfaces.msg import Time as TimeMsg
-from rclpy.clock import ROSClock
+from rclpy.clock import Clock
 from rclpy.parameter import Parameter
 from std_msgs.msg import Header as HeaderMsg
 
@@ -189,7 +189,7 @@ def extract_values(inst: ROSMessage) -> dict[str, Any]:
 
 
 def populate_instance(
-    msg: dict[str, Any], inst: ROSMessage, clock: ROSClock | None = None
+    msg: dict[str, Any], inst: ROSMessage, clock: Clock | None = None
 ) -> ROSMessage:
     """
     Populate a ROS message instance with the provided values.
@@ -198,7 +198,7 @@ def populate_instance(
     according to the values in msg.
     """
     if clock is None:
-        clock = ROSClock()
+        clock = Clock()
 
     inst_type = msg_instance_type_repr(inst)
 
@@ -311,12 +311,12 @@ def _to_inst(
     msg: dict[str, Any] | Sequence | str | float | bool,
     rostype: str,
     roottype: str,
-    clock: ROSClock | None = None,
+    clock: Clock | None = None,
     inst: object | None = None,
     stack: list[str] | None = None,
 ) -> object:
     if clock is None:
-        clock = ROSClock()
+        clock = Clock()
     if stack is None:
         stack = []
 
@@ -370,7 +370,7 @@ def _to_binary_inst(msg: Sequence) -> list | bytes | array.array:
 def _to_time_inst(
     msg: dict[str, Any] | str,
     rostype: str,
-    clock: ROSClock,
+    clock: Clock,
     inst: TimeMsg | DurationMsg | None = None,
 ) -> TimeMsg | DurationMsg:
     # A special case for the string "now"
@@ -429,7 +429,7 @@ def _to_list_inst(
     msg: ListType,
     rostype: str,
     roottype: str,
-    clock: ROSClock,
+    clock: Clock,
     inst: ListType,
     stack: list[str],
 ) -> ListType:
@@ -461,7 +461,7 @@ def _to_object_inst(
     msg: dict[str, Any],
     rostype: str,
     roottype: str,
-    clock: ROSClock,
+    clock: Clock,
     inst: ROSMessage,
     stack: list[str],
 ) -> ROSMessage:

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from builtin_interfaces.msg import Duration as DurationMsg
 from builtin_interfaces.msg import Time as TimeMsg
-from rclpy.clock import Clock
+from rclpy.clock import ROSClock
 from rclpy.parameter import Parameter
 from std_msgs.msg import Header as HeaderMsg
 
@@ -54,6 +54,7 @@ from rosbridge_library.util import bson
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from rclpy.clock import Clock
     from rclpy.node import Node
 
 
@@ -200,7 +201,7 @@ def populate_instance(
     according to the values in msg.
     """
     if clock is None:
-        clock = Clock()
+        clock = ROSClock()
 
     inst_type = msg_instance_type_repr(inst)
 
@@ -318,7 +319,7 @@ def _to_inst(
     stack: list[str] | None = None,
 ) -> object:
     if clock is None:
-        clock = Clock()
+        clock = ROSClock()
     if stack is None:
         stack = []
 

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -30,28 +30,34 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import array
 import math
 import re
 import sys
 from base64 import standard_b64decode, standard_b64encode
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
-from rcl_interfaces.msg import Parameter
+from builtin_interfaces.msg import Duration as DurationMsg
+from builtin_interfaces.msg import Time as TimeMsg
 from rclpy.clock import ROSClock
-from rclpy.time import Duration, Time
+from rclpy.parameter import Parameter
+from std_msgs.msg import Header as HeaderMsg
 
 from rosbridge_library.internal import ros_loader
+from rosbridge_library.internal.type_support import ROSMessage
 from rosbridge_library.util import bson
 
-try:
-    import rospy
-except ImportError:
-    rospy = None
+if TYPE_CHECKING:
+    from rclpy.node import Node
+
 
 type_map = {
-    "bool": ["bool", "boolean"],
-    "int": [
+    "bool": ("bool", "boolean"),
+    "int": (
         "int8",
         "octet",
         "uint8",
@@ -62,15 +68,19 @@ type_map = {
         "uint32",
         "int64",
         "uint64",
-    ],
-    "float": ["float32", "float64", "double", "float"],
-    "str": ["string"],
+    ),
+    "float": ("float32", "float64", "double", "float"),
+    "str": ("string"),
 }
-primitive_types = [bool, int, float]
+primitive_types = (bool, int, float, str)
+list_types = (list, tuple, np.ndarray, array.array)
 
-list_types = [list, tuple, np.ndarray, array.array]
-ros_time_types = ["builtin_interfaces/Time", "builtin_interfaces/Duration"]
-ros_primitive_types = [
+# Type aliases for static type checking
+PrimitiveType = bool | int | float | str
+ListType = list | tuple | np.ndarray | array.array
+
+ros_time_types = ("builtin_interfaces/Time", "builtin_interfaces/Duration")
+ros_primitive_types = (
     "bool",
     "boolean",
     "octet",
@@ -88,16 +98,16 @@ ros_primitive_types = [
     "float",
     "double",
     "string",
-]
-ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]
-ros_binary_types = ["uint8[]", "char[]", "sequence<uint8>", "sequence<char>"]
+)
+ros_header_types = ("Header", "std_msgs/Header", "roslib/Header")
+ros_binary_types = ("uint8[]", "char[]", "sequence<uint8>", "sequence<char>")
 # Remove the list type wrapper, and length specifier, from rostypes i.e. sequence<double, 3>
 list_tokens = re.compile(r"<(.+?)(, \d+)?>")
 bounded_array_tokens = re.compile(r"(.+)\[.*\]")
-ros_binary_types_list_braces = [
+ros_binary_types_list_braces = (
     ("uint8[]", re.compile(r"uint8\[[^\]]*\]")),
     ("char[]", re.compile(r"char\[[^\]]*\]")),
-]
+)
 
 binary_encoder = None
 binary_encoder_type = "default"
@@ -106,16 +116,20 @@ bson_only_mode = False
 
 # TODO(@jubeira): configure module with a node handle.
 # The original code doesn't seem to actually use these parameters.
-def configure(node_handle=None):
+def configure(node_handle: Node | None = None) -> None:
     global binary_encoder, binary_encoder_type, bson_only_mode
 
     if node_handle is not None:
-        binary_encoder_type = node_handle.get_parameter_or(
-            "binary_encoder", Parameter("", value="default")
-        ).value
-        bson_only_mode = node_handle.get_parameter_or(
-            "bson_only_mode", Parameter("", value=False)
-        ).value
+        binary_encoder_type = (
+            node_handle.get_parameter_or("binary_encoder", Parameter("", value="default"))
+            .get_parameter_value()
+            .string_value
+        )
+        bson_only_mode = (
+            node_handle.get_parameter_or("bson_only_mode", Parameter("", value=False))
+            .get_parameter_value()
+            .bool_value
+        )
 
     if binary_encoder is None:
         if binary_encoder_type == "bson" or bson_only_mode:
@@ -127,13 +141,14 @@ def configure(node_handle=None):
             sys.exit(0)
 
 
-def get_encoder():
+def get_encoder() -> Callable[[ListType], bytes]:
     configure()
+    assert binary_encoder is not None, "Binary encoder is not configured"
     return binary_encoder
 
 
 class InvalidMessageException(Exception):
-    def __init__(self, inst):
+    def __init__(self, inst: object) -> None:
         Exception.__init__(
             self,
             f"Unable to extract message values from {type(inst).__name__} instance",
@@ -141,7 +156,7 @@ class InvalidMessageException(Exception):
 
 
 class NonexistentFieldException(Exception):
-    def __init__(self, basetype, fields):
+    def __init__(self, basetype: str, fields: list[str]) -> None:
         Exception.__init__(
             self,
             "Message type {} does not have a field {}".format(basetype, ".".join(fields)),
@@ -149,7 +164,9 @@ class NonexistentFieldException(Exception):
 
 
 class FieldTypeMismatchException(Exception):
-    def __init__(self, roottype, fields, expected_type, found_type):
+    def __init__(
+        self, roottype: str, fields: list[str], expected_type: str, found_type: type
+    ) -> None:
         if roottype == expected_type:
             Exception.__init__(
                 self,
@@ -164,14 +181,16 @@ class FieldTypeMismatchException(Exception):
             )
 
 
-def extract_values(inst):
+def extract_values(inst: ROSMessage) -> dict[str, Any]:
     rostype = msg_instance_type_repr(inst)
     if rostype is None:
         raise InvalidMessageException(inst=inst)
-    return _from_inst(inst, rostype)
+    return _from_object_inst(inst, rostype)
 
 
-def populate_instance(msg, inst, clock=None):
+def populate_instance(
+    msg: dict[str, Any], inst: ROSMessage, clock: ROSClock | None = None
+) -> ROSMessage:
     """
     Populate a ROS message instance with the provided values.
 
@@ -183,10 +202,10 @@ def populate_instance(msg, inst, clock=None):
 
     inst_type = msg_instance_type_repr(inst)
 
-    return _to_inst(msg, inst_type, inst_type, clock, inst)
+    return _to_object_inst(msg, inst_type, inst_type, clock, inst, [])
 
 
-def msg_instance_type_repr(msg_inst):
+def msg_instance_type_repr(msg_inst: ROSMessage) -> str:
     """Return a string representation of a ROS2 message type from a message instance."""
     # Message representation: '{package}.msg.{message_name}({fields})'.
     # A representation like '_type' member in ROS1 messages is needed: '{package}/{message_name}'.
@@ -198,7 +217,7 @@ def msg_instance_type_repr(msg_inst):
     return "{}/{}".format(inst_repr[0], inst_repr[2].split("(")[0])
 
 
-def msg_class_type_repr(msg_class):
+def msg_class_type_repr(msg_class: type[ROSMessage]) -> str:
     """Return a string representation of a ROS2 message type from a class representation."""
     # The string representation of the class is <class '{package}.msg._{message}.{Message}'>
     # (e.g. <class 'std_msgs.msg._string.String'>).
@@ -207,71 +226,78 @@ def msg_class_type_repr(msg_class):
     return f"{class_repr[0]}/{class_repr[1]}/{class_repr[3]}"
 
 
-def _from_inst(inst, rostype):
-    global bson_only_mode
+def _from_inst(
+    inst: ROSMessage | ListType | PrimitiveType | bytes, rostype: str
+) -> dict | list | PrimitiveType | bytes | None:
     # Special case for uint8[], we encode the string
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
+            assert isinstance(inst, list_types), "Expected a list type instance"
             encoded = get_encoder()(inst)
             return encoded.decode("ascii")
 
     # Check for time or duration
     if rostype in ros_time_types:
+        assert isinstance(inst, (TimeMsg, DurationMsg)), "Expected Time or Duration instance"
         return {"sec": inst.sec, "nanosec": inst.nanosec}
 
-    if bson_only_mode is None:
-        bson_only_mode = rospy.get_param("~bson_only_mode", False)
     # Check for primitive types
     if rostype in ros_primitive_types:
-        # JSON does not support Inf and NaN. They are mapped to None and encoded as null
-        if (
-            not bson_only_mode
-            and rostype in type_map.get("float")
-            and (math.isnan(inst) or math.isinf(inst))
-        ):
-            return None
-
-        # JSON does not support byte array. They are converted to int
-        if (not bson_only_mode) and (rostype == "octet"):
-            return int.from_bytes(inst, "little")
-
-        return inst
+        assert isinstance(inst, (primitive_types, bytes)), "Expected primitive type instance"
+        return _from_primitive_inst(inst, rostype)
 
     # Check if it's a list or tuple
-    if type(inst) in list_types:
+    if isinstance(inst, list_types):
         return _from_list_inst(inst, rostype)
 
     # Assume it's otherwise a full ros msg object
+    assert isinstance(inst, ROSMessage), "Expected ROSMessage instance"
     return _from_object_inst(inst, rostype)
 
 
-def _from_list_inst(inst, rostype):
+def _from_primitive_inst(inst: PrimitiveType | bytes, rostype: str) -> PrimitiveType | bytes | None:
+    if bson_only_mode:
+        return inst
+
+    # JSON does not support Inf and NaN. They are mapped to None and encoded as null
+    if rostype in type_map["float"]:
+        assert isinstance(inst, float), "Expected float"
+        if math.isnan(inst) or math.isinf(inst):
+            return None
+
+    # octet is translated to byte array with length 1
+    # JSON does not support byte array. They are converted to int
+    if rostype == "octet":
+        assert isinstance(inst, bytes), "Expected bytes for octet"
+        return int.from_bytes(inst, "little")
+
+    return inst
+
+
+def _from_list_inst(inst: ListType, rostype: str) -> list:
     # Can duck out early if the list is empty
     if len(inst) == 0:
         return []
 
     # Remove the list indicators from the rostype
-    try:
-        rostype = re.search(list_tokens, rostype).group(1)
-    except AttributeError:
-        rostype = re.search(bounded_array_tokens, rostype).group(1)
+    base_rostype = _remove_list_indicators(rostype)
 
     # Shortcut for primitives
-    if rostype in ros_primitive_types:
+    if base_rostype in ros_primitive_types:
         # Convert to Built-in integer types to dump as JSON
         if isinstance(inst, np.ndarray) and (
-            rostype in type_map.get("int") or rostype in type_map.get("float")
+            base_rostype in type_map["int"] or base_rostype in type_map["float"]
         ):
             return inst.tolist()
 
-        if rostype not in type_map.get("float"):
+        if base_rostype not in type_map["float"]:
             return list(inst)
 
     # Call to _to_inst for every element of the list
-    return [_from_inst(x, rostype) for x in inst]
+    return [_from_inst(x, base_rostype) for x in inst]
 
 
-def _from_object_inst(inst, _rostype):
+def _from_object_inst(inst: ROSMessage, _rostype: str) -> dict:
     # Create an empty dict then populate with values from the inst
     msg = {}
     # Equivalent for zip(inst.__slots__, inst._slot_types) in ROS1:
@@ -281,7 +307,14 @@ def _from_object_inst(inst, _rostype):
     return msg
 
 
-def _to_inst(msg, rostype, roottype, clock=None, inst=None, stack=None):
+def _to_inst(
+    msg: dict[str, Any] | Sequence | str | float | bool,
+    rostype: str,
+    roottype: str,
+    clock: ROSClock | None = None,
+    inst: object | None = None,
+    stack: list[str] | None = None,
+) -> object:
     if clock is None:
         clock = ROSClock()
     if stack is None:
@@ -290,28 +323,37 @@ def _to_inst(msg, rostype, roottype, clock=None, inst=None, stack=None):
     # Check if it's uint8[], and if it's a string, try to b64decode
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
+            assert isinstance(msg, Sequence)
             return _to_binary_inst(msg)
 
     # Check the type for time or rostime
     if rostype in ros_time_types:
+        assert isinstance(msg, (dict, str)), "Expected dict or str for time or duration msg"
+        assert inst is None or isinstance(inst, (TimeMsg, DurationMsg)), (
+            "Expected Time or Duration instance"
+        )
         return _to_time_inst(msg, rostype, clock, inst)
 
     # Check to see whether this is a primitive type
     if rostype in ros_primitive_types:
+        assert isinstance(msg, primitive_types), "Expected primitive type msg"
         return _to_primitive_inst(msg, rostype, roottype, stack)
 
     # Check whether we're dealing with a list type
-    if inst is not None and type(inst) in list_types:
+    if inst is not None and isinstance(inst, (list, np.ndarray, array.array)):
+        assert isinstance(msg, list_types), "Expected a list msg"
         return _to_list_inst(msg, rostype, roottype, clock, inst, stack)
 
     # Otherwise, the type has to be a full ros msg type, so msg must be a dict
     if inst is None:
         inst = ros_loader.get_message_instance(rostype)
 
+    assert isinstance(msg, dict), "Expected a dict msg"
+    assert isinstance(inst, ROSMessage), "Expected ROSMessage instance"
     return _to_object_inst(msg, rostype, roottype, clock, inst, stack)
 
 
-def _to_binary_inst(msg):
+def _to_binary_inst(msg: Sequence) -> list | bytes | array.array:
     if isinstance(msg, str):
         return list(standard_b64decode(msg))
     if isinstance(msg, list):
@@ -325,19 +367,29 @@ def _to_binary_inst(msg):
     return bytes(bytearray(msg))
 
 
-def _to_time_inst(msg, rostype, clock, inst=None):
+def _to_time_inst(
+    msg: dict[str, Any] | str,
+    rostype: str,
+    clock: ROSClock,
+    inst: TimeMsg | DurationMsg | None = None,
+) -> TimeMsg | DurationMsg:
+    # A special case for the string "now"
+    if isinstance(msg, str):
+        if rostype == "builtin_interfaces/Time" and msg == "now":
+            return clock.now().to_msg()
+
+        err_msg = f"Invalid string for {rostype}: {msg}"
+        raise ValueError(err_msg)
+
     # Create an instance if we haven't been provided with one
-
-    if rostype == "builtin_interfaces/Time" and msg == "now":
-        return clock.now().to_msg()
-
     if inst is None:
         if rostype == "builtin_interfaces/Time":
-            inst = Time().to_msg()
+            inst = TimeMsg()
         elif rostype == "builtin_interfaces/Duration":
-            inst = Duration().to_msg()
-        else:
-            return None
+            inst = DurationMsg()
+        else:  # This should never happen, but just in case
+            msg = f"Unknown rostype for time: {rostype}"
+            raise ValueError(msg)
 
     # Copy across the fields, try ROS1 and ROS2 fieldnames
     for field in ["sec", "secs"]:
@@ -352,7 +404,9 @@ def _to_time_inst(msg, rostype, clock, inst=None):
     return inst
 
 
-def _to_primitive_inst(msg, rostype, roottype, stack):
+def _to_primitive_inst(
+    msg: PrimitiveType, rostype: str, roottype: str, stack: list[str]
+) -> PrimitiveType | bytes:
     # Typecheck the msg
     if isinstance(msg, int) and rostype in type_map["float"]:
         # probably wrong parsing,
@@ -371,9 +425,16 @@ def _to_primitive_inst(msg, rostype, roottype, stack):
     raise FieldTypeMismatchException(roottype, stack, rostype, msgtype)
 
 
-def _to_list_inst(msg, rostype, roottype, clock, inst, stack):
+def _to_list_inst(
+    msg: ListType,
+    rostype: str,
+    roottype: str,
+    clock: ROSClock,
+    inst: ListType,
+    stack: list[str],
+) -> ListType:
     # Typecheck the msg
-    if type(msg) not in list_types:
+    if not isinstance(msg, list_types):
         raise FieldTypeMismatchException(roottype, stack, rostype, type(msg))
 
     # Can duck out early if the list is empty
@@ -390,26 +451,31 @@ def _to_list_inst(msg, rostype, roottype, clock, inst, stack):
         return inst
 
     # Remove the list indicators from the rostype
-    try:
-        rostype = re.search(list_tokens, rostype).group(1)
-    except AttributeError:
-        rostype = re.search(bounded_array_tokens, rostype).group(1)
+    base_rostype = _remove_list_indicators(rostype)
 
     # Call to _to_inst for every element of the list
-    return [_to_inst(x, rostype, roottype, clock, None, stack) for x in msg]
+    return [_to_inst(x, base_rostype, roottype, clock, None, stack) for x in msg]
 
 
-def _to_object_inst(msg, rostype, roottype, clock, inst, stack):
+def _to_object_inst(
+    msg: dict[str, Any],
+    rostype: str,
+    roottype: str,
+    clock: ROSClock,
+    inst: ROSMessage,
+    stack: list[str],
+) -> ROSMessage:
     # Typecheck the msg
     if not isinstance(msg, dict):
         raise FieldTypeMismatchException(roottype, stack, rostype, type(msg))
 
     # Substitute the correct time if we're an std_msgs/Header
     if rostype in ros_header_types:
+        assert isinstance(inst, HeaderMsg), "Expected std_msgs/msg/Header instance"
         inst.stamp = clock.now().to_msg()
 
-    inst_fields = inst.get_fields_and_field_types()
-    for field_name in msg:
+    inst_fields: dict[str, str] = inst.get_fields_and_field_types()
+    for field_name, field_value in msg.items():
         # Add this field to the field stack
         field_stack = [*stack, field_name]
 
@@ -420,10 +486,41 @@ def _to_object_inst(msg, rostype, roottype, clock, inst, stack):
         field_rostype = inst_fields[field_name]
         field_inst = getattr(inst, field_name)
 
-        field_value = _to_inst(
-            msg[field_name], field_rostype, roottype, clock, field_inst, field_stack
+        field_inst_value = _to_inst(
+            field_value, field_rostype, roottype, clock, field_inst, field_stack
         )
 
-        setattr(inst, field_name, field_value)
+        setattr(inst, field_name, field_inst_value)
 
     return inst
+
+
+def _remove_list_indicators(rostype: str) -> str:
+    """
+    Remove list indicators from rostype string.
+
+    Handles patterns like:
+    - sequence<double, 3> -> double
+    - sequence<string> -> string
+    - uint8[] -> uint8
+    - char[10] -> char
+
+    :param rostype: The ROS type string that may contain list indicators
+    :type rostype: str
+    :return: The base type without list indicators
+    :rtype: str
+    :raises ValueError: If the rostype doesn't match expected list patterns
+    """
+    # Try sequence pattern first: sequence<type, length> or sequence<type>
+    list_match = re.search(list_tokens, rostype)
+    if list_match:
+        return list_match.group(1)
+
+    # Try bounded array pattern: type[length] or type[]
+    bounded_match = re.search(bounded_array_tokens, rostype)
+    if bounded_match:
+        return bounded_match.group(1)
+
+    # If neither pattern matches, this isn't a valid list type
+    err_msg = f"Invalid rostype for list: {rostype}"
+    raise ValueError(err_msg)

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -235,18 +235,24 @@ def _from_inst(
     # Special case for uint8[], we encode the string
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
-            assert isinstance(inst, list_types)
+            if not isinstance(inst, list_types):
+                err_msg = f"inst is not a list type, but a {type(inst)}"
+                raise TypeError(err_msg)
             encoded = get_encoder()(inst)
             return encoded.decode("ascii")
 
     # Check for time or duration
     if rostype in ros_time_types:
-        assert isinstance(inst, TimeMsg | DurationMsg)
+        if not isinstance(inst, TimeMsg | DurationMsg):
+            err_msg = f"inst is not TimeMsg or DurationMsg, but a {type(inst)}"
+            raise TypeError(err_msg)
         return {"sec": inst.sec, "nanosec": inst.nanosec}
 
     # Check for primitive types
     if rostype in ros_primitive_types:
-        assert isinstance(inst, (*primitive_types, bytes))
+        if not isinstance(inst, (*primitive_types, bytes)):
+            err_msg = f"inst is not a primitive type or bytes, but a {type(inst)}"
+            raise TypeError(err_msg)
         return _from_primitive_inst(inst, rostype)
 
     # Check if it's a list or tuple
@@ -254,7 +260,9 @@ def _from_inst(
         return _from_list_inst(inst, rostype)
 
     # Assume it's otherwise a full ros msg object
-    assert isinstance(inst, ROSMessage)
+    if not isinstance(inst, ROSMessage):
+        err_msg = f"inst is not a ROS Message, but a {type(inst)}"
+        raise TypeError(err_msg)
     return _from_object_inst(inst, rostype)
 
 
@@ -264,14 +272,18 @@ def _from_primitive_inst(inst: PrimitiveType | bytes, rostype: str) -> Primitive
 
     # JSON does not support Inf and NaN. They are mapped to None and encoded as null
     if rostype in type_map["float"]:
-        assert isinstance(inst, float)
+        if not isinstance(inst, float):
+            err_msg = f"inst is not a float, but a {type(inst)}"
+            raise TypeError(err_msg)
         if math.isnan(inst) or math.isinf(inst):
             return None
 
     # octet is translated to byte array with length 1
     # JSON does not support byte array. They are converted to int
     if rostype == "octet":
-        assert isinstance(inst, bytes)
+        if not isinstance(inst, bytes):
+            err_msg = f"inst is not bytes, but a {type(inst)}"
+            raise TypeError(err_msg)
         return int.from_bytes(inst, "little")
 
     return inst
@@ -326,33 +338,45 @@ def _to_inst(
     # Check if it's uint8[], and if it's a string, try to b64decode
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
-            assert isinstance(msg, Sequence)
+            if not isinstance(msg, Sequence):
+                err_msg = f"msg is not a Sequence, but a {type(msg)}"
+                raise TypeError(err_msg)
             return _to_binary_inst(msg)
 
     # Check the type for time or rostime
     if rostype in ros_time_types:
-        assert isinstance(msg, dict | str)
-        assert inst is None or isinstance(inst, TimeMsg | DurationMsg), (
-            "Expected Time or Duration instance"
-        )
+        if not isinstance(msg, dict | str):
+            err_msg = f"msg is not dict or str, but a {type(msg)}"
+            raise TypeError(err_msg)
+        if inst is not None and not isinstance(inst, TimeMsg | DurationMsg):
+            err_msg = f"inst is not Time or Duration message, but a {type(inst)}"
+            raise TypeError(err_msg)
         return _to_time_inst(msg, rostype, clock, inst)
 
     # Check to see whether this is a primitive type
     if rostype in ros_primitive_types:
-        assert isinstance(msg, primitive_types)
+        if not isinstance(msg, primitive_types):
+            err_msg = f"msg is not a primitive type, but a {type(msg)}"
+            raise TypeError(err_msg)
         return _to_primitive_inst(msg, rostype, roottype, stack)
 
     # Check whether we're dealing with a list type
     if inst is not None and isinstance(inst, list_types):
-        assert isinstance(msg, list_types)
+        if not isinstance(msg, list_types):
+            err_msg = f"msg is not a list type, but a {type(msg)}"
+            raise TypeError(err_msg)
         return _to_list_inst(msg, rostype, roottype, clock, inst, stack)
 
     # Otherwise, the type has to be a full ros msg type, so msg must be a dict
     if inst is None:
         inst = ros_loader.get_message_instance(rostype)
 
-    assert isinstance(msg, dict)
-    assert isinstance(inst, ROSMessage)
+    if not isinstance(msg, dict):
+        err_msg = f"msg is not a dict, but a {type(msg)}"
+        raise TypeError(err_msg)
+    if not isinstance(inst, ROSMessage):
+        err_msg = f"inst is not a ROS Message, but a {type(inst)}"
+        raise TypeError(err_msg)
     return _to_object_inst(msg, rostype, roottype, clock, inst, stack)
 
 
@@ -474,7 +498,9 @@ def _to_object_inst(
 
     # Substitute the correct time if we're an std_msgs/Header
     if rostype in ros_header_types:
-        assert isinstance(inst, HeaderMsg)
+        if not isinstance(inst, HeaderMsg):
+            err_msg = f"inst is not a HeaderMsg, but a {type(inst)}"
+            raise TypeError(err_msg)
         inst.stamp = clock.now().to_msg()
 
     inst_fields: dict[str, str] = inst.get_fields_and_field_types()

--- a/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
+++ b/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Generic
 
 from rosbridge_library.internal.cbor_conversion import extract_cbor_values

--- a/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
+++ b/rosbridge_library/src/rosbridge_library/internal/outgoing_message.py
@@ -1,7 +1,10 @@
+from typing import Any, Generic
+
 from rosbridge_library.internal.cbor_conversion import extract_cbor_values
 from rosbridge_library.internal.message_conversion import (
     extract_values as extract_json_values,
 )
+from rosbridge_library.internal.type_support import ROSMessageT
 
 try:
     from cbor import dumps as encode_cbor
@@ -9,38 +12,38 @@ except ImportError:
     from rosbridge_library.util.cbor import dumps as encode_cbor
 
 
-class OutgoingMessage:
+class OutgoingMessage(Generic[ROSMessageT]):
     """A message wrapper for caching encoding operations."""
 
-    def __init__(self, message):
+    def __init__(self, message: ROSMessageT) -> None:
         self._message = message
-        self._json_values = None
-        self._cbor_values = None
-        self._cbor_msg = None
-        self._cbor_raw_msg = None
+        self._json_values: dict[str, Any] | None = None
+        self._cbor_values: dict[str, Any] | None = None
+        self._cbor_msg: bytes | None = None
+        self._cbor_raw_msg: bytes | None = None
 
     @property
-    def message(self):
+    def message(self) -> ROSMessageT:
         return self._message
 
-    def get_json_values(self):
+    def get_json_values(self) -> dict[str, Any]:
         if self._json_values is None:
             self._json_values = extract_json_values(self._message)
         return self._json_values
 
-    def get_cbor_values(self):
+    def get_cbor_values(self) -> dict[str, Any]:
         if self._cbor_values is None:
             self._cbor_values = extract_cbor_values(self._message)
         return self._cbor_values
 
-    def get_cbor(self, outgoing_msg):
+    def get_cbor(self, outgoing_msg: dict[str, Any]) -> bytes:
         if self._cbor_msg is None:
             outgoing_msg["msg"] = self.get_cbor_values()
             self._cbor_msg = encode_cbor(outgoing_msg)
 
         return self._cbor_msg
 
-    def get_cbor_raw(self, outgoing_msg):
+    def get_cbor_raw(self, outgoing_msg: dict[str, Any]) -> bytes:
         if self._cbor_raw_msg is None:
             self._cbor_raw_msg = encode_cbor(outgoing_msg)
 

--- a/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
+++ b/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 from base64 import standard_b64decode, standard_b64encode
 from io import BytesIO
 from math import ceil, floor, sqrt

--- a/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
+++ b/rosbridge_library/src/rosbridge_library/internal/pngcompression.py
@@ -37,7 +37,7 @@ from math import ceil, floor, sqrt
 from PIL import Image
 
 
-def encode(string):
+def encode(string: str) -> str:
     r"""
     PNG-compress the string in a square RGB image padded with '\n'.
 
@@ -56,7 +56,7 @@ def encode(string):
     return encoded.decode()
 
 
-def decode(string):
+def decode(string: str) -> str:
     r"""b64 decode the string, then PNG-decompress and remove the '\n' padding."""
     decoded = standard_b64decode(string)
     buff = BytesIO(decoded)

--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -31,7 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 from threading import Timer
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 from rclpy.duration import Duration
 from rclpy.qos import DurabilityPolicy, QoSProfile
@@ -42,9 +45,14 @@ from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
     TypeConflictException,
 )
+from rosbridge_library.internal.type_support import ROSMessage, ROSMessageT
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
+    from rclpy.publisher import Publisher
 
 
-class MultiPublisher:
+class MultiPublisher(Generic[ROSMessageT]):
     """
     Keeps track of the clients that are using a particular publisher.
 
@@ -52,7 +60,14 @@ class MultiPublisher:
     this publisher.
     """
 
-    def __init__(self, topic, node_handle, msg_type=None, latched_client_id=None, queue_size=100):
+    def __init__(
+        self,
+        topic: str,
+        node_handle: Node,
+        msg_type: str | None = None,
+        latched_client_id: str | None = None,
+        queue_size: int = 100,
+    ) -> None:
         """
         Register a publisher on the specified topic.
 
@@ -70,24 +85,28 @@ class MultiPublisher:
         """
         # First check to see if the topic is already established
         topics_names_and_types = dict(node_handle.get_topic_names_and_types())
-        topic_type = topics_names_and_types.get(topic)
+        topic_types = topics_names_and_types.get(topic)
+        topic_type: str | None = None
 
         # If it's not established and no type was specified, exception
-        if msg_type is None and topic_type is None:
+        if msg_type is None and topic_types is None:
             raise TopicNotEstablishedException(topic)
 
-        # topic_type is a list of types or None at this point; only one type is supported.
-        if topic_type is not None:
-            if len(topic_type) > 1:
-                node_handle.get_logger().warning(f"More than one topic type detected: {topic_type}")
-            topic_type = topic_type[0]
+        # topic_types is a list of types or None at this point; only one type is supported.
+        if topic_types is not None:
+            if len(topic_types) > 1:
+                node_handle.get_logger().warning(
+                    f"More than one topic type detected: {topic_types}"
+                )
+            topic_type = topic_types[0]
 
         # Use the established topic type if none was specified
         if msg_type is None:
+            assert topic_type is not None, "topic_type cannot be None at this point"
             msg_type = topic_type
 
         # Load the message class, propagating any exceptions from bad msg types
-        msg_class = ros_loader.get_message_class(msg_type)
+        msg_class = cast("type[ROSMessageT]", ros_loader.get_message_class(msg_type))
 
         # Make sure the specified msg type and established msg type are same
         msg_type_string = msg_class_type_repr(msg_class)
@@ -95,7 +114,7 @@ class MultiPublisher:
             raise TypeConflictException(topic, topic_type, msg_type_string)
 
         # Create the publisher and associated member variables
-        self.clients = {}
+        self.clients: dict[str, bool] = {}
         self.latched_client_id = latched_client_id
         self.topic = topic
         self.node_handle = node_handle
@@ -115,14 +134,16 @@ class MultiPublisher:
         else:
             publisher_qos.depth = 1
 
-        self.publisher = node_handle.create_publisher(msg_class, topic, qos_profile=publisher_qos)
+        self.publisher: Publisher[ROSMessageT] = node_handle.create_publisher(
+            msg_class, topic, qos_profile=publisher_qos
+        )
 
-    def unregister(self):
+    def unregister(self) -> None:
         """Unregister the publisher and clear the clients."""
         self.node_handle.destroy_publisher(self.publisher)
         self.clients.clear()
 
-    def verify_type(self, msg_type):
+    def verify_type(self, msg_type: str) -> None:
         """
         Verify that the publisher publishes messages of the specified type.
 
@@ -135,7 +156,7 @@ class MultiPublisher:
         if ros_loader.get_message_class(msg_type) is not self.msg_class:
             raise TypeConflictException(self.topic, msg_class_type_repr(self.msg_class), msg_type)
 
-    def publish(self, msg):
+    def publish(self, msg: dict[str, Any]) -> None:
         """
         Publish a message using this publisher.
 
@@ -153,7 +174,7 @@ class MultiPublisher:
         # Publish the message
         self.publisher.publish(inst)
 
-    def register_client(self, client_id):
+    def register_client(self, client_id: str) -> None:
         """
         Register the specified client as a client of this publisher.
 
@@ -161,7 +182,7 @@ class MultiPublisher:
         """
         self.clients[client_id] = True
 
-    def unregister_client(self, client_id):
+    def unregister_client(self, client_id: str) -> None:
         """
         Unregister the specified client from this publisher.
 
@@ -173,7 +194,7 @@ class MultiPublisher:
         if client_id in self.clients:
             del self.clients[client_id]
 
-    def has_clients(self):
+    def has_clients(self) -> bool:
         """Return true if there are clients to this publisher."""
         return len(self.clients) != 0
 
@@ -188,12 +209,20 @@ class PublisherManager:
     then that publisher is unregistered from the ROS Master.
     """
 
-    def __init__(self):
-        self._publishers = {}
-        self.unregister_timers = {}
-        self.unregister_timeout = 10.0
+    def __init__(self) -> None:
+        self._publishers: dict[str, MultiPublisher[ROSMessage]] = {}
+        self.unregister_timers: dict[str, Timer] = {}
+        self.unregister_timeout: float = 10.0
 
-    def register(self, client_id, topic, node_handle, msg_type=None, latch=False, queue_size=100):
+    def register(
+        self,
+        client_id: str,
+        topic: str,
+        node_handle: Node,
+        msg_type: str | None = None,
+        latch: bool = False,
+        queue_size: int = 100,
+    ) -> None:
         """
         Register a publisher on the specified topic.
 
@@ -220,19 +249,19 @@ class PublisherManager:
                 queue_size=queue_size,
             )
         elif latch and self._publishers[topic].latched_client_id != client_id:
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 f"Client ID {client_id} attempted to register topic [{topic}] as "
                 "latched but this topic was previously registered."
             )
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 "Only a single registered latched publisher is supported at the time"
             )
         elif not latch and self._publishers[topic].latched_client_id:
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 f"New non-latched publisher registration for topic [{topic}] which is "
                 "already registered as latched. but this topic was previously registered."
             )
-            node_handle.get_logger().warn(
+            node_handle.get_logger().warning(
                 "Only a single registered latched publisher is supported at the time"
             )
 
@@ -241,7 +270,7 @@ class PublisherManager:
 
         self._publishers[topic].register_client(client_id)
 
-    def unregister(self, client_id, topic):
+    def unregister(self, client_id: str, topic: str) -> None:
         """
         Unregister a client from the publisher for the given topic.
 
@@ -265,13 +294,13 @@ class PublisherManager:
         )
         self.unregister_timers[topic].start()
 
-    def _unregister_impl(self, topic):
+    def _unregister_impl(self, topic: str) -> None:
         if not self._publishers[topic].has_clients():
             self._publishers[topic].unregister()
             del self._publishers[topic]
         del self.unregister_timers[topic]
 
-    def unregister_all(self, client_id):
+    def unregister_all(self, client_id: str) -> None:
         """
         Unregister a client from all publishers that they are registered to.
 
@@ -280,7 +309,15 @@ class PublisherManager:
         for topic in self._publishers:
             self.unregister(client_id, topic)
 
-    def publish(self, client_id, topic, msg, node_handle, latch=False, queue_size=100):
+    def publish(
+        self,
+        client_id: str,
+        topic: str,
+        msg: dict,
+        node_handle: Node,
+        latch: bool = False,
+        queue_size: int = 100,
+    ) -> None:
         """
         Publish a message on the given topic.
 

--- a/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
+++ b/rosbridge_library/src/rosbridge_library/internal/ros_loader.py
@@ -30,9 +30,18 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import importlib
 from threading import Lock
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from rosbridge_library.internal.type_support import (
+        ROSAction,
+        ROSMessage,
+        ROSService,
+    )
 
 """ ros_loader contains methods for dynamically loading ROS message classes at
 runtime.  It's achieved by using roslib to load the manifest files for the
@@ -42,9 +51,9 @@ Methods typically return the requested class or instance, or None if not found
 """
 
 # Variable containing the loaded classes
-_loaded_msgs: dict[str, Any] = {}
-_loaded_srvs: dict[str, Any] = {}
-_loaded_actions: dict[str, Any] = {}
+_loaded_msgs: dict[str, type[ROSMessage]] = {}
+_loaded_srvs: dict[str, type[ROSService]] = {}
+_loaded_actions: dict[str, type[ROSAction]] = {}
 _msgs_lock = Lock()
 _srvs_lock = Lock()
 _actions_lock = Lock()
@@ -73,7 +82,7 @@ class InvalidClassException(Exception):
         )
 
 
-def get_message_class(typestring: str) -> Any:
+def get_message_class(typestring: str) -> type[ROSMessage]:
     """
     Load the message type specified.
 
@@ -84,7 +93,7 @@ def get_message_class(typestring: str) -> Any:
     return _get_interface_class(typestring, "msg", _loaded_msgs, _msgs_lock)
 
 
-def get_service_class(typestring: str) -> Any:
+def get_service_class(typestring: str) -> type[ROSService]:
     """
     Load the service type specified.
 
@@ -95,7 +104,7 @@ def get_service_class(typestring: str) -> Any:
     return _get_interface_class(typestring, "srv", _loaded_srvs, _srvs_lock)
 
 
-def get_action_class(typestring: str) -> Any:
+def get_action_class(typestring: str) -> type[ROSAction]:
     """
     Load the action type specified.
 
@@ -106,7 +115,7 @@ def get_action_class(typestring: str) -> Any:
     return _get_interface_class(typestring, "action", _loaded_actions, _actions_lock)
 
 
-def get_message_instance(typestring: str) -> Any:
+def get_message_instance(typestring: str) -> ROSMessage:
     """
     If not loaded, load the specified type and return an instance of it.
 
@@ -114,40 +123,40 @@ def get_message_instance(typestring: str) -> Any:
 
     :return: The instance of the message class.
     """
-    cls = get_message_class(typestring)
+    cls: type[ROSMessage] = get_message_class(typestring)
     return cls()
 
 
-def get_service_request_instance(typestring: str) -> Any:
-    cls = get_service_class(typestring)
+def get_service_request_instance(typestring: str) -> ROSMessage:
+    cls: type[ROSService] = get_service_class(typestring)
     return cls.Request()
 
 
-def get_service_response_instance(typestring: str) -> Any:
-    cls = get_service_class(typestring)
+def get_service_response_instance(typestring: str) -> ROSMessage:
+    cls: type[ROSService] = get_service_class(typestring)
     return cls.Response()
 
 
-def get_action_goal_instance(typestring: str) -> Any:
-    cls = get_action_class(typestring)
+def get_action_goal_instance(typestring: str) -> ROSMessage:
+    cls: type[ROSAction] = get_action_class(typestring)
     return cls.Goal()
 
 
-def get_action_feedback_instance(typestring: str) -> Any:
-    cls = get_action_class(typestring)
+def get_action_feedback_instance(typestring: str) -> ROSMessage:
+    cls: type[ROSAction] = get_action_class(typestring)
     return cls.Feedback()
 
 
-def get_action_result_instance(typestring: str) -> Any:
-    cls = get_action_class(typestring)
+def get_action_result_instance(typestring: str) -> ROSMessage:
+    cls: type[ROSAction] = get_action_class(typestring)
     return cls.Result()
 
 
 def _get_interface_class(
-    typestring: str, intf_type: str, loaded_intfs: dict[str, Any], intf_lock: Lock
-) -> Any:
+    typestring: str, intf_type: str, loaded_intfs: dict[str, type[Any]], intf_lock: Lock
+) -> type[Any]:
     """
-    If not loaded, load the specified ROS interface class then return an instance of it.
+    If not loaded, load the specified ROS interface class then return the class.
 
     Throws various exceptions if loading the interface class fails.
     """
@@ -167,16 +176,21 @@ def _get_interface_class(
         return _get_class(typestring, intf_type, loaded_intfs, intf_lock)
 
 
-def _get_class(typestring: str, subname: str, cache: dict[str, Any], lock: Lock) -> Any:
+def _get_class(
+    typestring: str,
+    subname: str,
+    cache: dict[str, type[ROSMessage]] | dict[str, type[ROSService]] | dict[str, type[ROSAction]],
+    lock: Lock,
+) -> type[ROSMessage | ROSService | ROSAction]:
     """
-    If not loaded, load the specified class then returns an instance of it.
+    If not loaded, load the specified class then returns the class.
 
     Loaded classes are cached in the provided cache dict
 
-    Throws various exceptions if loading the msg class fails.
+    Throws various exceptions if loading the class fails.
     """
     # First, see if we have this type string cached
-    cls = _get_from_cache(cache, lock, typestring)
+    cls: type[ROSMessage | ROSService | ROSAction] | None = _get_from_cache(cache, lock, typestring)
     if cls is not None:
         return cls
 
@@ -199,7 +213,9 @@ def _get_class(typestring: str, subname: str, cache: dict[str, Any], lock: Lock)
     return cls
 
 
-def _load_class(modname: str, subname: str, classname: str) -> Any:
+def _load_class(
+    modname: str, subname: str, classname: str
+) -> type[ROSMessage | ROSService | ROSAction]:
     """
     Load the manifest and import the module that contains the specified type.
 
@@ -235,13 +251,17 @@ def _splittype(typestring: str) -> tuple[str, str]:
     raise InvalidTypeStringException(typestring)
 
 
-def _add_to_cache(cache: dict[str, Any], lock: Lock, key: str, value: Any) -> None:
+def _add_to_cache(
+    cache: dict[str, Any], lock: Lock, key: str, value: type[ROSMessage | ROSService | ROSAction]
+) -> None:
     lock.acquire()
     cache[key] = value
     lock.release()
 
 
-def _get_from_cache(cache: dict[str, Any], lock: Lock, key: str) -> Any:
+def _get_from_cache(
+    cache: dict[str, Any], lock: Lock, key: str
+) -> type[ROSMessage | ROSService | ROSAction] | None:
     """
     Return the value for the specified key from the cache.
 

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -32,7 +32,7 @@
 from __future__ import annotations
 
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from rclpy.callback_groups import ReentrantCallbackGroup
 
@@ -61,7 +61,7 @@ class ServiceCaller(Thread):
     def __init__(
         self,
         service: str,
-        args: dict,
+        args: list | dict[str, Any] | None,
         timeout: float,
         success_callback: Callable[[dict], None],
         error_callback: Callable[[Exception], None],
@@ -108,7 +108,7 @@ class ServiceCaller(Thread):
             self.error(e)
 
 
-def args_to_service_request_instance(inst: ROSMessage, args: list | dict | None) -> None:
+def args_to_service_request_instance(inst: ROSMessage, args: list | dict[str, Any] | None) -> None:
     """
     Populate a service request instance with the provided args.
 
@@ -129,7 +129,7 @@ def args_to_service_request_instance(inst: ROSMessage, args: list | dict | None)
 def call_service(
     node_handle: Node,
     service: str,
-    args: dict | None = None,
+    args: list | dict[str, Any] | None = None,
     server_ready_timeout: float = 1.0,
     server_response_timeout: float = 5.0,
 ) -> dict:

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -32,7 +32,7 @@
 from __future__ import annotations
 
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable
 
 from rclpy.callback_groups import ReentrantCallbackGroup
 
@@ -49,9 +49,11 @@ if TYPE_CHECKING:
     from rclpy.client import Client
     from rclpy.node import Node
 
+    from rosbridge_library.internal.type_support import ROSMessage
+
 
 class InvalidServiceException(Exception):
-    def __init__(self, service_name) -> None:
+    def __init__(self, service_name: str) -> None:
         Exception.__init__(self, f"Service {service_name} does not exist")
 
 
@@ -106,7 +108,7 @@ class ServiceCaller(Thread):
             self.error(e)
 
 
-def args_to_service_request_instance(inst: Any, args: list | dict | None) -> Any:
+def args_to_service_request_instance(inst: ROSMessage, args: list | dict | None) -> None:
     """
     Populate a service request instance with the provided args.
 
@@ -162,7 +164,7 @@ def call_service(
     future = client.call_async(inst)
     event = Event()
 
-    def future_done_callback():
+    def future_done_callback() -> None:
         event.set()
 
     future.add_done_callback(lambda _: future_done_callback())

--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -32,7 +32,7 @@
 from __future__ import annotations
 
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from rclpy.callback_groups import ReentrantCallbackGroup
 
@@ -46,6 +46,8 @@ from rosbridge_library.internal.ros_loader import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rclpy.client import Client
     from rclpy.node import Node
 
@@ -118,7 +120,7 @@ def args_to_service_request_instance(inst: ROSMessage, args: list | dict[str, An
     """
     msg = {}
     if isinstance(args, list):
-        msg = dict(zip(inst.get_fields_and_field_types().keys(), args))
+        msg = dict(zip(inst.get_fields_and_field_types().keys(), args, strict=False))
     elif isinstance(args, dict):
         msg = args
 

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 from functools import partial
 from threading import Lock, RLock
-from typing import TYPE_CHECKING, Callable, Generic, cast
+from typing import TYPE_CHECKING, Generic, cast
 
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
@@ -50,7 +50,7 @@ from rosbridge_library.internal.topics import (
 from rosbridge_library.internal.type_support import ROSMessageT
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from rclpy.node import Node
     from rclpy.subscription import Subscription

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -31,7 +31,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
+from functools import partial
 from threading import Lock, RLock
+from typing import TYPE_CHECKING, Callable, Generic, cast
 
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
@@ -43,13 +47,20 @@ from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
     TypeConflictException,
 )
+from rosbridge_library.internal.type_support import ROSMessageT
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from rclpy.node import Node
+    from rclpy.subscription import Subscription
 
 """ Manages and interfaces with ROS Subscriber objects.  A single subscriber
 is shared between multiple clients
 """
 
 
-class MultiSubscriber:
+class MultiSubscriber(Generic[ROSMessageT]):
     """
     Handles multiple clients for a single subscriber.
 
@@ -58,7 +69,15 @@ class MultiSubscriber:
     or accessing the subscribed clients.
     """
 
-    def __init__(self, topic, client_id, callback, node_handle, msg_type=None, raw=False):
+    def __init__(
+        self,
+        topic: str,
+        client_id: str,
+        callback: Callable[[OutgoingMessage[ROSMessageT]], None],
+        node_handle: Node,
+        msg_type: str | None = None,
+        raw: bool = False,
+    ) -> None:
         """
         Register a subscriber on the specified topic.
 
@@ -76,24 +95,28 @@ class MultiSubscriber:
         """
         # First check to see if the topic is already established
         topics_names_and_types = dict(node_handle.get_topic_names_and_types())
-        topic_type = topics_names_and_types.get(topic)
+        topic_types = topics_names_and_types.get(topic)
 
         # If it's not established and no type was specified, exception
-        if msg_type is None and topic_type is None:
+        if msg_type is None and topic_types is None:
             raise TopicNotEstablishedException(topic)
 
-        # topic_type is a list of types or None at this point; only one type is supported.
-        if topic_type is not None:
-            if len(topic_type) > 1:
-                node_handle.get_logger().warning(f"More than one topic type detected: {topic_type}")
-            topic_type = topic_type[0]
+        # topic_types is a list of types or None at this point; only one type is supported.
+        topic_type: str | None = None
+        if topic_types is not None:
+            if len(topic_types) > 1:
+                node_handle.get_logger().warning(
+                    f"More than one topic type detected: {topic_types}"
+                )
+            topic_type = topic_types[0]
 
         # Use the established topic type if none was specified
         if msg_type is None:
+            assert topic_type is not None
             msg_type = topic_type
 
         # Load the message class, propagating any exceptions from bad msg types
-        msg_class = ros_loader.get_message_class(msg_type)
+        msg_class = cast("type[ROSMessageT]", ros_loader.get_message_class(msg_type))
 
         # Make sure the specified msg type and established msg type are same
         msg_type_string = msg_class_type_repr(msg_class)
@@ -139,12 +162,17 @@ class MultiSubscriber:
         self.callback_group = MutuallyExclusiveCallbackGroup()
 
         self.subscriber = node_handle.create_subscription(
-            msg_class, topic, self.callback, qos, raw=raw, callback_group=self.callback_group
+            msg_class,
+            topic,
+            partial(self.callback, callbacks=None),
+            qos,
+            raw=raw,
+            callback_group=self.callback_group,
         )
-        self.new_subscriber = None
-        self.new_subscriptions = {}
+        self.new_subscriber: Subscription[ROSMessageT] | None = None
+        self.new_subscriptions: dict[str, Callable[[OutgoingMessage[ROSMessageT]], None]] = {}
 
-    def unregister(self):
+    def unregister(self) -> None:
         self.node_handle.destroy_subscription(self.subscriber)
         with self.rlock:
             self.subscriptions.clear()
@@ -152,7 +180,7 @@ class MultiSubscriber:
                 self.node_handle.destroy_subscription(self.new_subscriber)
                 self.new_subscriber = None
 
-    def verify_type(self, msg_type):
+    def verify_type(self, msg_type: str) -> None:
         """
         Verify that the subscriber subscribes to messages of this type.
 
@@ -164,7 +192,9 @@ class MultiSubscriber:
         if ros_loader.get_message_class(msg_type) is not self.msg_class:
             raise TypeConflictException(self.topic, msg_class_type_repr(self.msg_class), msg_type)
 
-    def subscribe(self, client_id, callback):
+    def subscribe(
+        self, client_id: str, callback: Callable[[OutgoingMessage[ROSMessageT]], None]
+    ) -> None:
         """
         Subscribe the specified client to this subscriber.
 
@@ -196,7 +226,7 @@ class MultiSubscriber:
                     callback_group=self.callback_group,
                 )
 
-    def unsubscribe(self, client_id):
+    def unsubscribe(self, client_id: str) -> None:
         """
         Unsubscribe the specified client from this subscriber.
 
@@ -208,12 +238,14 @@ class MultiSubscriber:
             if client_id in self.subscriptions:
                 del self.subscriptions[client_id]
 
-    def has_subscribers(self):
+    def has_subscribers(self) -> bool:
         """Return true if there are subscribers."""
         with self.rlock:
             return len(self.subscriptions) + len(self.new_subscriptions) != 0
 
-    def callback(self, msg, callbacks=None):
+    def callback(
+        self, msg: ROSMessageT, callbacks: Iterable[Callable[[OutgoingMessage], None]] | None = None
+    ) -> None:
         """
         Handle incoming messages on the rclpy subscription.
 
@@ -237,7 +269,7 @@ class MultiSubscriber:
                         f"Exception calling subscribe callback: {exc}"
                     )
 
-    def _new_sub_callback(self, msg):
+    def _new_sub_callback(self, msg: ROSMessageT) -> None:
         """
         Callbacks for new subscribers.
 
@@ -252,6 +284,7 @@ class MultiSubscriber:
             self.callback(msg, self.new_subscriptions.values())
             self.subscriptions.update(self.new_subscriptions)
             self.new_subscriptions = {}
+            assert self.new_subscriber is not None
             self.node_handle.destroy_subscription(self.new_subscriber)
             self.new_subscriber = None
 
@@ -259,11 +292,19 @@ class MultiSubscriber:
 class SubscriberManager:
     """Keeps track of client subscriptions."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = Lock()
-        self._subscribers = {}
+        self._subscribers: dict[str, MultiSubscriber] = {}
 
-    def subscribe(self, client_id, topic, callback, node_handle, msg_type=None, raw=False):
+    def subscribe(
+        self,
+        client_id: str,
+        topic: str,
+        callback: Callable[[OutgoingMessage], None],
+        node_handle: Node,
+        msg_type: str | None = None,
+        raw: bool = False,
+    ) -> None:
         """
         Subscribe to a topic.
 
@@ -283,7 +324,7 @@ class SubscriberManager:
             if msg_type is not None and not raw:
                 self._subscribers[topic].verify_type(msg_type)
 
-    def unsubscribe(self, client_id, topic):
+    def unsubscribe(self, client_id: str, topic: str) -> None:
         """
         Unsubscribe from a topic.
 

--- a/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
@@ -30,11 +30,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import sys
 import time
 import traceback
 from collections import deque
 from threading import Condition, Thread
+from typing import Callable, Generic, TypeVar
 
 """ Sits between incoming messages from a subscription, and the outgoing
 publish method.  Provides throttling / buffering capabilities.
@@ -43,9 +46,20 @@ When the parameters change, the handler may transition to a different kind
 of handler
 """
 
+MsgT = TypeVar("MsgT")
 
-class MessageHandler:
-    def __init__(self, previous_handler=None, publish=None):
+
+class MessageHandler(Generic[MsgT]):
+    last_publish: float
+    throttle_rate: float
+    queue_length: int
+    publish: Callable[[MsgT], None] | None
+
+    def __init__(
+        self,
+        previous_handler: MessageHandler | None = None,
+        publish: Callable[[MsgT], None] | None = None,
+    ) -> None:
         if previous_handler:
             self.last_publish = previous_handler.last_publish
             self.throttle_rate = previous_handler.throttle_rate
@@ -57,59 +71,62 @@ class MessageHandler:
             self.queue_length = 0
             self.publish = publish
 
-    def set_throttle_rate(self, throttle_rate):
+    def set_throttle_rate(self, throttle_rate: float) -> MessageHandler:
         self.throttle_rate = throttle_rate / 1000.0
         return self.transition()
 
-    def set_queue_length(self, queue_length):
+    def set_queue_length(self, queue_length: int) -> MessageHandler:
         self.queue_length = queue_length
         return self.transition()
 
-    def time_remaining(self):
+    def time_remaining(self) -> float:
         return max((self.last_publish + self.throttle_rate) - time.monotonic(), 0)
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: MsgT) -> None:
         self.last_publish = time.monotonic()
+        if self.publish is None:
+            err_msg = "No publish method set for MessageHandler"
+            raise RuntimeError(err_msg)
         self.publish(msg)
 
-    def transition(self):
+    def transition(self) -> MessageHandler:
         if self.queue_length > 0:
             return QueueMessageHandler(self)
         if self.throttle_rate > 0:
             return ThrottleMessageHandler(self)
         return self
 
-    def finish(self, block=True):
+    def finish(self, block: bool = True) -> None:
         pass
 
 
-class ThrottleMessageHandler(MessageHandler):
-    def handle_message(self, msg):
+class ThrottleMessageHandler(MessageHandler[MsgT]):
+    def handle_message(self, msg: MsgT) -> None:
         if self.time_remaining() == 0:
             MessageHandler.handle_message(self, msg)
 
-    def transition(self):
+    def transition(self) -> MessageHandler:
         if self.queue_length > 0:
             return QueueMessageHandler(self)
         if self.throttle_rate > 0:
             return self
         return MessageHandler(self)
 
-    def finish(self, block=True):
+    def finish(self, block: bool = True) -> None:
         pass
 
 
-class QueueMessageHandler(MessageHandler, Thread):
-    def __init__(self, previous_handler):
+class QueueMessageHandler(MessageHandler[MsgT], Thread):
+    def __init__(self, previous_handler: MessageHandler) -> None:
         Thread.__init__(self)
         MessageHandler.__init__(self, previous_handler)
         self.daemon = True
-        self.queue = deque(maxlen=self.queue_length)
+        self.queue: deque[MsgT] = deque(maxlen=self.queue_length)
         self.c = Condition()
         self.alive = True
         self.start()
 
-    def handle_message(self, msg):
+    def handle_message(self, msg: MsgT) -> None:
         with self.c:
             if not self.alive:
                 return
@@ -118,7 +135,7 @@ class QueueMessageHandler(MessageHandler, Thread):
             if should_notify:
                 self.c.notify()
 
-    def transition(self):
+    def transition(self) -> MessageHandler:
         if self.queue_length > 0:
             with self.c:
                 old_queue = self.queue
@@ -132,7 +149,7 @@ class QueueMessageHandler(MessageHandler, Thread):
             return ThrottleMessageHandler(self)
         return MessageHandler(self)
 
-    def finish(self, block=True):
+    def finish(self, block: bool = True) -> None:
         """
         Notify the thread to finish, and optionally wait for it to finish.
 
@@ -148,7 +165,7 @@ class QueueMessageHandler(MessageHandler, Thread):
         if block:
             self.join()
 
-    def run(self):
+    def run(self) -> None:
         while self.alive:
             msg = None
             with self.c:

--- a/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscription_modifiers.py
@@ -37,7 +37,10 @@ import time
 import traceback
 from collections import deque
 from threading import Condition, Thread
-from typing import Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 """ Sits between incoming messages from a subscription, and the outgoing
 publish method.  Provides throttling / buffering capabilities.

--- a/rosbridge_library/src/rosbridge_library/internal/topics.py
+++ b/rosbridge_library/src/rosbridge_library/internal/topics.py
@@ -32,6 +32,8 @@
 
 """Exceptions and code common to both publishers and subscribers."""
 
+from __future__ import annotations
+
 
 class TopicNotEstablishedException(Exception):
     def __init__(self, topic: str) -> None:

--- a/rosbridge_library/src/rosbridge_library/internal/topics.py
+++ b/rosbridge_library/src/rosbridge_library/internal/topics.py
@@ -34,7 +34,7 @@
 
 
 class TopicNotEstablishedException(Exception):
-    def __init__(self, topic):
+    def __init__(self, topic: str) -> None:
         Exception.__init__(
             self,
             f"Cannot infer topic type for topic {topic} as it is not yet advertised",
@@ -42,7 +42,7 @@ class TopicNotEstablishedException(Exception):
 
 
 class TypeConflictException(Exception):
-    def __init__(self, topic, orig_type, new_type):
+    def __init__(self, topic: str, orig_type: str, new_type: str) -> None:
         Exception.__init__(
             self,
             f"Tried to register topic {topic} with type {new_type} but it is already established with type {orig_type}",

--- a/rosbridge_library/src/rosbridge_library/internal/type_support.py
+++ b/rosbridge_library/src/rosbridge_library/internal/type_support.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 from typing import Protocol, TypeVar, runtime_checkable
 
 

--- a/rosbridge_library/src/rosbridge_library/internal/type_support.py
+++ b/rosbridge_library/src/rosbridge_library/internal/type_support.py
@@ -1,0 +1,62 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2025, Fictionlab sp. z o.o.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ROSMessage(Protocol):
+    """Protocol for ROS message types."""
+
+    __slots__: list[str]
+    _fields_and_field_types: dict[str, str]
+
+    def get_fields_and_field_types(self) -> dict[str, str]:
+        """Return a dictionary of field names to field types."""
+
+
+@runtime_checkable
+class ROSService(Protocol):
+    """Protocol for ROS service types."""
+
+    Request: type[ROSMessage]
+    Response: type[ROSMessage]
+    Event: type[ROSMessage]
+
+
+@runtime_checkable
+class ROSAction(Protocol):
+    """Protocol for ROS action types."""
+
+    Goal: type[ROSMessage]
+    Result: type[ROSMessage]
+    Feedback: type[ROSMessage]

--- a/rosbridge_library/src/rosbridge_library/internal/type_support.py
+++ b/rosbridge_library/src/rosbridge_library/internal/type_support.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol, TypeVar, runtime_checkable
 
 
 @runtime_checkable
@@ -60,3 +60,14 @@ class ROSAction(Protocol):
     Goal: type[ROSMessage]
     Result: type[ROSMessage]
     Feedback: type[ROSMessage]
+
+
+# Type variables for ROS types
+ROSMessageT = TypeVar("ROSMessageT", bound=ROSMessage)
+ROSServiceT = TypeVar("ROSServiceT", bound=ROSService)
+ROSServiceRequestT = TypeVar("ROSServiceRequestT", bound=ROSMessage)
+ROSServiceResponseT = TypeVar("ROSServiceResponseT", bound=ROSMessage)
+ROSActionT = TypeVar("ROSActionT", bound=ROSAction)
+ROSActionGoalT = TypeVar("ROSActionGoalT", bound=ROSMessage)
+ROSActionResultT = TypeVar("ROSActionResultT", bound=ROSMessage)
+ROSActionFeedbackT = TypeVar("ROSActionFeedbackT", bound=ROSMessage)

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -33,12 +33,14 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capabilities.fragmentation import Fragmentation
 from rosbridge_library.util import bson, json
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rclpy.node import Node
 
     from rosbridge_library.capabilities.advertise_action import AdvertisedActionHandler

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -30,22 +30,31 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from rosbridge_library.capabilities.fragmentation import Fragmentation
 from rosbridge_library.util import bson, json
 
+if TYPE_CHECKING:
+    from rclpy.node import Node
 
-def is_number(s):
+    from rosbridge_library.capabilities.advertise_action import AdvertisedActionHandler
+    from rosbridge_library.capabilities.advertise_service import AdvertisedServiceHandler
+    from rosbridge_library.capability import Capability
+
+
+def is_number(s: object) -> bool | None:
     try:
-        float(s)
+        float(s)  # type: ignore[arg-type]
         return True
     except ValueError:
         return False
 
 
-def has_binary(obj):
+def has_binary(obj: object) -> bool:
     """Return True if obj is a binary or contains a binary attribute."""
     if isinstance(obj, list):
         return any(has_binary(item) for item in obj)
@@ -81,15 +90,15 @@ class Protocol:
     # !! this might be related to (or even be avoided by using) throttle_rate !!
     delay_between_messages = 0
     # global list of non-ros advertised services
-    external_service_list: dict[str, Any]
+    external_service_list: dict[str, AdvertisedServiceHandler]
     # global list of non-ros advertised actions
-    external_action_list: dict[str, Any]
+    external_action_list: dict[str, AdvertisedActionHandler]
     # Use only BSON for the whole communication if the server has been started with bson_only_mode:=True
     bson_only_mode = False
 
     parameters = None
 
-    def __init__(self, client_id, node_handle):
+    def __init__(self, client_id: str, node_handle: Node) -> None:
         """
         Initialize the protocol with a client ID and a ROS2 node handle.
 
@@ -98,8 +107,8 @@ class Protocol:
         :param node_handle: A ROS2 node handle
         """
         self.client_id = client_id
-        self.capabilities = []
-        self.operations = {}
+        self.capabilities: list[Capability] = []
+        self.operations: dict[str, Callable[[dict[str, Any]], None]] = {}
         self.node_handle = node_handle
         self.external_service_list = {}
         self.external_action_list = {}
@@ -111,7 +120,7 @@ class Protocol:
 
     # added default message_string="" to allow recalling incoming until buffer is empty without giving a parameter
     # --> allows to get rid of (..or minimize) delay between client-side sends
-    def incoming(self, message_string=""):
+    def incoming(self, message_string: str = "") -> None:
         """
         Process an incoming message from the client.
 
@@ -232,7 +241,7 @@ class Protocol:
             self.old_buffer = self.buffer
             self.incoming()
 
-    def outgoing(self, message, compression="none"):
+    def outgoing(self, message: bson.Binary | bytearray | str, compression: str = "none") -> None:
         """
         Pass an outgoing message to the client.
 
@@ -241,7 +250,9 @@ class Protocol:
         :param message: The wire-level message to send to the client
         """
 
-    def send(self, message, cid=None, compression="none"):
+    def send(
+        self, message: dict[str, Any], cid: str | None = None, compression: str = "none"
+    ) -> None:
         """
         Prepare a message for sending to the client.
 
@@ -264,7 +275,7 @@ class Protocol:
 
             fragment_list = None
             if self.fragment_size is not None and len(serialized) > self.fragment_size:
-                mid = message.get("id", None)
+                mid = message.get("id")
 
                 # TODO: think about splitting into fragments that have specified size including header-fields!
                 # --> estimate header size --> split content into fragments that have the requested overall size,
@@ -288,7 +299,7 @@ class Protocol:
                 self.outgoing(serialized, compression)
                 time.sleep(self.delay_between_messages)
 
-    def finish(self):
+    def finish(self) -> None:
         """
         Indicate that the client is finished and clean up resources.
 
@@ -297,7 +308,11 @@ class Protocol:
         for capability in self.capabilities:
             capability.finish()
 
-    def serialize(self, msg, cid=None):  # noqa: ARG002
+    def serialize(
+        self,
+        msg: bytearray | bson.Binary | dict[str, Any],
+        cid: str | None = None,  # noqa: ARG002
+    ) -> bson.Binary | bytearray | str | None:
         """
         Turn a dictionary of values into the appropriate wire-level representation.
 
@@ -318,7 +333,7 @@ class Protocol:
             self.log("error", f"Unable to serialize message '{msg}': {e}")
             return None
 
-    def deserialize(self, msg, cid=None):  # noqa: ARG002
+    def deserialize(self, msg: str | bytes | bytearray, cid: str | None = None) -> dict[str, Any]:  # noqa: ARG002
         """
         Turn the wire-level representation into a dictionary of values.
 
@@ -354,7 +369,7 @@ class Protocol:
             raise
             # return None
 
-    def register_operation(self, opcode, handler):
+    def register_operation(self, opcode: str, handler: Callable[[dict[str, Any]], None]) -> None:
         """
         Register a handler for an opcode.
 
@@ -363,7 +378,7 @@ class Protocol:
         """
         self.operations[opcode] = handler
 
-    def unregister_operation(self, opcode):
+    def unregister_operation(self, opcode: str) -> None:
         """
         Unregister a handler for an opcode.
 
@@ -372,7 +387,7 @@ class Protocol:
         if opcode in self.operations:
             del self.operations[opcode]
 
-    def add_capability(self, capability_class):
+    def add_capability(self, capability_class: type[Capability]) -> None:
         """
         Add a capability to the protocol.
 
@@ -382,7 +397,7 @@ class Protocol:
         """
         self.capabilities.append(capability_class(self))
 
-    def log(self, level, message, lid=None):
+    def log(self, level: str, message: str, lid: str | None = None) -> None:
         """
         Log a message to the client.
 
@@ -390,7 +405,7 @@ class Protocol:
 
         :param level: The logger level of this message
         :param message: The string message to send to the user
-        :param lid: An associated for this log message
+        :param lid: An associated id for this log message
         """
         stdout_formatted_msg = None
         stdout_formatted_msg = (
@@ -402,7 +417,7 @@ class Protocol:
         if level in {"error", "err"}:
             self.node_handle.get_logger().error(stdout_formatted_msg)
         elif level in {"warning", "warn"}:
-            self.node_handle.get_logger().warn(stdout_formatted_msg)
+            self.node_handle.get_logger().warning(stdout_formatted_msg)
         elif level in {"info", "information"}:
             self.node_handle.get_logger().info(stdout_formatted_msg)
         else:

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -243,7 +243,7 @@ class Protocol:
             self.old_buffer = self.buffer
             self.incoming()
 
-    def outgoing(self, message: bson.Binary | bytearray | str, compression: str = "none") -> None:
+    def outgoing(self, message: bson.BSON | bytearray | str, compression: str = "none") -> None:
         """
         Pass an outgoing message to the client.
 
@@ -314,9 +314,9 @@ class Protocol:
 
     def serialize(
         self,
-        msg: bytearray | bson.Binary | dict[str, Any],
+        msg: bytearray | bson.BSON | dict[str, Any],
         cid: str | None = None,  # noqa: ARG002
-    ) -> bson.Binary | bytearray | str | None:
+    ) -> bson.BSON | bytearray | str | None:
         """
         Turn a dictionary of values into the appropriate wire-level representation.
 

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -251,7 +251,7 @@ class Protocol:
         """
 
     def send(
-        self, message: dict[str, Any], cid: str | None = None, compression: str = "none"
+        self, message: dict[str, Any] | bytes, cid: str | None = None, compression: str = "none"
     ) -> None:
         """
         Prepare a message for sending to the client.
@@ -275,7 +275,9 @@ class Protocol:
 
             fragment_list = None
             if self.fragment_size is not None and len(serialized) > self.fragment_size:
-                mid = message.get("id")
+                mid = None
+                if isinstance(message, dict) and "id" in message:
+                    mid = message["id"]
 
                 # TODO: think about splitting into fragments that have specified size including header-fields!
                 # --> estimate header size --> split content into fragments that have the requested overall size,

--- a/rosbridge_library/src/rosbridge_library/rosbridge_protocol.py
+++ b/rosbridge_library/src/rosbridge_library/rosbridge_protocol.py
@@ -30,6 +30,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from rosbridge_library.capabilities.action_feedback import ActionFeedback
 from rosbridge_library.capabilities.action_result import ActionResult
 from rosbridge_library.capabilities.advertise import Advertise
@@ -45,11 +49,16 @@ from rosbridge_library.capabilities.unadvertise_action import UnadvertiseAction
 from rosbridge_library.capabilities.unadvertise_service import UnadvertiseService
 from rosbridge_library.protocol import Protocol
 
+if TYPE_CHECKING:
+    from rclpy.node import Node
+
+    from rosbridge_library.capability import Capability
+
 
 class RosbridgeProtocol(Protocol):
     """Adds the handlers for the rosbridge opcodes."""
 
-    rosbridge_capabilities = (
+    rosbridge_capabilities: tuple[type[Capability], ...] = (
         Advertise,
         Publish,
         Subscribe,
@@ -71,7 +80,9 @@ class RosbridgeProtocol(Protocol):
 
     parameters = None
 
-    def __init__(self, client_id, node_handle, parameters=None):
+    def __init__(
+        self, client_id: str, node_handle: Node, parameters: dict[str, Any] | None = None
+    ) -> None:
         self.parameters = parameters
         Protocol.__init__(self, client_id, node_handle)
         for capability_class in self.rosbridge_capabilities:

--- a/rosbridge_library/src/rosbridge_library/util/__init__.py
+++ b/rosbridge_library/src/rosbridge_library/util/__init__.py
@@ -3,9 +3,9 @@ try:
     import ujson as json  # type: ignore[import-untyped]
 except ImportError:
     try:
-        import simplejson as json  # type: ignore[import-untyped]
+        import simplejson as json  # type: ignore[import-untyped, no-redef]
     except ImportError:
-        import json  # noqa: F401
+        import json  # type: ignore[no-redef] # noqa: F401
 
 import bson
 

--- a/rosbridge_library/src/rosbridge_library/util/cbor.py
+++ b/rosbridge_library/src/rosbridge_library/util/cbor.py
@@ -177,7 +177,7 @@ def dumps_tag(t, sort_keys=False):
 
 
 def _is_stringish(x):
-    return isinstance(x, (str, bytes))
+    return isinstance(x, str | bytes)
 
 
 def _is_intish(x):
@@ -191,7 +191,7 @@ def dumps(ob, sort_keys=False):
         return dumps_bool(ob)
     if _is_stringish(ob):
         return dumps_string(ob)
-    if isinstance(ob, (list, tuple)):
+    if isinstance(ob, list | tuple):
         return dumps_array(ob, sort_keys=sort_keys)
     # TODO: accept other enumerables and emit a variable length array
     if isinstance(ob, dict):

--- a/rosbridge_library/src/rosbridge_library/util/cbor.py
+++ b/rosbridge_library/src/rosbridge_library/util/cbor.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 import re
 import struct

--- a/rosbridge_library/src/rosbridge_library/util/cbor.py
+++ b/rosbridge_library/src/rosbridge_library/util/cbor.py
@@ -69,6 +69,9 @@ CBOR_TAG_CBOR_FILEHEADER = 55799  # can open a file with 0xd9d9f7
 _CBOR_TAG_BIGNUM_BYTES = struct.pack("B", CBOR_TAG | CBOR_TAG_BIGNUM)
 
 
+# ruff: noqa: ANN001, ANN201, ANN202, ANN204
+
+
 def dumps_int(val):
     """Return bytes representing int val in CBOR."""
     if val >= 0:

--- a/rosbridge_library/src/rosbridge_library/util/ros.py
+++ b/rosbridge_library/src/rosbridge_library/util/ros.py
@@ -30,8 +30,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from rclpy.node import Node
 
-def is_topic_published(node, topic_name):
+
+def is_topic_published(node: Node, topic_name: str) -> bool:
     """Check if a topic is published on a node."""
     published_topic_data = node.get_publisher_names_and_types_by_node(
         node.get_name(), node.get_namespace()
@@ -39,7 +41,7 @@ def is_topic_published(node, topic_name):
     return any(topic[0] == topic_name for topic in published_topic_data)
 
 
-def is_topic_subscribed(node, topic_name):
+def is_topic_subscribed(node: Node, topic_name: str) -> bool:
     """Check if a topic is subscribed to by a node."""
     subscribed_topic_data = node.get_subscriber_names_and_types_by_node(
         node.get_name(), node.get_namespace()

--- a/rosbridge_library/src/rosbridge_library/util/ros.py
+++ b/rosbridge_library/src/rosbridge_library/util/ros.py
@@ -30,7 +30,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from rclpy.node import Node
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
 
 
 def is_topic_published(node: Node, topic_name: str) -> bool:

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import time
 import unittest
 from json import dumps, loads
 from threading import Thread
+from typing import Any
 
 import rclpy
 from action_msgs.msg import GoalStatus
@@ -24,7 +27,7 @@ from rosbridge_library.protocol import Protocol
 
 
 class TestActionCapabilities(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = MultiThreadedExecutor()
         self.node = Node("test_action_capabilities")
@@ -44,35 +47,35 @@ class TestActionCapabilities(unittest.TestCase):
         self.result = ActionResult(self.proto)
         self.send_goal = SendActionGoal(self.proto)
         self.feedback = ActionFeedback(self.proto)
-        self.received_message = None
-        self.log_entries = []
+        self.received_message: dict[str, Any] | bytes | None = None
+        self.log_entries: list[tuple[str, str]] = []
 
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def local_send_cb(self, msg):
+    def local_send_cb(self, msg: dict[str, Any] | bytes) -> None:
         self.received_message = msg
 
-    def feedback_subscriber_cb(self, msg):
+    def feedback_subscriber_cb(self, msg: Fibonacci_FeedbackMessage) -> None:
         self.latest_feedback = msg
 
-    def mock_log(self, loglevel, message, _=None):
+    def mock_log(self, loglevel: str, message: str, _lid: str | None = None) -> None:
         self.log_entries.append((loglevel, message))
 
-    def test_advertise_missing_arguments(self):
+    def test_advertise_missing_arguments(self) -> None:
         advertise_msg = loads(dumps({"op": "advertise_action"}))
         self.assertRaises(MissingArgumentException, self.advertise.advertise_action, advertise_msg)
 
-    def test_advertise_invalid_arguments(self):
+    def test_advertise_invalid_arguments(self) -> None:
         advertise_msg = loads(dumps({"op": "advertise_action", "type": 42, "action": None}))
         self.assertRaises(InvalidArgumentException, self.advertise.advertise_action, advertise_msg)
 
-    def test_result_missing_arguments(self):
+    def test_result_missing_arguments(self) -> None:
         result_msg = loads(dumps({"op": "action_result"}))
         self.assertRaises(MissingArgumentException, self.result.action_result, result_msg)
 
@@ -81,11 +84,11 @@ class TestActionCapabilities(unittest.TestCase):
         result_msg = loads(dumps({"op": "action_result", "id": "dummy_action", "values": "none"}))
         self.assertRaises(MissingArgumentException, self.result.action_result, result_msg)
 
-    def test_result_invalid_arguments(self):
+    def test_result_invalid_arguments(self) -> None:
         result_msg = loads(dumps({"op": "action_result", "action": 5, "result": "error"}))
         self.assertRaises(InvalidArgumentException, self.result.action_result, result_msg)
 
-    def test_advertise_action(self):
+    def test_advertise_action(self) -> None:
         action_path = "/fibonacci_action_1"
         advertise_msg = loads(
             dumps(
@@ -98,7 +101,7 @@ class TestActionCapabilities(unittest.TestCase):
         )
         self.advertise.advertise_action(advertise_msg)
 
-    def test_execute_advertised_action(self):
+    def test_execute_advertised_action(self) -> None:
         # Advertise the action
         action_path = "/fibonacci_action_2"
         advertise_msg = loads(
@@ -207,7 +210,7 @@ class TestActionCapabilities(unittest.TestCase):
         self.assertEqual(self.received_message["values"]["sequence"], [0, 1, 1, 2, 3, 5])
         self.assertEqual(self.received_message["status"], GoalStatus.STATUS_SUCCEEDED)
 
-    def test_cancel_advertised_action(self):
+    def test_cancel_advertised_action(self) -> None:
         # Advertise the action
         action_path = "/fibonacci_action_3"
         advertise_msg = loads(
@@ -297,7 +300,7 @@ class TestActionCapabilities(unittest.TestCase):
         self.assertEqual(self.received_message["values"]["sequence"], [])
         self.assertEqual(self.received_message["status"], GoalStatus.STATUS_CANCELED)
 
-    def test_unadvertise_action(self):
+    def test_unadvertise_action(self) -> None:
         # Advertise the action
         action_path = "/fibonacci_action_4"
         advertise_msg = loads(

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import time

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -38,10 +38,10 @@ class TestActionCapabilities(unittest.TestCase):
 
         self.proto = Protocol(self._testMethodName, self.node)
         # change the log function so we can verify errors are logged
-        self.proto.log = self.mock_log
+        self.proto.log = self.mock_log  # type: ignore[method-assign]
         # change the send callback so we can access the rosbridge messages
         # being sent
-        self.proto.send = self.local_send_cb
+        self.proto.send = self.local_send_cb  # type: ignore[method-assign]
         self.advertise = AdvertiseAction(self.proto)
         self.unadvertise = UnadvertiseAction(self.proto)
         self.result = ActionResult(self.proto)
@@ -58,14 +58,19 @@ class TestActionCapabilities(unittest.TestCase):
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def local_send_cb(self, msg: dict[str, Any] | bytes) -> None:
-        self.received_message = msg
+    def local_send_cb(
+        self,
+        message: dict[str, Any] | bytes,
+        cid: str | None = None,  # noqa: ARG002
+        compression: str = "none",  # noqa: ARG002
+    ) -> None:
+        self.received_message = message
 
     def feedback_subscriber_cb(self, msg: Fibonacci_FeedbackMessage) -> None:
         self.latest_feedback = msg
 
-    def mock_log(self, loglevel: str, message: str, _lid: str | None = None) -> None:
-        self.log_entries.append((loglevel, message))
+    def mock_log(self, level: str, message: str, lid: str | None = None) -> None:  # noqa: ARG002
+        self.log_entries.append((level, message))
 
     def test_advertise_missing_arguments(self) -> None:
         advertise_msg = loads(dumps({"op": "advertise_action"}))

--- a/rosbridge_library/test/capabilities/test_advertise.py
+++ b/rosbridge_library/test/capabilities/test_advertise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import unittest
 from json import dumps, loads
@@ -172,3 +172,7 @@ class TestAdvertise(unittest.TestCase):
         self.assertTrue(is_topic_published(self.node, topic))
         time.sleep(manager.unregister_timeout + 1.0)
         self.assertFalse(is_topic_published(self.node, topic))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/capabilities/test_advertise.py
+++ b/rosbridge_library/test/capabilities/test_advertise.py
@@ -20,7 +20,7 @@ from rosbridge_library.util.ros import is_topic_published
 
 
 class TestAdvertise(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_advertise")
@@ -30,13 +30,13 @@ class TestAdvertise(unittest.TestCase):
 
         manager.unregister_timeout = 1.0
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def test_missing_arguments(self):
+    def test_missing_arguments(self) -> None:
         proto = Protocol("hello", self.node)
         adv = Advertise(proto)
         msg = {"op": "advertise"}
@@ -48,7 +48,7 @@ class TestAdvertise(unittest.TestCase):
         msg = {"op": "advertise", "type": "std_msgs/String"}
         self.assertRaises(MissingArgumentException, adv.advertise, loads(dumps(msg)))
 
-    def test_invalid_arguments(self):
+    def test_invalid_arguments(self) -> None:
         proto = Protocol("hello", self.node)
         adv = Advertise(proto)
 
@@ -58,7 +58,7 @@ class TestAdvertise(unittest.TestCase):
         msg = {"op": "advertise", "topic": "/jon", "type": 3}
         self.assertRaises(InvalidArgumentException, adv.advertise, loads(dumps(msg)))
 
-    def test_invalid_msg_typestrings(self):
+    def test_invalid_msg_typestrings(self) -> None:
         invalid = [
             "",
             "/",
@@ -91,7 +91,7 @@ class TestAdvertise(unittest.TestCase):
                 ros_loader.InvalidTypeStringException, adv.advertise, loads(dumps(msg))
             )
 
-    def test_invalid_msg_package(self):
+    def test_invalid_msg_package(self) -> None:
         nonexistent = [
             "roslib/Time",
             "roslib/Duration",
@@ -116,7 +116,7 @@ class TestAdvertise(unittest.TestCase):
             }
             self.assertRaises(ros_loader.InvalidModuleException, adv.advertise, loads(dumps(msg)))
 
-    def test_invalid_msg_classes(self):
+    def test_invalid_msg_classes(self) -> None:
         nonexistent = [
             "builtin_interfaces/SpaceTime",
             "std_msgs/Spool",
@@ -135,7 +135,7 @@ class TestAdvertise(unittest.TestCase):
             }
             self.assertRaises(ros_loader.InvalidClassException, adv.advertise, loads(dumps(msg)))
 
-    def test_valid_msg_classes(self):
+    def test_valid_msg_classes(self) -> None:
         assortedmsgs = [
             "geometry_msgs/Pose",
             "action_msgs/GoalStatus",
@@ -159,7 +159,7 @@ class TestAdvertise(unittest.TestCase):
             adv.advertise(loads(dumps(msg)))
             adv.unadvertise(loads(dumps(msg)))
 
-    def test_do_advertise(self):
+    def test_do_advertise(self) -> None:
         proto = Protocol("hello", self.node)
         adv = Advertise(proto)
         topic = "/test_do_advertise"

--- a/rosbridge_library/test/capabilities/test_advertise.py
+++ b/rosbridge_library/test/capabilities/test_advertise.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from json import dumps, loads

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import time
@@ -257,3 +257,7 @@ class TestCallService(unittest.TestCase):
         self.assertFalse(received["msg"]["result"])
         values = received["msg"]["values"]
         self.assertEqual(values, "Timeout exceeded while waiting for service response")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import time
 import unittest
 from json import dumps, loads
 from threading import Thread
+from typing import TYPE_CHECKING, Any
 
 import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
@@ -17,22 +20,28 @@ from rosbridge_library.internal.exceptions import (
 )
 from rosbridge_library.protocol import Protocol
 
+if TYPE_CHECKING:
+    from rclpy.client import Client
+    from rclpy.service import Service
+
 
 class TestCallService(unittest.TestCase):
-    def trigger_cb(self, _request, response):
+    def trigger_cb(self, _request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """Handle request for a test service with no arguments."""
         response.success = True
         response.message = "called trigger service successfully"
         return response
 
-    def trigger_long_cb(self, _request, response):
+    def trigger_long_cb(
+        self, _request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
         """Handle request for a long running test service with no arguments."""
         time.sleep(0.5)
         response.success = True
         response.message = "called trigger service successfully"
         return response
 
-    def set_bool_cb(self, request, response):
+    def set_bool_cb(self, request: SetBool.Request, response: SetBool.Response) -> SetBool.Response:
         """Handle request for a test service with arguments."""
         response.success = request.data
         if request.data:
@@ -41,7 +50,7 @@ class TestCallService(unittest.TestCase):
             response.message = "set bool to false"
         return response
 
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_call_service")
@@ -53,20 +62,22 @@ class TestCallService(unittest.TestCase):
 
         # Create service servers with a separate callback group
         self.cb_group = ReentrantCallbackGroup()
-        self.trigger_srv = self.node.create_service(
-            Trigger,
+        self.trigger_srv: Service[Trigger.Request, Trigger.Response] = self.node.create_service(
+            Trigger,  # type: ignore[arg-type]
             self.node.get_name() + "/trigger",
             self.trigger_cb,
             callback_group=self.cb_group,
         )
-        self.trigger_long_srv = self.node.create_service(
-            Trigger,
-            self.node.get_name() + "/trigger_long",
-            self.trigger_long_cb,
-            callback_group=self.cb_group,
+        self.trigger_long_srv: Service[Trigger.Request, Trigger.Response] = (
+            self.node.create_service(
+                Trigger,  # type: ignore[arg-type]
+                self.node.get_name() + "/trigger_long",
+                self.trigger_long_cb,
+                callback_group=self.cb_group,
+            )
         )
-        self.set_bool_srv = self.node.create_service(
-            SetBool,
+        self.set_bool_srv: Service[SetBool.Request, SetBool.Response] = self.node.create_service(
+            SetBool,  # type: ignore[arg-type]
             self.node.get_name() + "/set_bool",
             self.set_bool_cb,
             callback_group=self.cb_group,
@@ -75,37 +86,44 @@ class TestCallService(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.executor.shutdown()
         self.exec_thread.join()
         self.node.destroy_node()
         rclpy.shutdown()
 
-    def test_missing_arguments(self):
+    def test_missing_arguments(self) -> None:
         proto = Protocol("test_missing_arguments", self.node)
         s = CallService(proto)
         msg = loads(dumps({"op": "call_service"}))
         self.assertRaises(MissingArgumentException, s.call_service, msg)
 
-    def test_invalid_arguments(self):
+    def test_invalid_arguments(self) -> None:
         proto = Protocol("test_invalid_arguments", self.node)
         s = CallService(proto)
 
         msg = loads(dumps({"op": "call_service", "service": 3}))
         self.assertRaises(InvalidArgumentException, s.call_service, msg)
 
-    def test_call_service_works(self):
-        client = self.node.create_client(Trigger, self.trigger_srv.srv_name)
+    def test_call_service_works(self) -> None:
+        client: Client[Trigger.Request, Trigger.Response] = self.node.create_client(
+            Trigger,  # type: ignore[arg-type]
+            self.trigger_srv.srv_name,
+        )
         assert client.wait_for_service(1.0)
 
         proto = Protocol("test_call_service_works", self.node)
         s = CallService(proto)
         send_msg = loads(dumps({"op": "call_service", "service": self.trigger_srv.srv_name}))
 
-        received = {"msg": None, "arrived": False}
+        received: dict[str, Any] = {"msg": None, "arrived": False}
 
-        def cb(msg, cid=None, compression="none"):  # noqa: ARG001
+        def cb(
+            msg: dict[str, Any] | bytes,
+            cid: str | None = None,  # noqa: ARG001
+            compression: str = "none",  # noqa: ARG001
+        ) -> None:
             print(msg)
             received["msg"] = msg
             received["arrived"] = True
@@ -119,8 +137,11 @@ class TestCallService(unittest.TestCase):
         self.assertEqual(values["success"], True)
         self.assertEqual(values["message"], "called trigger service successfully")
 
-    def test_call_service_args(self):
-        client = self.node.create_client(SetBool, self.set_bool_srv.srv_name)
+    def test_call_service_args(self) -> None:
+        client: Client[SetBool.Request, SetBool.Response] = self.node.create_client(
+            SetBool,  # type: ignore[arg-type]
+            self.set_bool_srv.srv_name,
+        )
         assert client.wait_for_service(1.0)
 
         proto = Protocol("test_call_service_args", self.node)
@@ -135,9 +156,13 @@ class TestCallService(unittest.TestCase):
             )
         )
 
-        received = {"msg": None, "arrived": False}
+        received: dict[str, Any] = {"msg": None, "arrived": False}
 
-        def cb(msg, cid=None, compression="none"):  # noqa: ARG001
+        def cb(
+            msg: dict[str, Any] | bytes,
+            cid: str | None = None,  # noqa: ARG001
+            compression: str = "none",  # noqa: ARG001
+        ) -> None:
             received["msg"] = msg
             received["arrived"] = True
 
@@ -150,8 +175,11 @@ class TestCallService(unittest.TestCase):
         self.assertEqual(values["success"], True)
         self.assertEqual(values["message"], "set bool to true")
 
-    def test_call_service_fails(self):
-        client = self.node.create_client(Trigger, self.trigger_srv.srv_name)
+    def test_call_service_fails(self) -> None:
+        client: Client[Trigger.Request, Trigger.Response] = self.node.create_client(
+            Trigger,  # type: ignore[arg-type]
+            self.trigger_srv.srv_name,
+        )
         assert client.wait_for_service(1.0)
 
         proto = Protocol("test_call_service_works", self.node)
@@ -166,9 +194,13 @@ class TestCallService(unittest.TestCase):
             )
         )
 
-        received = {"msg": None, "arrived": False}
+        received: dict[str, Any] = {"msg": None, "arrived": False}
 
-        def cb(msg, cid=None, compression="none"):  # noqa: ARG001
+        def cb(
+            msg: dict[str, Any] | bytes,
+            cid: str | None = None,  # noqa: ARG001
+            compression: str = "none",  # noqa: ARG001
+        ) -> None:
             print(msg)
             received["msg"] = msg
             received["arrived"] = True
@@ -180,8 +212,11 @@ class TestCallService(unittest.TestCase):
         self.assertTrue(received["arrived"])
         self.assertFalse(received["msg"]["result"])
 
-    def test_call_service_timeout(self):
-        client = self.node.create_client(Trigger, self.trigger_long_srv.srv_name)
+    def test_call_service_timeout(self) -> None:
+        client: Client[Trigger.Request, Trigger.Response] = self.node.create_client(
+            Trigger,  # type: ignore[arg-type]
+            self.trigger_long_srv.srv_name,
+        )
         assert client.wait_for_service(1.0)
 
         proto = Protocol("test_call_service_timeout", self.node)
@@ -190,9 +225,13 @@ class TestCallService(unittest.TestCase):
             dumps({"op": "call_service", "service": self.trigger_long_srv.srv_name, "timeout": 2.0})
         )
 
-        received = {"msg": None, "arrived": False}
+        received: dict[str, Any] = {"msg": None, "arrived": False}
 
-        def cb(msg, cid=None, compression="none"):  # noqa: ARG001
+        def cb(
+            msg: dict[str, Any] | bytes,
+            cid: str | None = None,  # noqa: ARG001
+            compression: str = "none",  # noqa: ARG001
+        ) -> None:
             print("Received message")
             received["msg"] = msg
             received["arrived"] = True

--- a/rosbridge_library/test/capabilities/test_call_service.py
+++ b/rosbridge_library/test/capabilities/test_call_service.py
@@ -120,15 +120,15 @@ class TestCallService(unittest.TestCase):
         received: dict[str, Any] = {"msg": None, "arrived": False}
 
         def cb(
-            msg: dict[str, Any] | bytes,
+            message: dict[str, Any] | bytes,
             cid: str | None = None,  # noqa: ARG001
             compression: str = "none",  # noqa: ARG001
         ) -> None:
-            print(msg)
-            received["msg"] = msg
+            print(message)
+            received["msg"] = message
             received["arrived"] = True
 
-        proto.send = cb
+        proto.send = cb  # type: ignore[method-assign]
 
         s.call_service(send_msg)
 
@@ -159,14 +159,14 @@ class TestCallService(unittest.TestCase):
         received: dict[str, Any] = {"msg": None, "arrived": False}
 
         def cb(
-            msg: dict[str, Any] | bytes,
+            message: dict[str, Any] | bytes,
             cid: str | None = None,  # noqa: ARG001
             compression: str = "none",  # noqa: ARG001
         ) -> None:
-            received["msg"] = msg
+            received["msg"] = message
             received["arrived"] = True
 
-        proto.send = cb
+        proto.send = cb  # type: ignore[method-assign]
 
         s.call_service(send_msg)
 
@@ -197,15 +197,15 @@ class TestCallService(unittest.TestCase):
         received: dict[str, Any] = {"msg": None, "arrived": False}
 
         def cb(
-            msg: dict[str, Any] | bytes,
+            message: dict[str, Any] | bytes,
             cid: str | None = None,  # noqa: ARG001
             compression: str = "none",  # noqa: ARG001
         ) -> None:
-            print(msg)
-            received["msg"] = msg
+            print(message)
+            received["msg"] = message
             received["arrived"] = True
 
-        proto.send = cb
+        proto.send = cb  # type: ignore[method-assign]
 
         s.call_service(send_msg)
 
@@ -228,15 +228,15 @@ class TestCallService(unittest.TestCase):
         received: dict[str, Any] = {"msg": None, "arrived": False}
 
         def cb(
-            msg: dict[str, Any] | bytes,
+            message: dict[str, Any] | bytes,
             cid: str | None = None,  # noqa: ARG001
             compression: str = "none",  # noqa: ARG001
         ) -> None:
             print("Received message")
-            received["msg"] = msg
+            received["msg"] = message
             received["arrived"] = True
 
-        proto.send = cb
+        proto.send = cb  # type: ignore[method-assign]
 
         s.call_service(send_msg)
 

--- a/rosbridge_library/test/capabilities/test_publish.py
+++ b/rosbridge_library/test/capabilities/test_publish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import time
@@ -74,3 +74,7 @@ class TestAdvertise(unittest.TestCase):
         pub.publish(pub_msg)
         time.sleep(0.5)
         self.assertEqual(received["msg"].data, msg["data"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/capabilities/test_publish.py
+++ b/rosbridge_library/test/capabilities/test_publish.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import time
 import unittest
 from json import dumps, loads
 from threading import Thread
+from typing import Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -19,7 +22,7 @@ from rosbridge_library.protocol import Protocol
 
 
 class TestAdvertise(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_publish")
@@ -28,37 +31,37 @@ class TestAdvertise(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def test_missing_arguments(self):
+    def test_missing_arguments(self) -> None:
         proto = Protocol("hello", self.node)
         pub = Publish(proto)
-        msg = {"op": "publish"}
+        msg: dict[str, Any] = {"op": "publish"}
         self.assertRaises(MissingArgumentException, pub.publish, msg)
 
         msg = {"op": "publish", "msg": {}}
         self.assertRaises(MissingArgumentException, pub.publish, msg)
 
-    def test_invalid_arguments(self):
+    def test_invalid_arguments(self) -> None:
         proto = Protocol("hello", self.node)
         pub = Publish(proto)
 
         msg = {"op": "publish", "topic": 3}
         self.assertRaises(InvalidArgumentException, pub.publish, msg)
 
-    def test_publish_works(self):
+    def test_publish_works(self) -> None:
         proto = Protocol("hello", self.node)
         pub = Publish(proto)
         topic = "/test_publish_works"
         msg = {"data": "test publish works"}
 
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: String) -> None:
             received["msg"] = msg
 
         subscriber_qos = QoSProfile(

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -32,10 +32,10 @@ class TestServiceCapabilities(unittest.TestCase):
 
         self.proto = Protocol(self._testMethodName, self.node)
         # change the log function so we can verify errors are logged
-        self.proto.log = self.mock_log
+        self.proto.log = self.mock_log  # type: ignore[method-assign]
         # change the send callback so we can access the rosbridge messages
         # being sent
-        self.proto.send = self.local_send_cb
+        self.proto.send = self.local_send_cb  # type: ignore[method-assign]
         self.advertise = AdvertiseService(self.proto)
         self.unadvertise = UnadvertiseService(self.proto)
         self.response = ServiceResponse(self.proto)
@@ -47,11 +47,16 @@ class TestServiceCapabilities(unittest.TestCase):
         self.node.destroy_node()
         rclpy.shutdown()
 
-    def local_send_cb(self, msg: dict[str, Any] | bytes) -> None:
-        self.received_message = msg
+    def local_send_cb(
+        self,
+        message: dict[str, Any] | bytes,
+        cid: str | None = None,  # noqa: ARG002
+        compression: str = "none",  # noqa: ARG002
+    ) -> None:
+        self.received_message = message
 
-    def mock_log(self, loglevel: str, message: str, _lid: str | None = None) -> None:
-        self.log_entries.append((loglevel, message))
+    def mock_log(self, level: str, message: str, lid: str | None = None) -> None:  # noqa: ARG002
+        self.log_entries.append((level, message))
 
     def test_advertise_missing_arguments(self) -> None:
         advertise_msg = loads(dumps({"op": "advertise_service"}))

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import time

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import time
 import unittest
 from json import dumps, loads
 from threading import Thread
+from typing import Any
 
 import rclpy
 from rclpy.node import Node
@@ -19,7 +22,7 @@ from rosbridge_library.protocol import Protocol
 
 
 class TestServiceCapabilities(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.node = Node("test_service_capabilities")
 
@@ -37,28 +40,28 @@ class TestServiceCapabilities(unittest.TestCase):
         self.unadvertise = UnadvertiseService(self.proto)
         self.response = ServiceResponse(self.proto)
         self.call_service = CallService(self.proto)
-        self.received_message = None
-        self.log_entries = []
+        self.received_message: dict[str, Any] | bytes | None = None
+        self.log_entries: list[tuple[str, str]] = []
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.node.destroy_node()
         rclpy.shutdown()
 
-    def local_send_cb(self, msg):
+    def local_send_cb(self, msg: dict[str, Any] | bytes) -> None:
         self.received_message = msg
 
-    def mock_log(self, loglevel, message, _=None):
+    def mock_log(self, loglevel: str, message: str, _lid: str | None = None) -> None:
         self.log_entries.append((loglevel, message))
 
-    def test_advertise_missing_arguments(self):
+    def test_advertise_missing_arguments(self) -> None:
         advertise_msg = loads(dumps({"op": "advertise_service"}))
         self.assertRaises(MissingArgumentException, self.advertise.advertise_service, advertise_msg)
 
-    def test_advertise_invalid_arguments(self):
+    def test_advertise_invalid_arguments(self) -> None:
         advertise_msg = loads(dumps({"op": "advertise_service", "type": 42, "service": None}))
         self.assertRaises(InvalidArgumentException, self.advertise.advertise_service, advertise_msg)
 
-    def test_response_missing_arguments(self):
+    def test_response_missing_arguments(self) -> None:
         response_msg = loads(dumps({"op": "service_response"}))
         self.assertRaises(MissingArgumentException, self.response.service_response, response_msg)
 
@@ -69,11 +72,11 @@ class TestServiceCapabilities(unittest.TestCase):
         )
         self.assertRaises(MissingArgumentException, self.response.service_response, response_msg)
 
-    def test_response_invalid_arguments(self):
+    def test_response_invalid_arguments(self) -> None:
         response_msg = loads(dumps({"op": "service_response", "service": 5, "result": "error"}))
         self.assertRaises(InvalidArgumentException, self.response.service_response, response_msg)
 
-    def test_advertise_service(self):
+    def test_advertise_service(self) -> None:
         service_path = "/set_bool_1"
         advertise_msg = loads(
             dumps(
@@ -86,7 +89,7 @@ class TestServiceCapabilities(unittest.TestCase):
         )
         self.advertise.advertise_service(advertise_msg)
 
-    def test_call_advertised_service(self):
+    def test_call_advertised_service(self) -> None:
         # Advertise the service
         service_path = "/set_bool_2"
         advertise_msg = loads(
@@ -151,7 +154,7 @@ class TestServiceCapabilities(unittest.TestCase):
         self.assertEqual(self.received_message["op"], "service_response")
         self.assertTrue(self.received_message["result"])
 
-    def test_call_advertised_service_with_timeout(self):
+    def test_call_advertised_service_with_timeout(self) -> None:
         # Advertise the service
         service_path = "/set_bool_3"
         advertise_msg = loads(
@@ -207,7 +210,7 @@ class TestServiceCapabilities(unittest.TestCase):
             self.received_message["values"], "Timeout exceeded while waiting for service response"
         )
 
-    def test_unadvertise_with_live_request(self):
+    def test_unadvertise_with_live_request(self) -> None:
         # Advertise the service
         service_path = "/set_bool_3"
         advertise_msg = loads(

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -48,7 +48,9 @@ class TestSubscribe(unittest.TestCase):
         topic = "/test_update_params"
         msg_type = "std_msgs/String"
 
-        subscription = subscribe.Subscription(client_id, topic, None, self.node)
+        subscription: subscribe.Subscription[String] = subscribe.Subscription(
+            client_id, topic, None, self.node
+        )
 
         min_throttle_rate = 5
         min_queue_length = 2
@@ -58,7 +60,9 @@ class TestSubscribe(unittest.TestCase):
             for queue_length in range(min_queue_length, min_queue_length + 10):
                 for frag_size in range(min_frag_size, min_frag_size + 10):
                     sid = throttle_rate * 100 + queue_length * 10 + frag_size
-                    subscription.subscribe(sid, msg_type, throttle_rate, queue_length, frag_size)
+                    subscription.subscribe(
+                        str(sid), msg_type, throttle_rate, queue_length, frag_size
+                    )
 
         subscription.update_params()
 
@@ -118,13 +122,13 @@ class TestSubscribe(unittest.TestCase):
         received: dict[str, Any] = {"msg": None}
 
         def send(
-            outgoing: dict[str, Any] | bytes,
+            message: dict[str, Any] | bytes,
             cid: str | None = None,  # noqa: ARG001
             compression: str = "none",  # noqa: ARG001
         ) -> None:
-            received["msg"] = outgoing
+            received["msg"] = message
 
-        proto.send = send
+        proto.send = send  # type: ignore[method-assign]
 
         sub.subscribe(loads(dumps({"op": "subscribe", "topic": topic, "type": msg_type})))
 

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import time
 import unittest
 from json import dumps, loads
 from threading import Thread
+from typing import Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -19,7 +22,7 @@ from rosbridge_library.protocol import Protocol
 
 
 class TestSubscribe(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_subscribe")
@@ -28,16 +31,13 @@ class TestSubscribe(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def dummy_cb(self, msg):
-        pass
-
-    def test_update_params(self):
+    def test_update_params(self) -> None:
         """
         Test the update_params method of the Subscription class.
 
@@ -79,13 +79,13 @@ class TestSubscribe(unittest.TestCase):
         finally:
             subscription.unregister()
 
-    def test_missing_arguments(self):
+    def test_missing_arguments(self) -> None:
         proto = Protocol("test_missing_arguments", self.node)
         sub = subscribe.Subscribe(proto)
         msg = {"op": "subscribe"}
         self.assertRaises(MissingArgumentException, sub.subscribe, msg)
 
-    def test_invalid_arguments(self):
+    def test_invalid_arguments(self) -> None:
         proto = Protocol("test_invalid_arguments", self.node)
         sub = subscribe.Subscribe(proto)
 
@@ -107,7 +107,7 @@ class TestSubscribe(unittest.TestCase):
         msg = {"op": "subscribe", "topic": "/jon", "compression": 9000}
         self.assertRaises(InvalidArgumentException, sub.subscribe, msg)
 
-    def test_subscribe_works(self):
+    def test_subscribe_works(self) -> None:
         proto = Protocol("test_subscribe_works", self.node)
         sub = subscribe.Subscribe(proto)
         topic = "/test_subscribe_works"
@@ -115,9 +115,13 @@ class TestSubscribe(unittest.TestCase):
         msg.data = "test test_subscribe_works works"
         msg_type = "std_msgs/String"
 
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def send(outgoing, cid=None, compression="none"):  # noqa: ARG001
+        def send(
+            outgoing: dict[str, Any] | bytes,
+            cid: str | None = None,  # noqa: ARG001
+            compression: str = "none",  # noqa: ARG001
+        ) -> None:
             received["msg"] = outgoing
 
         proto.send = send

--- a/rosbridge_library/test/capabilities/test_subscribe.py
+++ b/rosbridge_library/test/capabilities/test_subscribe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import time
@@ -140,3 +140,7 @@ class TestSubscribe(unittest.TestCase):
         pub.publish(msg)
         time.sleep(0.1)
         self.assertEqual(received["msg"]["msg"]["data"], msg.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import socket
 
 from rosbridge_library.util import json

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
@@ -3,6 +3,8 @@ import socket
 
 from rosbridge_library.util import json
 
+# ruff: noqa: ANN201
+
 # ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
 # ##############################################################################

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_client_complex-srv.py
@@ -130,9 +130,9 @@ try:
             # print(e)
             pass
 
-    returned_data = json.loads(
-        reconstructed
-    )  # when service response is received --> access it (as defined in srv-file)
+    # when service response is received --> access it (as defined in srv-file)
+    assert reconstructed is not None
+    returned_data = json.loads(reconstructed)
     if returned_data["values"] is None:
         print("response was None -> service was not available")
     else:

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import socket
 import sys
 import time

--- a/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
+++ b/rosbridge_library/test/experimental/complex_srv+tcp/test_non-ros_service_server_complex-srv.py
@@ -6,6 +6,8 @@ from random import randint
 
 from rosbridge_library.util import json
 
+# ruff: noqa: ANN001, ANN201
+
 # ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
 # ##############################################################################
@@ -83,7 +85,7 @@ def connect_tcp_socket():
     return tcp_sock
 
 
-def advertise_service():  # advertise service
+def advertise_service() -> None:  # advertise service
     advertise_message_object = {
         "op": "advertise_service",
         "type": service_type,
@@ -95,7 +97,7 @@ def advertise_service():  # advertise service
     tcp_socket.send(str(advertise_message))
 
 
-def unadvertise_service():  # unadvertise service
+def unadvertise_service() -> None:  # unadvertise service
     unadvertise_message_object = {"op": "unadvertise_service", "service": service_name}
     unadvertise_message = json.dumps(unadvertise_message_object)
     tcp_socket.send(str(unadvertise_message))
@@ -172,7 +174,7 @@ def wait_for_service_request():  # receive data from rosbridge
     return data
 
 
-def send_service_response(response):  # send response to rosbridge
+def send_service_response(response) -> None:  # send response to rosbridge
     tcp_socket.send(response)
 
 

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
@@ -26,7 +26,7 @@ receive_message_intervall = 0.0
 # ##############################################################################
 
 
-def request_service():
+def request_service() -> None:
     service_request_object = {
         "op": "call_service",  # op-code for rosbridge
         "service": "/" + service_name,  # select service

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import socket
 from typing import Any
 

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_client_fragmented.py
@@ -40,7 +40,7 @@ def request_service() -> None:
     }
     service_request = json.dumps(service_request_object)
     print("sending JSON-message to rosbridge:", service_request)
-    sock.send(service_request)
+    sock.send(service_request.encode("utf-8"))
 
 
 # ##############################################################################
@@ -126,9 +126,9 @@ try:
             #            print(e)
             pass
 
-    returned_data = json.loads(
-        reconstructed
-    )  # when service response is received --> access it (as defined in srv-file)
+    # when service response is received --> access it (as defined in srv-file)
+    assert reconstructed is not None
+    returned_data = json.loads(reconstructed)
     if returned_data["values"] is None:
         print("response was None -> service was not available")
     else:

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_server_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_server_fragmented.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import socket
 import sys
 import time

--- a/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_server_fragmented.py
+++ b/rosbridge_library/test/experimental/fragmentation+srv+tcp/test_non-ros_service_server_fragmented.py
@@ -6,6 +6,8 @@ from random import randint
 
 from rosbridge_library.util import json
 
+# ruff: noqa: ANN001, ANN201
+
 # ##################### variables begin ########################################
 # these parameters should be changed to match the actual environment           #
 # ##############################################################################
@@ -84,7 +86,7 @@ def connect_tcp_socket():
     return tcp_sock
 
 
-def advertise_service():  # advertise service
+def advertise_service() -> None:  # advertise service
     advertise_message_object = {
         "op": "advertise_service",
         "type": service_type,
@@ -96,7 +98,7 @@ def advertise_service():  # advertise service
     tcp_socket.send(str(advertise_message))
 
 
-def unadvertise_service():  # unadvertise service
+def unadvertise_service() -> None:  # unadvertise service
     unadvertise_message_object = {"op": "unadvertise_service", "service": service_name}
     unadvertise_message = json.dumps(unadvertise_message_object)
     tcp_socket.send(str(unadvertise_message))
@@ -173,7 +175,7 @@ def wait_for_service_request():  # receive data from rosbridge
     return data
 
 
-def send_service_response(response):  # send response to rosbridge
+def send_service_response(response) -> None:  # send response to rosbridge
     tcp_socket.send(response)
 
 

--- a/rosbridge_library/test/internal/actions/test_actions.py
+++ b/rosbridge_library/test/internal/actions/test_actions.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from threading import Thread
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import numpy as np
 import rclpy
@@ -14,44 +17,41 @@ from rosbridge_library.internal import actions, ros_loader
 from rosbridge_library.internal import message_conversion as c
 from rosbridge_library.internal.message_conversion import FieldTypeMismatchException
 
+if TYPE_CHECKING:
+    from rclpy.action.client import ClientGoalHandle
+    from rclpy.action.server import ServerGoalHandle
+    from rclpy.executors import Executor
+    from rclpy.task import Future
+    from rclpy.type_support import GetResultServiceResponse
+
 
 class ActionTester:
-    def __init__(self, executor):
+    def __init__(self, executor: Executor) -> None:
         self.executor = executor
         self.node = Node("action_tester")
         self.executor.add_node(self.node)
-        self.action_server = ActionServer(
-            self.node,
-            Fibonacci,
-            "get_fibonacci_sequence",
-            self.execute_callback,
+        self.action_server: ActionServer[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback] = (
+            ActionServer(
+                self.node,
+                Fibonacci,  # type: ignore[arg-type]
+                "get_fibonacci_sequence",
+                self.execute_callback,
+            )
         )
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.executor.remove_node(self.node)
 
-    def start(self):
-        req = self.action_class.Goal()
-        gen = c.extract_values(req)
-        thread = actions.ActionClientHandler(
-            self.name,
-            self.name,
-            gen,
-            self.success,
-            self.error,
-            self.node,
-        )
-        thread.start()
-        thread.join()
-
-    def execute_callback(self, goal):
+    def execute_callback(
+        self, goal: ServerGoalHandle[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback]
+    ) -> Fibonacci.Result:
         self.goal = goal
         feedback_msg = Fibonacci.Feedback()
         feedback_msg.sequence = [0, 1]
 
         for i in range(1, goal.request.order):
             feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i - 1])
-            goal.publish_feedback(feedback_msg)
+            goal.publish_feedback(feedback_msg)  # type: ignore[arg-type] # rclpy type hint is incorrect
             time.sleep(0.1)
 
         goal.succeed()
@@ -59,22 +59,15 @@ class ActionTester:
         result.sequence = feedback_msg.sequence
         return result
 
-    def success(self, rsp):
+    def success(self, rsp: dict[str, Any]) -> None:
         self.rsp = rsp
 
-    def error(self, exc):
+    def error(self, exc: Exception) -> None:
         self.exc = exc
-
-    def validate(self, equality_function):
-        if hasattr(self, "exc"):
-            print(self.exc)
-            raise self.exc
-        equality_function(self.input, c.extract_values(self.req))
-        equality_function(self.output, self.rsp)
 
 
 class TestActions(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_node")
@@ -83,17 +76,18 @@ class TestActions(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def msgs_equal(self, msg1, msg2):
+    def msgs_equal(self, msg1: object, msg2: object) -> None:
         if isinstance(msg1, str) and isinstance(msg2, str):
             pass
         else:
             self.assertEqual(type(msg1), type(msg2))
         if type(msg1) in c.list_types:
+            assert isinstance(msg1, c.list_types) and isinstance(msg2, c.list_types)
             for x, y in zip(msg1, msg2):
                 self.msgs_equal(x, y)
         elif (
@@ -103,6 +97,7 @@ class TestActions(unittest.TestCase):
         ):
             self.assertEqual(msg1, msg2)
         else:
+            assert isinstance(msg1, dict) and isinstance(msg2, dict)
             for x in msg1:
                 self.assertTrue(x in msg2)
             for x in msg2:
@@ -110,10 +105,11 @@ class TestActions(unittest.TestCase):
             for x in msg1:
                 self.msgs_equal(msg1[x], msg2[x])
 
-    def test_populate_goal_args(self):
+    def test_populate_goal_args(self) -> None:
         # Test empty messages
         for action_type in ["TestEmpty", "TestFeedbackAndResult", "TestResultOnly"]:
             cls = ros_loader.get_action_class("rosbridge_test_msgs/" + action_type)
+            args: Any
             for args in [[], {}, None]:
                 # Should throw no exceptions
                 actions.args_to_action_goal_instance(cls.Goal(), args)
@@ -140,23 +136,30 @@ class TestActions(unittest.TestCase):
             # Should throw no exceptions
             actions.args_to_action_goal_instance(cls.Goal(), args)
 
-    def test_send_action_goal(self):
+    def test_send_action_goal(self) -> None:
         """Test a simple action call."""
         ActionTester(self.executor)
-        self.result = None
+        received: dict[str, Any] = {"msg": None}
 
-        def get_response_callback(future):
+        def get_response_callback(future: Future[ClientGoalHandle]) -> None:
             goal_handle = future.result()
+            assert goal_handle is not None
             if not goal_handle.accepted:
                 return
-            result_future = future.result().get_result_async()
+            result_future = goal_handle.get_result_async()
             result_future.add_done_callback(get_result_callback)
 
-        def get_result_callback(future):
-            self.result = future.result().result
+        def get_result_callback(future: Future[GetResultServiceResponse[Fibonacci.Result]]) -> None:
+            response = future.result()
+            assert response is not None
+            received["msg"] = response.result
 
         # First, call the action the 'proper' way
-        client = ActionClient(self.node, Fibonacci, "get_fibonacci_sequence")
+        client: ActionClient[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback] = ActionClient(
+            self.node,
+            Fibonacci,  # type: ignore[arg-type]
+            "get_fibonacci_sequence",
+        )
         client.wait_for_server()
         goal = Fibonacci.Goal()
         goal.order = 5
@@ -166,8 +169,8 @@ class TestActions(unittest.TestCase):
             time.sleep(0.1)
         client.destroy()
 
-        self.assertIsNotNone(self.result)
-        self.assertEqual(list(self.result.sequence), [0, 1, 1, 2, 3, 5])
+        self.assertIsNotNone(received["msg"])
+        self.assertEqual(list(received["msg"].sequence), [0, 1, 1, 2, 3, 5])
 
         # Now, call using the services
         json_ret = actions.SendGoal().send_goal(
@@ -178,17 +181,17 @@ class TestActions(unittest.TestCase):
         )
         self.assertEqual(list(json_ret["result"]["sequence"]), [0, 1, 1, 2, 3, 5])
 
-    def test_action_client_handler(self):
+    def test_action_client_handler(self) -> None:
         """Test service_call via the thread caller."""
         ActionTester(self.executor)
 
-        received = {"json": None}
+        received: dict[str, Any] = {"json": None}
 
-        def success(json):
+        def success(json: dict[str, Any]) -> None:
             received["json"] = json
 
-        def error():
-            raise Exception
+        def error(exc: Exception) -> NoReturn:
+            raise exc
 
         # Now, call using the services
         order = 5

--- a/rosbridge_library/test/internal/actions/test_actions.py
+++ b/rosbridge_library/test/internal/actions/test_actions.py
@@ -88,7 +88,7 @@ class TestActions(unittest.TestCase):
             self.assertEqual(type(msg1), type(msg2))
         if type(msg1) in c.list_types:
             assert isinstance(msg1, c.list_types) and isinstance(msg2, c.list_types)
-            for x, y in zip(msg1, msg2):
+            for x, y in zip(msg1, msg2, strict=False):
                 self.msgs_equal(x, y)
         elif (
             type(msg1) in c.primitive_types

--- a/rosbridge_library/test/internal/publishers/test_multi_publisher.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_publisher.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from threading import Thread
@@ -13,11 +15,12 @@ from rosbridge_library.internal import ros_loader
 from rosbridge_library.internal.message_conversion import FieldTypeMismatchException
 from rosbridge_library.internal.publishers import MultiPublisher
 from rosbridge_library.internal.topics import TypeConflictException
-from rosbridge_library.internal.type_support import ROSMessage
 from rosbridge_library.util.ros import is_topic_published
 
 if TYPE_CHECKING:
     from std_msgs.msg import String
+
+    from rosbridge_library.internal.type_support import ROSMessage
 
 
 class TestMultiPublisher(unittest.TestCase):

--- a/rosbridge_library/test/internal/publishers/test_multi_publisher.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_publisher.py
@@ -2,6 +2,7 @@
 import time
 import unittest
 from threading import Thread
+from typing import TYPE_CHECKING, Any
 
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
@@ -12,11 +13,15 @@ from rosbridge_library.internal import ros_loader
 from rosbridge_library.internal.message_conversion import FieldTypeMismatchException
 from rosbridge_library.internal.publishers import MultiPublisher
 from rosbridge_library.internal.topics import TypeConflictException
+from rosbridge_library.internal.type_support import ROSMessage
 from rosbridge_library.util.ros import is_topic_published
+
+if TYPE_CHECKING:
+    from std_msgs.msg import String
 
 
 class TestMultiPublisher(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = MultiThreadedExecutor(num_threads=2)
         self.node = Node("test_multi_publisher")
@@ -25,13 +30,13 @@ class TestMultiPublisher(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def test_register_multipublisher(self):
+    def test_register_multipublisher(self) -> None:
         """Register a publisher on a clean topic with a good msg type."""
         topic = "/test_register_multipublisher"
         msg_type = "std_msgs/String"
@@ -40,24 +45,24 @@ class TestMultiPublisher(unittest.TestCase):
         MultiPublisher(topic, self.node, msg_type)
         self.assertTrue(is_topic_published(self.node, topic))
 
-    def test_unregister_multipublisher(self):
+    def test_unregister_multipublisher(self) -> None:
         """Register and unregister a publisher on a clean topic with a good msg type."""
         topic = "/test_unregister_multipublisher"
         msg_type = "std_msgs/String"
 
         self.assertFalse(is_topic_published(self.node, topic))
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         self.assertTrue(is_topic_published(self.node, topic))
         p.unregister()
         self.assertFalse(is_topic_published(self.node, topic))
 
-    def test_register_client(self):
+    def test_register_client(self) -> None:
         """Adds a publisher then removes it."""
         topic = "/test_register_client"
         msg_type = "std_msgs/String"
         client_id = "client1"
 
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         self.assertFalse(p.has_clients())
 
         p.register_client(client_id)
@@ -66,12 +71,12 @@ class TestMultiPublisher(unittest.TestCase):
         p.unregister_client(client_id)
         self.assertFalse(p.has_clients())
 
-    def test_register_multiple_clients(self):
+    def test_register_multiple_clients(self) -> None:
         """Adds multiple publishers then removes them."""
         topic = "/test_register_multiple_clients"
         msg_type = "std_msgs/String"
 
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         self.assertFalse(p.has_clients())
 
         for i in range(1000):
@@ -84,7 +89,7 @@ class TestMultiPublisher(unittest.TestCase):
 
         self.assertFalse(p.has_clients())
 
-    def test_verify_type(self):
+    def test_verify_type(self) -> None:
         topic = "/test_verify_type"
         msg_type = "std_msgs/String"
         othertypes = [
@@ -101,20 +106,20 @@ class TestMultiPublisher(unittest.TestCase):
             "sensor_msgs/PointCloud2",
         ]
 
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         p.verify_type(msg_type)
         for othertype in othertypes:
             self.assertRaises(TypeConflictException, p.verify_type, othertype)
 
-    def test_publish(self):
+    def test_publish(self) -> None:
         """Make sure that publishing works."""
         topic = "/test_publish"
         msg_type = "std_msgs/String"
         msg = {"data": "why hello there"}
 
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: ROSMessage) -> None:
             received["msg"] = msg
 
         subscriber_qos = QoSProfile(
@@ -125,20 +130,20 @@ class TestMultiPublisher(unittest.TestCase):
             ros_loader.get_message_class(msg_type), topic, cb, subscriber_qos
         )
 
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         p.publish(msg)
         time.sleep(0.1)
         self.assertEqual(received["msg"].data, msg["data"])
 
-    def test_publish_twice(self):
+    def test_publish_twice(self) -> None:
         """Make sure that publishing works."""
         topic = "/test_publish_twice"
         msg_type = "std_msgs/String"
         msg = {"data": "why hello there"}
 
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: ROSMessage) -> None:
             received["msg"] = msg
 
         subscriber_qos = QoSProfile(
@@ -149,7 +154,7 @@ class TestMultiPublisher(unittest.TestCase):
             ros_loader.get_message_class(msg_type), topic, cb, subscriber_qos
         )
 
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         p.publish(msg)
         time.sleep(0.1)
         self.assertEqual(received["msg"].data, msg["data"])
@@ -173,11 +178,11 @@ class TestMultiPublisher(unittest.TestCase):
         p.publish(msg)
         self.assertEqual(received["msg"].data, msg["data"])
 
-    def test_bad_publish(self):
+    def test_bad_publish(self) -> None:
         """Make sure that bad publishing fails."""
         topic = "/test_publish"
         msg_type = "std_msgs/String"
         msg = {"data": 3}
 
-        p = MultiPublisher(topic, self.node, msg_type)
+        p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         self.assertRaises(FieldTypeMismatchException, p.publish, msg)

--- a/rosbridge_library/test/internal/publishers/test_multi_publisher.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import unittest
 from threading import Thread
@@ -186,3 +186,7 @@ class TestMultiPublisher(unittest.TestCase):
 
         p: MultiPublisher[String] = MultiPublisher(topic, self.node, msg_type)
         self.assertRaises(FieldTypeMismatchException, p.publish, msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -2,6 +2,7 @@
 import time
 import unittest
 from threading import Thread
+from typing import Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -22,7 +23,7 @@ manager.unregister_timeout = 1.0
 
 
 class TestPublisherManager(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_publisher_manager")
@@ -31,13 +32,13 @@ class TestPublisherManager(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def test_register_publisher(self):
+    def test_register_publisher(self) -> None:
         """Register a publisher on a clean topic with a good msg type."""
         topic = "/test_register_publisher"
         msg_type = "std_msgs/String"
@@ -59,7 +60,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertFalse(is_topic_published(self.node, topic))
         self.assertFalse(topic in manager.unregister_timers)
 
-    def test_register_publisher_multiclient(self):
+    def test_register_publisher_multiclient(self) -> None:
         topic = "/test_register_publisher_multiclient"
         msg_type = "std_msgs/String"
         client1 = "client_test_register_publisher_1"
@@ -90,7 +91,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertFalse(is_topic_published(self.node, topic))
         self.assertFalse(topic in manager.unregister_timers)
 
-    def test_register_publisher_conflicting_types(self):
+    def test_register_publisher_conflicting_types(self) -> None:
         topic = "/test_register_publisher_conflicting_types"
         msg_type = "std_msgs/String"
         msg_type_bad = "std_msgs/Int32"
@@ -107,7 +108,7 @@ class TestPublisherManager(unittest.TestCase):
             TypeConflictException, manager.register, "client2", topic, self.node, msg_type_bad
         )
 
-    def test_register_multiple_publishers(self):
+    def test_register_multiple_publishers(self) -> None:
         topic1 = "/test_register_multiple_publishers1"
         topic2 = "/test_register_multiple_publishers2"
         msg_type = "std_msgs/String"
@@ -148,7 +149,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertFalse(topic1 in manager.unregister_timers)
         self.assertFalse(topic2 in manager.unregister_timers)
 
-    def test_register_no_msgtype(self):
+    def test_register_no_msgtype(self) -> None:
         topic = "/test_register_no_msgtype"
         client = "client_test_register_no_msgtype"
 
@@ -156,7 +157,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertFalse(is_topic_published(self.node, topic))
         self.assertRaises(TopicNotEstablishedException, manager.register, client, topic, self.node)
 
-    def test_register_infer_topictype(self):
+    def test_register_infer_topictype(self) -> None:
         topic = "/test_register_infer_topictype"
         client = "client_test_register_infer_topictype"
 
@@ -180,7 +181,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertTrue(topic in manager.unregister_timers)
         self.assertTrue(is_topic_published(self.node, topic))
 
-    def test_register_multiple_notopictype(self):
+    def test_register_multiple_notopictype(self) -> None:
         topic = "/test_register_multiple_notopictype"
         msg_type = "std_msgs/String"
         client1 = "client_test_register_multiple_notopictype_1"
@@ -212,7 +213,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertFalse(topic in manager.unregister_timers)
         self.assertFalse(is_topic_published(self.node, topic))
 
-    def test_publish_not_registered(self):
+    def test_publish_not_registered(self) -> None:
         topic = "/test_publish_not_registered"
         msg = {"data": "test publish not registered"}
         client = "client_test_publish_not_registered"
@@ -223,15 +224,15 @@ class TestPublisherManager(unittest.TestCase):
             TopicNotEstablishedException, manager.publish, client, topic, msg, self.node
         )
 
-    def test_publisher_manager_publish(self):
+    def test_publisher_manager_publish(self) -> None:
         """Make sure that publishing works."""
         topic = "/test_publisher_manager_publish"
         msg = {"data": "test publisher manager publish"}
         client = "client_test_publisher_manager_publish"
 
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: String) -> None:
             received["msg"] = msg
 
         subscriber_qos = QoSProfile(
@@ -244,7 +245,7 @@ class TestPublisherManager(unittest.TestCase):
         time.sleep(0.5)
         self.assertEqual(received["msg"].data, msg["data"])
 
-    def test_publisher_manager_bad_publish(self):
+    def test_publisher_manager_bad_publish(self) -> None:
         """Make sure that bad publishing fails."""
         topic = "/test_publisher_manager_bad_publish"
         client = "client_test_publisher_manager_bad_publish"

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import unittest
 from threading import Thread
@@ -256,3 +256,6 @@ class TestPublisherManager(unittest.TestCase):
         self.assertRaises(
             FieldTypeMismatchException, manager.publish, client, topic, msg, self.node
         )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from threading import Thread
@@ -256,6 +258,7 @@ class TestPublisherManager(unittest.TestCase):
         self.assertRaises(
             FieldTypeMismatchException, manager.publish, client, topic, msg, self.node
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -2,8 +2,9 @@
 import random
 import time
 import unittest
+from collections.abc import Callable
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import numpy as np
 import rclpy
@@ -118,7 +119,7 @@ class TestServices(unittest.TestCase):
             self.assertEqual(type(msg1), type(msg2))
         if type(msg1) in c.list_types:
             assert isinstance(msg1, c.list_types) and isinstance(msg2, c.list_types)
-            for x, y in zip(msg1, msg2):
+            for x, y in zip(msg1, msg2, strict=False):
                 self.msgs_equal(x, y)
         elif (
             type(msg1) in c.primitive_types
@@ -193,7 +194,7 @@ class TestServices(unittest.TestCase):
 
         result = res.result
 
-        for x, y in zip(result.names, json_ret["result"]["names"]):
+        for x, y in zip(result.names, json_ret["result"]["names"], strict=False):
             self.assertEqual(x, y)
 
     def test_service_caller(self) -> None:
@@ -237,7 +238,7 @@ class TestServices(unittest.TestCase):
 
         result = res.result
 
-        for x, y in zip(result.names, rcvd["json"]["result"]["names"]):
+        for x, y in zip(result.names, rcvd["json"]["result"]["names"], strict=False):
             self.assertEqual(x, y)
 
     def test_service_tester(self) -> None:

--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import random
 import time
 import unittest
-from collections.abc import Callable
 from threading import Thread
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -15,11 +16,14 @@ from rclpy.node import Node
 from rosbridge_library.internal import message_conversion as c
 from rosbridge_library.internal import ros_loader, services
 from rosbridge_library.internal.message_conversion import FieldTypeMismatchException
-from rosbridge_library.internal.type_support import ROSMessage
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rclpy.client import Client
     from rclpy.service import Service
+
+    from rosbridge_library.internal.type_support import ROSMessage
 
 
 def populate_random_args(d: object) -> object:

--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -3,19 +3,25 @@ import random
 import time
 import unittest
 from threading import Thread
+from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
 import numpy as np
 import rclpy
 from rcl_interfaces.srv import ListParameters
-from rclpy.executors import SingleThreadedExecutor
+from rclpy.executors import Executor, SingleThreadedExecutor
 from rclpy.node import Node
 
 from rosbridge_library.internal import message_conversion as c
 from rosbridge_library.internal import ros_loader, services
 from rosbridge_library.internal.message_conversion import FieldTypeMismatchException
+from rosbridge_library.internal.type_support import ROSMessage
+
+if TYPE_CHECKING:
+    from rclpy.client import Client
+    from rclpy.service import Service
 
 
-def populate_random_args(d):
+def populate_random_args(d: object) -> object:
     # Given a dictionary d, replaces primitives with random values
     if isinstance(d, dict):
         for x in d:
@@ -33,21 +39,21 @@ def populate_random_args(d):
 
 
 class ServiceTester:
-    def __init__(self, executor, name, srv_type):
+    def __init__(self, executor: Executor, name: str, srv_type: str) -> None:
         self.name = name
         self.executor = executor
         self.node = Node("service_tester_" + srv_type.replace("/", "_"))
         self.executor.add_node(self.node)
         self.srvClass = ros_loader.get_service_class(srv_type)
-        self.service = self.node.create_service(self.srvClass, name, self.callback)
+        self.service: Service = self.node.create_service(self.srvClass, name, self.callback)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.executor.remove_node(self.node)
 
-    def start(self):
+    def start(self) -> None:
         req = self.srvClass.Request()
-        gen = c.extract_values(req)
-        gen = populate_random_args(gen)
+        gen = populate_random_args(c.extract_values(req))
+        assert isinstance(gen, dict)
         self.input = gen
         thread = services.ServiceCaller(
             self.name,
@@ -60,11 +66,11 @@ class ServiceTester:
         thread.start()
         thread.join()
 
-    def callback(self, req, res):
+    def callback(self, req: ROSMessage, res: ROSMessage) -> ROSMessage:
         self.req = req
         time.sleep(0.1)
-        gen = c.extract_values(res)
-        gen = populate_random_args(gen)
+        gen = populate_random_args(c.extract_values(res))
+        assert isinstance(gen, dict)
         try:
             res = c.populate_instance(gen, res)
         except:  # Will print() and raise
@@ -76,13 +82,13 @@ class ServiceTester:
         self.output = gen
         return res
 
-    def success(self, rsp):
+    def success(self, rsp: dict[str, Any]) -> None:
         self.rsp = rsp
 
-    def error(self, exc):
+    def error(self, exc: Exception) -> None:
         self.exc = exc
 
-    def validate(self, equality_function):
+    def validate(self, equality_function: Callable[[object, object], None]) -> None:
         if hasattr(self, "exc"):
             print(self.exc)
             raise self.exc
@@ -91,7 +97,7 @@ class ServiceTester:
 
 
 class TestServices(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_node")
@@ -100,17 +106,18 @@ class TestServices(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def msgs_equal(self, msg1, msg2):
+    def msgs_equal(self, msg1: object, msg2: object) -> None:
         if isinstance(msg1, str) and isinstance(msg2, str):
             pass
         else:
             self.assertEqual(type(msg1), type(msg2))
         if type(msg1) in c.list_types:
+            assert isinstance(msg1, c.list_types) and isinstance(msg2, c.list_types)
             for x, y in zip(msg1, msg2):
                 self.msgs_equal(x, y)
         elif (
@@ -120,6 +127,7 @@ class TestServices(unittest.TestCase):
         ):
             self.assertEqual(msg1, msg2)
         else:
+            assert isinstance(msg1, dict) and isinstance(msg2, dict)
             for x in msg1:
                 self.assertTrue(x in msg2)
             for x in msg2:
@@ -127,10 +135,11 @@ class TestServices(unittest.TestCase):
             for x in msg1:
                 self.msgs_equal(msg1[x], msg2[x])
 
-    def test_populate_request_args(self):
+    def test_populate_request_args(self) -> None:
         # Test empty messages
         for srv_type in ["TestEmpty", "TestResponseOnly"]:
             cls = ros_loader.get_service_class("rosbridge_test_msgs/" + srv_type)
+            args: Any
             for args in [[], {}, None]:
                 # Should throw no exceptions
                 services.args_to_service_request_instance(cls.Request(), args)
@@ -157,13 +166,16 @@ class TestServices(unittest.TestCase):
             # Should throw no exceptions
             services.args_to_service_request_instance(cls.Request(), args)
 
-    def test_service_call(self):
+    def test_service_call(self) -> None:
         """Test a simple list_parameters service call."""
         # Prepare parameter
         self.node.declare_parameter("test_parameter", 1.0)
 
         # First, call the service the 'proper' way
-        p = self.node.create_client(ListParameters, self.node.get_name() + "/list_parameters")
+        p: Client[ListParameters.Request, ListParameters.Response] = self.node.create_client(
+            ListParameters,  # type: ignore[arg-type]
+            self.node.get_name() + "/list_parameters",
+        )
         p.wait_for_service(0.5)
         ret = p.call_async(ListParameters.Request())
         while not ret.done():
@@ -175,29 +187,38 @@ class TestServices(unittest.TestCase):
             self.node,
             self.node.get_name() + "/list_parameters",
         )
-        for x, y in zip(ret.result().result.names, json_ret["result"]["names"]):
+
+        res = ret.result()
+        assert res is not None
+
+        result = res.result
+
+        for x, y in zip(result.names, json_ret["result"]["names"]):
             self.assertEqual(x, y)
 
-    def test_service_caller(self):
+    def test_service_caller(self) -> None:
         """Same as test_service_call but via the thread caller."""
         # Prepare parameter
         self.node.declare_parameter("test_parameter", 1.0)
 
         # First, call the service the 'proper' way
-        p = self.node.create_client(ListParameters, self.node.get_name() + "/list_parameters")
+        p: Client[ListParameters.Request, ListParameters.Response] = self.node.create_client(
+            ListParameters,  # type: ignore[arg-type]
+            self.node.get_name() + "/list_parameters",
+        )
         p.wait_for_service(0.5)
         ret = p.call_async(ListParameters.Request())
         while not ret.done():
             time.sleep(0.1)
         self.node.destroy_client(p)
 
-        rcvd = {"json": None}
+        rcvd: dict[str, Any] = {"json": None}
 
-        def success(json):
+        def success(json: dict[str, Any]) -> None:
             rcvd["json"] = json
 
-        def error():
-            raise Exception
+        def error(exc: Exception) -> NoReturn:
+            raise exc
 
         # Now, call using the services
         services.ServiceCaller(
@@ -211,10 +232,15 @@ class TestServices(unittest.TestCase):
 
         time.sleep(0.2)
 
-        for x, y in zip(ret.result().result.names, rcvd["json"]["result"]["names"]):
+        res = ret.result()
+        assert res is not None
+
+        result = res.result
+
+        for x, y in zip(result.names, rcvd["json"]["result"]["names"]):
             self.assertEqual(x, y)
 
-    def test_service_tester(self):
+    def test_service_tester(self) -> None:
         t = ServiceTester(
             self.executor, "/test_service_tester", "rosbridge_test_msgs/TestRequestAndResponse"
         )
@@ -222,7 +248,7 @@ class TestServices(unittest.TestCase):
         time.sleep(0.2)
         t.validate(self.msgs_equal)
 
-    def test_service_tester_alltypes(self):
+    def test_service_tester_alltypes(self) -> None:
         ts = []
         for srv in [
             "TestResponseOnly",
@@ -244,7 +270,7 @@ class TestServices(unittest.TestCase):
         for t in ts:
             t.validate(self.msgs_equal)
 
-    def test_random_service_types(self):
+    def test_random_service_types(self) -> None:
         common = [
             "rcl_interfaces/ListParameters",
             "rcl_interfaces/SetParameters",

--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -292,3 +292,7 @@ class TestServices(unittest.TestCase):
 
         for t in ts:
             t.validate(self.msgs_equal)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import unittest
 from threading import Thread
@@ -212,3 +212,7 @@ class TestMultiSubscriber(unittest.TestCase):
         time.sleep(0.1)
         self.assertEqual(msg.data, received["msg1"]["data"])
         self.assertEqual(msg.data, received["msg2"]["data"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from threading import Thread
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -10,10 +12,12 @@ from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import Int32, String
 
-from rosbridge_library.internal.outgoing_message import OutgoingMessage
 from rosbridge_library.internal.subscribers import MultiSubscriber
 from rosbridge_library.internal.topics import TypeConflictException
 from rosbridge_library.util.ros import is_topic_subscribed
+
+if TYPE_CHECKING:
+    from rosbridge_library.internal.outgoing_message import OutgoingMessage
 
 
 class TestMultiSubscriber(unittest.TestCase):

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -2,6 +2,7 @@
 import time
 import unittest
 from threading import Thread
+from typing import Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -9,13 +10,14 @@ from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import Int32, String
 
+from rosbridge_library.internal.outgoing_message import OutgoingMessage
 from rosbridge_library.internal.subscribers import MultiSubscriber
 from rosbridge_library.internal.topics import TypeConflictException
 from rosbridge_library.util.ros import is_topic_subscribed
 
 
 class TestMultiSubscriber(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.client_id = "test_client_id"
 
         rclpy.init()
@@ -26,13 +28,13 @@ class TestMultiSubscriber(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def test_register_multisubscriber(self):
+    def test_register_multisubscriber(self) -> None:
         """Register a subscriber on a clean topic with a good msg type."""
         topic = "/test_register_multisubscriber"
         msg_type = "std_msgs/String"
@@ -41,20 +43,20 @@ class TestMultiSubscriber(unittest.TestCase):
         MultiSubscriber(topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
-    def test_unregister_multisubscriber(self):
+    def test_unregister_multisubscriber(self) -> None:
         """Register and unregister a subscriber on a clean topic with a good msg type."""
         topic = "/test_unregister_multisubscriber"
         msg_type = "std_msgs/String"
 
         self.assertFalse(is_topic_subscribed(self.node, topic))
-        multi = MultiSubscriber(
+        multi: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
         self.assertTrue(is_topic_subscribed(self.node, topic))
         multi.unregister()
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
-    def test_verify_type(self):
+    def test_verify_type(self) -> None:
         topic = "/test_verify_type"
         msg_type = "std_msgs/String"
         othertypes = [
@@ -71,25 +73,25 @@ class TestMultiSubscriber(unittest.TestCase):
             "sensor_msgs/PointCloud2",
         ]
 
-        s = MultiSubscriber(
+        s: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
         s.verify_type(msg_type)
         for othertype in othertypes:
             self.assertRaises(TypeConflictException, s.verify_type, othertype)
 
-    def test_subscribe_unsubscribe(self):
+    def test_subscribe_unsubscribe(self) -> None:
         topic = "/test_subscribe_unsubscribe"
         msg_type = "std_msgs/String"
 
         self.assertFalse(is_topic_subscribed(self.node, topic))
-        multi = MultiSubscriber(
+        multi: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
         self.assertTrue(is_topic_subscribed(self.node, topic))
         self.assertEqual(len(multi.new_subscriptions), 0)
 
-        multi.subscribe(self.client_id, None)
+        multi.subscribe(self.client_id, lambda _: None)
         self.assertEqual(len(multi.new_subscriptions), 1)
 
         multi.unsubscribe(self.client_id)
@@ -99,7 +101,7 @@ class TestMultiSubscriber(unittest.TestCase):
         time.sleep(0.1)
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
-    def test_subscribe_receive_json(self):
+    def test_subscribe_receive_json(self) -> None:
         topic = "/test_subscribe_receive_json"
         msg_type = "std_msgs/String"
 
@@ -111,9 +113,9 @@ class TestMultiSubscriber(unittest.TestCase):
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
         pub = self.node.create_publisher(String, topic, publisher_qos)
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: OutgoingMessage[String]) -> None:
             received["msg"] = msg.get_json_values()
 
         MultiSubscriber(topic, self.client_id, cb, self.node, msg_type=msg_type)
@@ -122,7 +124,7 @@ class TestMultiSubscriber(unittest.TestCase):
         time.sleep(0.1)
         self.assertEqual(msg.data, received["msg"]["data"])
 
-    def test_subscribe_receive_json_multiple(self):
+    def test_subscribe_receive_json_multiple(self) -> None:
         topic = "/test_subscribe_receive_json_multiple"
         msg_type = "std_msgs/Int32"
 
@@ -133,9 +135,9 @@ class TestMultiSubscriber(unittest.TestCase):
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
         pub = self.node.create_publisher(Int32, topic, publisher_qos)
-        received = {"msgs": []}
+        received: dict[str, Any] = {"msgs": []}
 
-        def cb(msg):
+        def cb(msg: OutgoingMessage[Int32]) -> None:
             received["msgs"].append(msg.get_json_values()["data"])
 
         MultiSubscriber(topic, self.client_id, cb, self.node, msg_type=msg_type)
@@ -148,7 +150,7 @@ class TestMultiSubscriber(unittest.TestCase):
         time.sleep(0.1)
         self.assertEqual(numbers, received["msgs"])
 
-    def test_unsubscribe_does_not_receive_further_msgs(self):
+    def test_unsubscribe_does_not_receive_further_msgs(self) -> None:
         topic = "/test_unsubscribe_does_not_receive_further_msgs"
         msg_type = "std_msgs/String"
 
@@ -162,7 +164,7 @@ class TestMultiSubscriber(unittest.TestCase):
         pub = self.node.create_publisher(String, topic, publisher_qos)
         received = {"count": 0}
 
-        def cb(_msg):
+        def cb(_msg: OutgoingMessage[String]) -> None:
             received["count"] = received["count"] + 1
 
         multi = MultiSubscriber(topic, self.client_id, cb, self.node, msg_type=msg_type)
@@ -176,7 +178,7 @@ class TestMultiSubscriber(unittest.TestCase):
         time.sleep(0.1)
         self.assertEqual(received["count"], 1)
 
-    def test_multiple_subscribers(self):
+    def test_multiple_subscribers(self) -> None:
         topic = "/test_subscribe_receive_json"
         msg_type = "std_msgs/String"
         client1 = "client_test_subscribe_receive_json_1"
@@ -191,12 +193,12 @@ class TestMultiSubscriber(unittest.TestCase):
         )
         pub = self.node.create_publisher(String, topic, publisher_qos)
 
-        received = {"msg1": None, "msg2": None}
+        received: dict[str, Any] = {"msg1": None, "msg2": None}
 
-        def cb1(msg):
+        def cb1(msg: OutgoingMessage) -> None:
             received["msg1"] = msg.get_json_values()
 
-        def cb2(msg):
+        def cb2(msg: OutgoingMessage) -> None:
             received["msg2"] = msg.get_json_values()
 
         multi = MultiSubscriber(topic, client1, cb1, self.node, msg_type=msg_type)

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -2,6 +2,7 @@
 import time
 import unittest
 from threading import Thread
+from typing import Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -9,6 +10,7 @@ from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import String
 
+from rosbridge_library.internal.outgoing_message import OutgoingMessage
 from rosbridge_library.internal.subscribers import manager
 from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
@@ -18,7 +20,7 @@ from rosbridge_library.util.ros import is_topic_subscribed
 
 
 class TestSubscriberManager(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_subscriber_manager")
@@ -27,13 +29,13 @@ class TestSubscriberManager(unittest.TestCase):
         self.exec_thread = Thread(target=self.executor.spin)
         self.exec_thread.start()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def test_subscribe(self):
+    def test_subscribe(self) -> None:
         """Register a publisher on a clean topic with a good msg type."""
         topic = "/test_subscribe"
         msg_type = "std_msgs/String"
@@ -41,7 +43,7 @@ class TestSubscriberManager(unittest.TestCase):
 
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
-        manager.subscribe(client, topic, None, self.node, msg_type)
+        manager.subscribe(client, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
@@ -49,7 +51,7 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
-    def test_register_subscriber_multiclient(self):
+    def test_register_subscriber_multiclient(self) -> None:
         topic = "/test_register_subscriber_multiclient"
         msg_type = "std_msgs/String"
         client1 = "client_test_register_subscriber_multiclient_1"
@@ -57,11 +59,11 @@ class TestSubscriberManager(unittest.TestCase):
 
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
-        manager.subscribe(client1, topic, None, self.node, msg_type)
+        manager.subscribe(client1, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
-        manager.subscribe(client2, topic, None, self.node, msg_type)
+        manager.subscribe(client2, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
@@ -73,7 +75,7 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
-    def test_register_publisher_conflicting_types(self):
+    def test_register_publisher_conflicting_types(self) -> None:
         topic = "/test_register_publisher_conflicting_types"
         msg_type = "std_msgs/String"
         msg_type_bad = "std_msgs/Int32"
@@ -81,7 +83,7 @@ class TestSubscriberManager(unittest.TestCase):
 
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
-        manager.subscribe(client, topic, None, self.node, msg_type)
+        manager.subscribe(client, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
@@ -95,7 +97,7 @@ class TestSubscriberManager(unittest.TestCase):
             msg_type_bad,
         )
 
-    def test_register_multiple_publishers(self):
+    def test_register_multiple_publishers(self) -> None:
         topic1 = "/test_register_multiple_publishers1"
         topic2 = "/test_register_multiple_publishers2"
         msg_type = "std_msgs/String"
@@ -106,13 +108,13 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(is_topic_subscribed(self.node, topic1))
         self.assertFalse(is_topic_subscribed(self.node, topic2))
 
-        manager.subscribe(client, topic1, None, self.node, msg_type)
+        manager.subscribe(client, topic1, lambda _: None, self.node, msg_type)
         self.assertTrue(topic1 in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic1))
         self.assertFalse(topic2 in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic2))
 
-        manager.subscribe(client, topic2, None, self.node, msg_type)
+        manager.subscribe(client, topic2, lambda _: None, self.node, msg_type)
         self.assertTrue(topic1 in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic1))
         self.assertTrue(topic2 in manager._subscribers)
@@ -130,7 +132,7 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(topic2 in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic2))
 
-    def test_register_no_msgtype(self):
+    def test_register_no_msgtype(self) -> None:
         topic = "/test_register_no_msgtype"
         client = "client_test_register_no_msgtype"
 
@@ -140,7 +142,7 @@ class TestSubscriberManager(unittest.TestCase):
             TopicNotEstablishedException, manager.subscribe, client, topic, None, self.node
         )
 
-    def test_register_infer_topictype(self):
+    def test_register_infer_topictype(self) -> None:
         topic = "/test_register_infer_topictype"
         client = "client_test_register_infer_topictype"
 
@@ -155,7 +157,7 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertTrue(is_topic_subscribed(self.node, topic))
         self.assertFalse(topic in manager._subscribers)
 
-        manager.subscribe(client, topic, None, self.node)
+        manager.subscribe(client, topic, lambda _: None, self.node)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
@@ -163,7 +165,7 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
-    def test_register_multiple_notopictype(self):
+    def test_register_multiple_notopictype(self) -> None:
         topic = "/test_register_multiple_notopictype"
         msg_type = "std_msgs/String"
         client1 = "client_test_register_multiple_notopictype_1"
@@ -172,11 +174,11 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
-        manager.subscribe(client1, topic, None, self.node, msg_type)
+        manager.subscribe(client1, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
-        manager.subscribe(client2, topic, None, self.node)
+        manager.subscribe(client2, topic, lambda _: None, self.node)
         self.assertTrue(topic in manager._subscribers)
         self.assertTrue(is_topic_subscribed(self.node, topic))
 
@@ -188,7 +190,7 @@ class TestSubscriberManager(unittest.TestCase):
         self.assertFalse(topic in manager._subscribers)
         self.assertFalse(is_topic_subscribed(self.node, topic))
 
-    def test_subscribe_not_registered(self):
+    def test_subscribe_not_registered(self) -> None:
         topic = "/test_subscribe_not_registered"
         client = "client_test_subscribe_not_registered"
 
@@ -198,7 +200,7 @@ class TestSubscriberManager(unittest.TestCase):
             TopicNotEstablishedException, manager.subscribe, client, topic, None, self.node
         )
 
-    def test_publisher_manager_publish(self):
+    def test_publisher_manager_publish(self) -> None:
         topic = "/test_publisher_manager_publish"
         msg_type = "std_msgs/String"
         client = "client_test_publisher_manager_publish"
@@ -211,9 +213,9 @@ class TestSubscriberManager(unittest.TestCase):
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
         pub = self.node.create_publisher(String, topic, publisher_qos)
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: OutgoingMessage[String]) -> None:
             received["msg"] = msg.get_json_values()
 
         manager.subscribe(client, topic, cb, self.node, msg_type)

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import unittest
 from threading import Thread
@@ -240,3 +240,7 @@ class TestSubscriberManager(unittest.TestCase):
         pub.publish(msg)
         time.sleep(0.1)
         self.assertEqual(msg.data, received["msg"]["data"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from threading import Thread
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -10,13 +12,15 @@ from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import String
 
-from rosbridge_library.internal.outgoing_message import OutgoingMessage
 from rosbridge_library.internal.subscribers import manager
 from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
     TypeConflictException,
 )
 from rosbridge_library.util.ros import is_topic_subscribed
+
+if TYPE_CHECKING:
+    from rosbridge_library.internal.outgoing_message import OutgoingMessage
 
 
 class TestSubscriberManager(unittest.TestCase):

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import time
 import unittest
 from typing import Any

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -1,55 +1,54 @@
 #!/usr/bin/env python
 import time
 import unittest
+from typing import Any
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 
-from rosbridge_library.internal import subscription_modifiers
+from rosbridge_library.internal.subscription_modifiers import (
+    MessageHandler,
+    QueueMessageHandler,
+    ThrottleMessageHandler,
+)
 
 
 class TestMessageHandlers(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()
         self.node = Node("test_subscription_modifiers")
         self.executor.add_node(self.node)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.executor.remove_node(self.node)
         self.node.destroy_node()
         rclpy.shutdown()
 
-    def dummy_cb(self, msg):
+    def dummy_cb(self, msg: str) -> None:
         pass
 
-    def test_default_message_handler(self):
-        handler = subscription_modifiers.MessageHandler(None, self.dummy_cb)
+    def test_default_message_handler(self) -> None:
+        handler = MessageHandler(None, self.dummy_cb)
         self.help_test_default(handler)
 
-    def test_throttle_message_handler(self):
-        handler = subscription_modifiers.ThrottleMessageHandler(
-            subscription_modifiers.MessageHandler(None, self.dummy_cb)
-        )
+    def test_throttle_message_handler(self) -> None:
+        handler: MessageHandler = QueueMessageHandler(MessageHandler(None, self.dummy_cb))
         self.help_test_throttle(handler, 50)
 
-    def test_queue_message_handler_passes_msgs(self):
-        handler = subscription_modifiers.QueueMessageHandler(
-            subscription_modifiers.MessageHandler(None, self.dummy_cb)
-        )
+    def test_queue_message_handler_passes_msgs(self) -> None:
+        handler: MessageHandler = QueueMessageHandler(MessageHandler(None, self.dummy_cb))
         self.help_test_queue(handler, 1000)
         handler.finish()
 
-    def test_queue_message_handler_stops(self):
-        received = {"msgs": []}
+    def test_queue_message_handler_stops(self) -> None:
+        received: dict[str, Any] = {"msgs": []}
 
-        def cb(msg):
+        def cb(msg: str) -> None:
             received["msgs"].append(msg)
 
-        handler = subscription_modifiers.QueueMessageHandler(
-            subscription_modifiers.MessageHandler(None, cb)
-        )
+        handler: QueueMessageHandler = QueueMessageHandler(MessageHandler(None, cb))
 
         self.assertTrue(handler.is_alive())
 
@@ -57,19 +56,19 @@ class TestMessageHandlers(unittest.TestCase):
 
         self.assertFalse(handler.is_alive())
 
-    def test_queue_message_handler_queue(self):
-        received = {"msgs": []}
+    def test_queue_message_handler_queue(self) -> None:
+        received: dict[str, Any] = {"msgs": []}
 
-        def cb(msg):
+        def cb(msg: str) -> None:
             received["msgs"].append(msg)
 
         msgs = range(1000)
 
-        handler = subscription_modifiers.MessageHandler(None, cb)
+        handler: MessageHandler = MessageHandler(None, cb)
 
         handler = handler.set_throttle_rate(10000)
         handler = handler.set_queue_length(10)
-        self.assertIsInstance(handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(handler, QueueMessageHandler)
 
         # 'hello' is handled immediately
         handler.handle_message("hello")
@@ -91,20 +90,20 @@ class TestMessageHandlers(unittest.TestCase):
         finally:
             handler.finish()
 
-    def test_queue_message_handler_dropping(self):
-        received = {"msgs": []}
+    def test_queue_message_handler_dropping(self) -> None:
+        received: dict[str, Any] = {"msgs": []}
 
-        def cb(msg):
+        def cb(msg: int) -> None:
             received["msgs"].append(msg)
             time.sleep(1)
 
         queue_length = 5
         msgs = range(queue_length * 5)
 
-        handler = subscription_modifiers.MessageHandler(None, cb)
+        handler = MessageHandler(None, cb)
 
         handler = handler.set_queue_length(queue_length)
-        self.assertIsInstance(handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(handler, QueueMessageHandler)
 
         # send all messages at once.
         # only the first and the last queue_length should get through,
@@ -126,25 +125,25 @@ class TestMessageHandlers(unittest.TestCase):
 
         handler.finish()
 
-    def test_queue_message_handler_rate(self):
-        handler = subscription_modifiers.MessageHandler(None, self.dummy_cb)
+    def test_queue_message_handler_rate(self) -> None:
+        handler = MessageHandler(None, self.dummy_cb)
         self.help_test_queue_rate(handler, 50, 10)
         handler.finish()
 
     # Helper methods for each of the three Handler types, plus one for Queue+Rate.
     # Used in standalone testing as well as the test_transition_functionality test
-    def help_test_default(self, handler):
+    def help_test_default(self, handler: MessageHandler) -> MessageHandler:
         handler = handler.set_queue_length(0)
         handler = handler.set_throttle_rate(0)
-        self.assertIsInstance(handler, subscription_modifiers.MessageHandler)
+        self.assertIsInstance(handler, MessageHandler)
 
         msg = "test_default_message_handler"
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb_str(msg: str) -> None:
             received["msg"] = msg
 
-        handler.publish = cb
+        handler.publish = cb_str
 
         self.assertTrue(handler.time_remaining() == 0)
         t1 = time.monotonic()
@@ -158,10 +157,10 @@ class TestMessageHandlers(unittest.TestCase):
 
         received = {"msgs": []}
 
-        def cb(msg):
+        def cb_int(msg: int) -> None:
             received["msgs"].append(msg)
 
-        handler.publish = cb
+        handler.publish = cb_int
         xs = list(range(10000))
         for x in xs:
             handler.handle_message(x)
@@ -169,20 +168,20 @@ class TestMessageHandlers(unittest.TestCase):
         self.assertEqual(received["msgs"], xs)
         return handler
 
-    def help_test_throttle(self, handler, throttle_rate):
+    def help_test_throttle(self, handler: MessageHandler, throttle_rate: float) -> MessageHandler:
         handler = handler.set_queue_length(0)
         handler = handler.set_throttle_rate(throttle_rate)
-        self.assertIsInstance(handler, subscription_modifiers.ThrottleMessageHandler)
+        self.assertIsInstance(handler, ThrottleMessageHandler)
 
         msg = "test_throttle_message_handler"
 
         # First, try with a single message
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb_str(msg: str) -> None:
             received["msg"] = msg
 
-        handler.publish = cb
+        handler.publish = cb_str
 
         # ensure the handler doesn't swallow this message
         time.sleep(2.0 * handler.throttle_rate)
@@ -194,10 +193,10 @@ class TestMessageHandlers(unittest.TestCase):
 
         received = {"msgs": []}
 
-        def cb(msg):
+        def cb_int(msg: int) -> None:
             received["msgs"].append(msg)
 
-        handler.publish = cb
+        handler.publish = cb_int
         x = 0
         time_padding = handler.throttle_rate / 4.0
         for i in range(1, 10):
@@ -213,13 +212,13 @@ class TestMessageHandlers(unittest.TestCase):
             self.assertEqual(len(received["msgs"]), i)
         return handler
 
-    def help_test_queue(self, handler, queue_length):
+    def help_test_queue(self, handler: MessageHandler, queue_length: int) -> MessageHandler:
         handler = handler.set_queue_length(queue_length)
-        self.assertIsInstance(handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(handler, QueueMessageHandler)
 
-        received = {"msgs": []}
+        received: dict[str, Any] = {"msgs": []}
 
-        def cb(msg):
+        def cb(msg: int) -> None:
             received["msgs"].append(msg)
 
         handler.publish = cb
@@ -233,14 +232,16 @@ class TestMessageHandlers(unittest.TestCase):
         self.assertEqual(msgs, received["msgs"])
         return handler
 
-    def help_test_queue_rate(self, handler, throttle_rate, queue_length):
+    def help_test_queue_rate(
+        self, handler: MessageHandler, throttle_rate: float, queue_length: int
+    ) -> MessageHandler:
         handler = handler.set_throttle_rate(throttle_rate)
         handler = handler.set_queue_length(queue_length)
-        self.assertIsInstance(handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(handler, QueueMessageHandler)
 
-        received = {"msg": None}
+        received: dict[str, Any] = {"msg": None}
 
-        def cb(msg):
+        def cb(msg: int) -> None:
             received["msg"] = msg
 
         handler.publish = cb
@@ -265,114 +266,114 @@ class TestMessageHandlers(unittest.TestCase):
         return handler
 
     # Test that each transition works and is stable
-    def test_transitions(self):
+    def test_transitions(self) -> None:
         # MessageHandler.transition is stable
-        handler = subscription_modifiers.MessageHandler(None, self.dummy_cb)
+        handler = MessageHandler(None, self.dummy_cb)
         next_handler = handler.transition()
         self.assertEqual(handler, next_handler)
 
         # Going from MessageHandler to ThrottleMessageHandler...
-        handler = subscription_modifiers.MessageHandler(None, self.dummy_cb)
+        handler = MessageHandler(None, self.dummy_cb)
         next_handler = handler.set_throttle_rate(100)
-        self.assertIsInstance(next_handler, subscription_modifiers.ThrottleMessageHandler)
+        self.assertIsInstance(next_handler, ThrottleMessageHandler)
         handler = next_handler
         # Testing transition returns another ThrottleMessageHandler
         next_handler = handler.transition()
         self.assertEqual(handler, next_handler)
         # And finally going back to MessageHandler
         next_handler = handler.set_throttle_rate(0)
-        self.assertIsInstance(next_handler, subscription_modifiers.MessageHandler)
+        self.assertIsInstance(next_handler, MessageHandler)
 
         # Same for QueueMessageHandler
-        handler = subscription_modifiers.MessageHandler(None, self.dummy_cb)
+        handler = MessageHandler(None, self.dummy_cb)
         next_handler = handler.set_queue_length(100)
-        self.assertIsInstance(next_handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(next_handler, QueueMessageHandler)
         handler = next_handler
         next_handler = handler.transition()
         self.assertEqual(handler, next_handler)
         next_handler = handler.set_queue_length(0)
-        self.assertIsInstance(next_handler, subscription_modifiers.MessageHandler)
+        self.assertIsInstance(next_handler, MessageHandler)
 
         # Checking a QueueMessageHandler with rate limit can be generated both ways
-        handler = subscription_modifiers.MessageHandler(None, self.dummy_cb)
+        handler = MessageHandler(None, self.dummy_cb)
         next_handler = handler.set_queue_length(100).set_throttle_rate(100)
-        self.assertIsInstance(next_handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(next_handler, QueueMessageHandler)
         next_handler.finish()
         next_handler = handler.set_throttle_rate(100).set_queue_length(100)
-        self.assertIsInstance(next_handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(next_handler, QueueMessageHandler)
         next_handler.finish()
         handler = next_handler
         next_handler = handler.transition()
         self.assertEqual(handler, next_handler)
         # Check both steps on the way back to plain MessageHandler
         next_handler = handler.set_throttle_rate(0)
-        self.assertIsInstance(next_handler, subscription_modifiers.QueueMessageHandler)
+        self.assertIsInstance(next_handler, QueueMessageHandler)
         next_handler = handler.set_queue_length(0)
-        self.assertIsInstance(next_handler, subscription_modifiers.MessageHandler)
+        self.assertIsInstance(next_handler, MessageHandler)
 
-    def test_transition_functionality(self):
+    def test_transition_functionality(self) -> None:
         # Test individually
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler: MessageHandler = MessageHandler(None, None)
         handler = self.help_test_queue(handler, 10)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_throttle(handler, 50)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_default(handler)
         handler.finish()
 
         # Test combinations
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_queue(handler, 10)
         handler = self.help_test_throttle(handler, 50)
         handler = self.help_test_default(handler)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_queue(handler, 10)
         handler = self.help_test_default(handler)
         handler = self.help_test_throttle(handler, 50)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_throttle(handler, 50)
         handler = self.help_test_queue_rate(handler, 50, 10)
         handler = self.help_test_default(handler)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_throttle(handler, 50)
         handler = self.help_test_default(handler)
         handler = self.help_test_queue_rate(handler, 50, 10)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_default(handler)
         handler = self.help_test_throttle(handler, 50)
         handler = self.help_test_queue_rate(handler, 50, 10)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_default(handler)
         handler = self.help_test_queue(handler, 10)
         handler = self.help_test_throttle(handler, 50)
         handler.finish()
 
         # Test duplicates
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_queue_rate(handler, 50, 10)
         handler = self.help_test_queue_rate(handler, 100, 10)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_throttle(handler, 50)
         handler = self.help_test_throttle(handler, 100)
         handler.finish()
 
-        handler = subscription_modifiers.MessageHandler(None, None)
+        handler = MessageHandler(None, None)
         handler = self.help_test_default(handler)
         handler = self.help_test_default(handler)
         handler.finish()

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import unittest
 from typing import Any
@@ -377,3 +377,7 @@ class TestMessageHandlers(unittest.TestCase):
         handler = self.help_test_default(handler)
         handler = self.help_test_default(handler)
         handler.finish()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -43,14 +43,14 @@ from std_msgs.msg import (
 
 
 class TestCBORConversion(unittest.TestCase):
-    def test_string(self):
+    def test_string(self) -> None:
         msg = String(data="foo")
         extracted = extract_cbor_values(msg)
 
         self.assertEqual(extracted["data"], msg.data)
         self.assertEqual(type(extracted["data"]), str)
 
-    def test_bool(self):
+    def test_bool(self) -> None:
         for val in [True, False]:
             msg = Bool(data=val)
             extracted = extract_cbor_values(msg)
@@ -58,9 +58,12 @@ class TestCBORConversion(unittest.TestCase):
             self.assertEqual(extracted["data"], msg.data, f"val={val}")
             self.assertEqual(type(extracted["data"]), bool, f"val={val}")
 
-    def test_numbers(self):
+    def test_numbers(self) -> None:
+        # msg: ROSMessage
+        # msg_type: type[ROSMessage]
         for msg_type in [Int8, Int16, Int32, Int64]:
             msg = msg_type(data=-5)
+            assert isinstance(msg, (Int8, Int16, Int32, Int64))
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["data"], msg.data, f"type={msg_type}")
@@ -68,6 +71,7 @@ class TestCBORConversion(unittest.TestCase):
 
         for msg_type in [UInt8, UInt16, UInt32, UInt64]:
             msg = msg_type(data=5)
+            assert isinstance(msg, (UInt8, UInt16, UInt32, UInt64))
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["data"], msg.data, f"type={msg_type}")
@@ -75,14 +79,16 @@ class TestCBORConversion(unittest.TestCase):
 
         for msg_type in [Float32, Float64]:
             msg = msg_type(data=2.3)
+            assert isinstance(msg, (Float32, Float64))
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["data"], msg.data, f"type={msg_type}")
             self.assertEqual(type(extracted["data"]), float, f"type={msg_type}")
 
-    def test_time(self):
+    def test_time(self) -> None:
         for msg_type in [Time, Duration]:
             msg = msg_type()
+            assert isinstance(msg, (Time, Duration))
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["sec"], msg.sec, f"type={msg_type}")
@@ -90,7 +96,7 @@ class TestCBORConversion(unittest.TestCase):
             self.assertEqual(type(extracted["sec"]), int, f"type={msg_type}")
             self.assertEqual(type(extracted["nanosec"]), int, f"type={msg_type}")
 
-    def test_byte_array(self):
+    def test_byte_array(self) -> None:
         msg = UInt8MultiArray(data=[0, 1, 2])
         extracted = extract_cbor_values(msg)
 
@@ -99,7 +105,7 @@ class TestCBORConversion(unittest.TestCase):
         for i, val in enumerate(msg.data):
             self.assertEqual(data[i], val)
 
-    def test_integer_array(self):
+    def test_integer_array(self) -> None:
         for msg_type in [
             Int8MultiArray,
             Int16MultiArray,
@@ -110,6 +116,18 @@ class TestCBORConversion(unittest.TestCase):
             UInt64MultiArray,
         ]:
             msg = msg_type(data=[0, 1, 2])
+            assert isinstance(
+                msg,
+                (
+                    Int8MultiArray,
+                    Int16MultiArray,
+                    Int32MultiArray,
+                    Int64MultiArray,
+                    UInt16MultiArray,
+                    UInt32MultiArray,
+                    UInt64MultiArray,
+                ),
+            )
             extracted = extract_cbor_values(msg)
 
             tag = extracted["data"]
@@ -128,12 +146,13 @@ class TestCBORConversion(unittest.TestCase):
 
             self.assertEqual(array("b", unpacked), msg.data, f"type={msg_type}")
 
-    def test_float_array(self):
+    def test_float_array(self) -> None:
         for msg_type in [
             Float32MultiArray,
             Float64MultiArray,
         ]:
             msg = msg_type(data=[0, 1, 2])
+            assert isinstance(msg, (Float32MultiArray, Float64MultiArray))
             extracted = extract_cbor_values(msg)
 
             tag = extracted["data"]
@@ -152,7 +171,7 @@ class TestCBORConversion(unittest.TestCase):
 
             self.assertEqual(array("f", unpacked), msg.data, f"type={msg_type}")
 
-    def test_nested_messages(self):
+    def test_nested_messages(self) -> None:
         msg = UInt8MultiArray(
             layout=MultiArrayLayout(
                 data_offset=5,
@@ -181,7 +200,7 @@ class TestCBORConversion(unittest.TestCase):
             self.assertEqual(ex_layout["dim"][i]["size"], val.size)
             self.assertEqual(ex_layout["dim"][i]["stride"], val.stride)
 
-    def test_unicode_keys(self):
+    def test_unicode_keys(self) -> None:
         msg = String(data="foo")
         extracted = extract_cbor_values(msg)
 

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -63,7 +63,7 @@ class TestCBORConversion(unittest.TestCase):
         # msg_type: type[ROSMessage]
         for msg_type in [Int8, Int16, Int32, Int64]:
             msg = msg_type(data=-5)
-            assert isinstance(msg, (Int8, Int16, Int32, Int64))
+            assert isinstance(msg, Int8 | Int16 | Int32 | Int64)
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["data"], msg.data, f"type={msg_type}")
@@ -71,7 +71,7 @@ class TestCBORConversion(unittest.TestCase):
 
         for msg_type in [UInt8, UInt16, UInt32, UInt64]:
             msg = msg_type(data=5)
-            assert isinstance(msg, (UInt8, UInt16, UInt32, UInt64))
+            assert isinstance(msg, UInt8 | UInt16 | UInt32 | UInt64)
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["data"], msg.data, f"type={msg_type}")
@@ -79,7 +79,7 @@ class TestCBORConversion(unittest.TestCase):
 
         for msg_type in [Float32, Float64]:
             msg = msg_type(data=2.3)
-            assert isinstance(msg, (Float32, Float64))
+            assert isinstance(msg, Float32 | Float64)
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["data"], msg.data, f"type={msg_type}")
@@ -88,7 +88,7 @@ class TestCBORConversion(unittest.TestCase):
     def test_time(self) -> None:
         for msg_type in [Time, Duration]:
             msg = msg_type()
-            assert isinstance(msg, (Time, Duration))
+            assert isinstance(msg, Time | Duration)
             extracted = extract_cbor_values(msg)
 
             self.assertEqual(extracted["sec"], msg.sec, f"type={msg_type}")
@@ -118,15 +118,13 @@ class TestCBORConversion(unittest.TestCase):
             msg = msg_type(data=[0, 1, 2])
             assert isinstance(
                 msg,
-                (
-                    Int8MultiArray,
-                    Int16MultiArray,
-                    Int32MultiArray,
-                    Int64MultiArray,
-                    UInt16MultiArray,
-                    UInt32MultiArray,
-                    UInt64MultiArray,
-                ),
+                Int8MultiArray
+                | Int16MultiArray
+                | Int32MultiArray
+                | Int64MultiArray
+                | UInt16MultiArray
+                | UInt32MultiArray
+                | UInt64MultiArray,
             )
             extracted = extract_cbor_values(msg)
 
@@ -152,7 +150,7 @@ class TestCBORConversion(unittest.TestCase):
             Float64MultiArray,
         ]:
             msg = msg_type(data=[0, 1, 2])
-            assert isinstance(msg, (Float32MultiArray, Float64MultiArray))
+            assert isinstance(msg, Float32MultiArray | Float64MultiArray)
             extracted = extract_cbor_values(msg)
 
             tag = extracted["data"]

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -205,3 +205,7 @@ class TestCBORConversion(unittest.TestCase):
         keys = extracted.keys()
         for key in keys:
             self.assertEqual(type(key), str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import struct
 import unittest
 from array import array

--- a/rosbridge_library/test/internal/test_compression.py
+++ b/rosbridge_library/test/internal/test_compression.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import unittest
 
 from rosbridge_library.internal import pngcompression

--- a/rosbridge_library/test/internal/test_compression.py
+++ b/rosbridge_library/test/internal/test_compression.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import unittest
 
 from rosbridge_library.internal import pngcompression
@@ -19,3 +19,7 @@ class TestCompression(unittest.TestCase):
         self.assertNotEqual(string, encoded)
         decoded = pngcompression.decode(encoded)
         self.assertEqual(string, decoded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/test_compression.py
+++ b/rosbridge_library/test/internal/test_compression.py
@@ -5,14 +5,14 @@ from rosbridge_library.internal import pngcompression
 
 
 class TestCompression(unittest.TestCase):
-    def test_compress(self):
+    def test_compress(self) -> None:
         bytes_data = list(range(128)) * 10000
         string = str(bytearray(bytes_data))
         encoded = pngcompression.encode(string)
         self.assertNotEqual(string, encoded)
         self.assertIsInstance(encoded, str)
 
-    def test_compress_decompress(self):
+    def test_compress_decompress(self) -> None:
         bytes_data = list(range(128)) * 10000
         string = str(bytearray(bytes_data))
         encoded = pngcompression.encode(string)

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -37,7 +37,7 @@ class TestMessageConversion(unittest.TestCase):
             self.assertEqual(type(msg1), type(msg2))
         if type(msg1) in c.list_types:
             assert isinstance(msg1, c.list_types) and isinstance(msg2, c.list_types)
-            for x, y in zip(msg1, msg2):
+            for x, y in zip(msg1, msg2, strict=False):
                 self.msgs_equal(x, y)
         elif type(msg1) in c.primitive_types or type(msg1) is str:
             self.assertEqual(msg1, msg2)

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import unittest
 from base64 import standard_b64encode
 from json import dumps, loads
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from builtin_interfaces.msg import Time as TimeMsg
 from rclpy.serialization import deserialize_message, serialize_message
 
 from rosbridge_library.internal import message_conversion as c
 from rosbridge_library.internal import ros_loader
 
+if TYPE_CHECKING:
+    import array
+    from collections.abc import Sequence
+
+    from rosbridge_library.internal.type_support import ROSMessage
+
 
 class TestMessageConversion(unittest.TestCase):
-    def validate_instance(self, inst1):
+    def validate_instance(self, inst1: ROSMessage) -> None:
         """
         Validate that the instance is correct by serializing and deserializing it.
 
@@ -20,17 +30,19 @@ class TestMessageConversion(unittest.TestCase):
         inst2 = deserialize_message(serialize_message(inst1), type(inst1))
         self.assertEqual(inst1, inst2)
 
-    def msgs_equal(self, msg1, msg2):
+    def msgs_equal(self, msg1: object, msg2: object) -> None:
         if isinstance(msg1, str) and isinstance(msg2, str):
             pass
         else:
             self.assertEqual(type(msg1), type(msg2))
         if type(msg1) in c.list_types:
+            assert isinstance(msg1, c.list_types) and isinstance(msg2, c.list_types)
             for x, y in zip(msg1, msg2):
                 self.msgs_equal(x, y)
         elif type(msg1) in c.primitive_types or type(msg1) is str:
             self.assertEqual(msg1, msg2)
         else:
+            assert isinstance(msg1, dict) and isinstance(msg2, dict)
             for x in msg1:
                 self.assertTrue(x in msg2)
             for x in msg2:
@@ -38,10 +50,11 @@ class TestMessageConversion(unittest.TestCase):
             for x in msg1:
                 self.msgs_equal(msg1[x], msg2[x])
 
-    def do_primitive_test(self, data_value, msgtype):
+    def do_primitive_test(self, data_value: object, msgtype: str) -> None:
         for msg in [{"data": data_value}, loads(dumps({"data": data_value}))]:
             inst = ros_loader.get_message_instance(msgtype)
             c.populate_instance(msg, inst)
+            assert hasattr(inst, "data")
             self.assertEqual(inst.data, data_value)
             self.validate_instance(inst)
             extracted = c.extract_values(inst)
@@ -50,10 +63,11 @@ class TestMessageConversion(unittest.TestCase):
                 self.assertEqual(msg["data"], msg2["data"])
                 self.assertEqual(msg2["data"], inst.data)
 
-    def do_byte_test(self, data_value, msgtype):
+    def do_byte_test(self, data_value: int, msgtype: str) -> None:
         for msg in [{"data": data_value}]:
             inst = ros_loader.get_message_instance(msgtype)
             c.populate_instance(msg, inst)
+            assert hasattr(inst, "data")
             self.assertEqual(inst.data, bytes([data_value]))
             self.validate_instance(inst)
             extracted = c.extract_values(inst)
@@ -61,7 +75,7 @@ class TestMessageConversion(unittest.TestCase):
                 self.assertEqual(msg["data"], msg2["data"])
                 self.assertEqual(bytes([msg2["data"]]), inst.data)
 
-    def do_test(self, orig_msg, msgtype):
+    def do_test(self, orig_msg: dict[str, Any], msgtype: str) -> None:
         for msg in [orig_msg, loads(dumps(orig_msg))]:
             inst = ros_loader.get_message_instance(msgtype)
             c.populate_instance(msg, inst)
@@ -70,7 +84,7 @@ class TestMessageConversion(unittest.TestCase):
             for msg2 in [extracted, loads(dumps(extracted))]:
                 self.msgs_equal(msg, msg2)
 
-    def test_int_primitives(self):
+    def test_int_primitives(self) -> None:
         # Test raw primitives
         for msg in range(-100, 100):
             for rostype in ["int8", "int16", "int32", "int64"]:
@@ -82,33 +96,33 @@ class TestMessageConversion(unittest.TestCase):
                 self.assertEqual(c._to_primitive_inst(msg, rostype, rostype, []), msg)
                 self.assertEqual(c._to_inst(msg, rostype, rostype), msg)
 
-    def test_byte_primitives(self):
+    def test_byte_primitives(self) -> None:
         # Test raw primitives
         for msg in range(200):
             for rostype in ["octet"]:
                 self.assertEqual(c._to_primitive_inst(msg, rostype, rostype, []), bytes([msg]))
                 self.assertEqual(c._to_inst(msg, rostype, rostype), bytes([msg]))
 
-    def test_bool_primitives(self):
+    def test_bool_primitives(self) -> None:
         self.assertTrue(c._to_primitive_inst(True, "bool", "bool", []))
         self.assertTrue(c._to_inst(True, "bool", "bool"))
         self.assertFalse(c._to_primitive_inst(False, "bool", "bool", []))
         self.assertFalse(c._to_inst(False, "bool", "bool"))
 
-    def test_float_primitives(self):
+    def test_float_primitives(self) -> None:
         for msg in [0.12341234 + i for i in range(-100, 100)]:
             for rostype in ["float32", "float64"]:
                 self.assertEqual(c._to_primitive_inst(msg, rostype, rostype, []), msg)
                 self.assertEqual(c._to_inst(msg, rostype, rostype), msg)
                 c._to_inst(msg, rostype, rostype)
 
-    def test_float_special_cases(self):
+    def test_float_special_cases(self) -> None:
         for msg in [1e9999999, -1e9999999, float("nan")]:
             for rostype in ["float32", "float64"]:
                 self.assertEqual(c._from_inst(msg, rostype), None)
                 self.assertEqual(dumps({"data": c._from_inst(msg, rostype)}), '{"data": null}')
 
-    def test_signed_int_base_msgs(self):
+    def test_signed_int_base_msgs(self) -> None:
         int8s = range(-127, 128)
         for int8 in int8s:
             self.do_primitive_test(int8, "std_msgs/Int8")
@@ -137,7 +151,7 @@ class TestMessageConversion(unittest.TestCase):
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/Int16")
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/Int32")
 
-    def test_unsigned_int_base_msgs(self):
+    def test_unsigned_int_base_msgs(self) -> None:
         int8s = range(256)
         for int8 in int8s:
             self.do_primitive_test(int8, "std_msgs/Char")
@@ -175,25 +189,26 @@ class TestMessageConversion(unittest.TestCase):
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/UInt16")
             self.assertRaises(Exception, self.do_primitive_test, int64, "std_msgs/UInt32")
 
-    def test_byte_base_msg(self):
+    def test_byte_base_msg(self) -> None:
         int8s = range(256)
         for int8 in int8s:
             self.do_byte_test(int8, "std_msgs/Byte")
 
-    def test_bool_base_msg(self):
+    def test_bool_base_msg(self) -> None:
         self.do_primitive_test(True, "std_msgs/Bool")
         self.do_primitive_test(False, "std_msgs/Bool")
 
-    def test_string_base_msg(self):
+    def test_string_base_msg(self) -> None:
         for x in c.ros_primitive_types:
             self.do_primitive_test(x, "std_msgs/String")
 
-    def test_time_msg(self):
+    def test_time_msg(self) -> None:
         now_inst = c._to_inst("now", "builtin_interfaces/Time", "builtin_interfaces/Time")
+        assert isinstance(now_inst, TimeMsg)
         self.assertTrue("sec" in now_inst.get_fields_and_field_types())
         self.assertTrue("nanosec" in now_inst.get_fields_and_field_types())
 
-        msg = {"sec": 3, "nanosec": 5}
+        msg: dict[str, Any] = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Time")
 
         msg = {"times": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
@@ -208,15 +223,15 @@ class TestMessageConversion(unittest.TestCase):
         )
         self.assertEqual(inst1, inst2)
 
-    def test_duration_msg(self):
-        msg = {"sec": 3, "nanosec": 5}
+    def test_duration_msg(self) -> None:
+        msg: dict[str, Any] = {"sec": 3, "nanosec": 5}
         self.do_test(msg, "builtin_interfaces/Duration")
 
         msg = {"durations": [{"sec": 3, "nanosec": 5}, {"sec": 2, "nanosec": 7}]}
         self.do_test(msg, "rosbridge_test_msgs/TestDurationArray")
 
-    def test_header_msg(self):
-        msg = {
+    def test_header_msg(self) -> None:
+        msg: dict[str, Any] = {
             "stamp": {"sec": 12347, "nanosec": 322304},
             "frame_id": "2394dnfnlcx;v[p234j]",
         }
@@ -229,7 +244,7 @@ class TestMessageConversion(unittest.TestCase):
         msg = {"header": [msg["header"], msg["header"], msg["header"]]}
         self.do_test(msg, "rosbridge_test_msgs/TestHeaderArray")
 
-    def test_assorted_msgs(self):
+    def test_assorted_msgs(self) -> None:
         assortedmsgs = [
             "geometry_msgs/Pose",
             "action_msgs/GoalStatus",
@@ -253,10 +268,11 @@ class TestMessageConversion(unittest.TestCase):
             c.populate_instance(msg, inst2)
             self.assertEqual(inst, inst2)
 
-    def test_int8array(self):
-        def test_int8_msg(rostype, data):
+    def test_int8array(self) -> None:
+        def test_int8_msg(rostype: str, data: list[int] | str) -> Sequence:
             msg = {"data": data}
             inst = ros_loader.get_message_instance(rostype)
+            assert hasattr(inst, "data")
             c.populate_instance(msg, inst)
             self.validate_instance(inst)
             return inst.data
@@ -287,10 +303,11 @@ class TestMessageConversion(unittest.TestCase):
             ret = test_int8_msg(rostype, b64str_int8s)
             np.testing.assert_array_equal(ret, np.array(int8s))
 
-    def test_float32array(self):
-        def test_float32_msg(rostype, data):
+    def test_float32array(self) -> None:
+        def test_float32_msg(rostype: str, data: list[float] | list[int]) -> Sequence:
             msg = {"data": data}
             inst = ros_loader.get_message_instance(rostype)
+            assert hasattr(inst, "data")
             c.populate_instance(msg, inst)
             self.validate_instance(inst)
             return inst.data
@@ -322,10 +339,11 @@ class TestMessageConversion(unittest.TestCase):
             np.testing.assert_array_equal(ret, np.array(ints))
 
     # Test a float32 array with a length with non-numeric characters in it
-    def test_float32_complexboundedarray(self):
-        def test_nestedboundedarray_msg(rostype, data):
+    def test_float32_complexboundedarray(self) -> None:
+        def test_nestedboundedarray_msg(rostype: str, data: list[float]) -> array.array:
             msg = {"data": {"data": data}}
             inst = ros_loader.get_message_instance(rostype)
+            assert hasattr(inst, "data")
             c.populate_instance(msg, inst)
             self.validate_instance(inst)
             return inst.data

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -356,3 +356,6 @@ class TestMessageConversion(unittest.TestCase):
             ret = test_nestedboundedarray_msg(rostype, floats)
 
             self.assertEqual(c._from_inst(ret, rostype), {"data": floats})
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -357,5 +357,6 @@ class TestMessageConversion(unittest.TestCase):
 
             self.assertEqual(c._from_inst(ret, rostype), {"data": floats})
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/rosbridge_library/test/internal/test_outgoing_message.py
+++ b/rosbridge_library/test/internal/test_outgoing_message.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import unittest
 
 from std_msgs.msg import String

--- a/rosbridge_library/test/internal/test_outgoing_message.py
+++ b/rosbridge_library/test/internal/test_outgoing_message.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import unittest
 
 from std_msgs.msg import String
@@ -26,3 +26,7 @@ class TestOutgoingMessage(unittest.TestCase):
 
         again = outgoing.get_cbor_values()
         self.assertTrue(result is again)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rosbridge_library/test/internal/test_outgoing_message.py
+++ b/rosbridge_library/test/internal/test_outgoing_message.py
@@ -7,7 +7,7 @@ from rosbridge_library.internal.outgoing_message import OutgoingMessage
 
 
 class TestOutgoingMessage(unittest.TestCase):
-    def test_json_values(self):
+    def test_json_values(self) -> None:
         msg = String(data="foo")
         outgoing = OutgoingMessage(msg)
 
@@ -17,7 +17,7 @@ class TestOutgoingMessage(unittest.TestCase):
         again = outgoing.get_json_values()
         self.assertTrue(result is again)
 
-    def test_cbor_values(self):
+    def test_cbor_values(self) -> None:
         msg = String(data="foo")
         outgoing = OutgoingMessage(msg)
 

--- a/rosbridge_library/test/internal/test_ros_loader.py
+++ b/rosbridge_library/test/internal/test_ros_loader.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import unittest
 
 from rosidl_runtime_py.utilities import get_message

--- a/rosbridge_library/test/internal/test_ros_loader.py
+++ b/rosbridge_library/test/internal/test_ros_loader.py
@@ -10,7 +10,7 @@ class TestROSLoader(unittest.TestCase):
     #################
     # Message Tests #
     #################
-    def test_bad_msg_names(self):
+    def test_bad_msg_names(self) -> None:
         bad = [
             "",
             "/",
@@ -37,7 +37,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidTypeStringException, ros_loader.get_message_instance, x
             )
 
-    def test_irregular_msg_names(self):
+    def test_irregular_msg_names(self) -> None:
         irregular = [
             "std_msgs//String",
             "//std_msgs/String",
@@ -53,7 +53,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_message_class(x), None)
             self.assertNotEqual(ros_loader.get_message_instance(x), None)
 
-    def test_std_msg_names(self):
+    def test_std_msg_names(self) -> None:
         stdmsgs = [
             "std_msgs/Bool",
             "std_msgs/Byte",
@@ -90,7 +90,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(inst, None)
             self.assertEqual(get_message(x), type(inst))
 
-    def test_msg_cache(self):
+    def test_msg_cache(self) -> None:
         stdmsgs = [
             "std_msgs/Bool",
             "std_msgs/Byte",
@@ -128,7 +128,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertEqual(get_message(x), type(inst))
             self.assertTrue(x in ros_loader._loaded_msgs)
 
-    def test_assorted_msg_names(self):
+    def test_assorted_msg_names(self) -> None:
         assortedmsgs = [
             "geometry_msgs/Pose",
             "action_msgs/GoalStatus",
@@ -149,7 +149,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(inst, None)
             self.assertEqual(get_message(x), type(inst))
 
-    def test_invalid_msg_names_primitives(self):
+    def test_invalid_msg_names_primitives(self) -> None:
         invalid = [
             "bool",
             "int8",
@@ -176,7 +176,7 @@ class TestROSLoader(unittest.TestCase):
                 x,
             )
 
-    def test_nonexistent_package_names(self):
+    def test_nonexistent_package_names(self) -> None:
         nonexistent = [
             "wangle_msgs/Jam",
             "whistleblower_msgs/Document",
@@ -188,7 +188,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertRaises(ros_loader.InvalidModuleException, ros_loader.get_message_class, x)
             self.assertRaises(ros_loader.InvalidModuleException, ros_loader.get_message_instance, x)
 
-    def test_packages_without_msgs(self):
+    def test_packages_without_msgs(self) -> None:
         no_msgs = [
             "roslib/Time",
             "roslib/Duration",
@@ -199,7 +199,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertRaises(ros_loader.InvalidModuleException, ros_loader.get_message_class, x)
             self.assertRaises(ros_loader.InvalidModuleException, ros_loader.get_message_instance, x)
 
-    def test_nonexistent_msg_class_names(self):
+    def test_nonexistent_msg_class_names(self) -> None:
         nonexistent = [
             "rcl_interfaces/Time",
             "rcl_interfaces/Duration",
@@ -215,7 +215,7 @@ class TestROSLoader(unittest.TestCase):
     #################
     # Service Tests #
     #################
-    def test_bad_service_names(self):
+    def test_bad_service_names(self) -> None:
         bad = [
             "",
             "/",
@@ -248,7 +248,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidTypeStringException, ros_loader.get_service_response_instance, x
             )
 
-    def test_irregular_service_names(self):
+    def test_irregular_service_names(self) -> None:
         irregular = [
             "rcl_interfaces//GetParameters",
             "/rcl_interfaces/GetParameters/",
@@ -265,7 +265,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_service_request_instance(x), None)
             self.assertNotEqual(ros_loader.get_service_response_instance(x), None)
 
-    def test_common_service_names(self):
+    def test_common_service_names(self) -> None:
         common = [
             "rcl_interfaces/GetParameters",
             "rcl_interfaces/SetParameters",
@@ -281,7 +281,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_service_request_instance(x), None)
             self.assertNotEqual(ros_loader.get_service_response_instance(x), None)
 
-    def test_srv_cache(self):
+    def test_srv_cache(self) -> None:
         common = [
             "rcl_interfaces/GetParameters",
             "rcl_interfaces/SetParameters",
@@ -298,7 +298,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_service_response_instance(x), None)
             self.assertTrue(x in ros_loader._loaded_srvs)
 
-    def test_packages_without_srvs(self):
+    def test_packages_without_srvs(self) -> None:
         no_msgs = ["roslib/A", "roslib/B", "roslib/C", "std_msgs/CuriousSrv"]
         for x in no_msgs:
             self.assertRaises(ros_loader.InvalidModuleException, ros_loader.get_service_class, x)
@@ -309,7 +309,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidModuleException, ros_loader.get_service_response_instance, x
             )
 
-    def test_nonexistent_service_package_names(self):
+    def test_nonexistent_service_package_names(self) -> None:
         nonexistent = [
             "butler_srvs/FetchDrink",
             "money_srvs/MoreMoney",
@@ -325,7 +325,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidModuleException, ros_loader.get_service_response_instance, x
             )
 
-    def test_nonexistent_service_class_names(self):
+    def test_nonexistent_service_class_names(self) -> None:
         nonexistent = [
             "std_srvs/Reboot",
             "std_srvs/Full",
@@ -343,7 +343,7 @@ class TestROSLoader(unittest.TestCase):
     ################
     # Action Tests #
     ################
-    def test_bad_action_names(self):
+    def test_bad_action_names(self) -> None:
         bad = [
             "",
             "/",
@@ -377,7 +377,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidTypeStringException, ros_loader.get_action_result_instance, x
             )
 
-    def test_irregular_action_names(self):
+    def test_irregular_action_names(self) -> None:
         irregular = [
             "example_interfaces//Fibonacci",
             "/example_interfaces/Fibonacci/",
@@ -395,7 +395,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_action_feedback_instance(x), None)
             self.assertNotEqual(ros_loader.get_action_result_instance(x), None)
 
-    def test_common_action_names(self):
+    def test_common_action_names(self) -> None:
         common = [
             "control_msgs/FollowJointTrajectory",
             "tf2_msgs/LookupTransform",
@@ -407,7 +407,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_action_feedback_instance(x), None)
             self.assertNotEqual(ros_loader.get_action_result_instance(x), None)
 
-    def test_action_cache(self):
+    def test_action_cache(self) -> None:
         common = [
             "control_msgs/FollowJointTrajectory",
             "tf2_msgs/LookupTransform",
@@ -420,7 +420,7 @@ class TestROSLoader(unittest.TestCase):
             self.assertNotEqual(ros_loader.get_action_result_instance(x), None)
             self.assertTrue(x in ros_loader._loaded_actions)
 
-    def test_packages_without_actions(self):
+    def test_packages_without_actions(self) -> None:
         no_msgs = ["roslib/A", "roslib/B", "roslib/C", "std_msgs/CuriousSrv"]
         for x in no_msgs:
             self.assertRaises(ros_loader.InvalidModuleException, ros_loader.get_action_class, x)
@@ -434,7 +434,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidModuleException, ros_loader.get_action_result_instance, x
             )
 
-    def test_nonexistent_action_package_names(self):
+    def test_nonexistent_action_package_names(self) -> None:
         nonexistent = [
             "butler_srvs/SetTable",
             "money_srvs/WithdrawMoreMoney",
@@ -453,7 +453,7 @@ class TestROSLoader(unittest.TestCase):
                 ros_loader.InvalidModuleException, ros_loader.get_action_result_instance, x
             )
 
-    def test_nonexistent_action_class_names(self):
+    def test_nonexistent_action_class_names(self) -> None:
         nonexistent = [
             "control_msgs/ControlFusionReactor",
             "tf2_msgs/GetDualQuaternionRepresentation",

--- a/rosbridge_library/test/internal/test_ros_loader.py
+++ b/rosbridge_library/test/internal/test_ros_loader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import unittest
 
 from rosidl_runtime_py.utilities import get_message

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -31,6 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
 
 import sys
 import time

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -111,7 +111,7 @@ class RosbridgeWebsocketNode(Node):
         if keyfile == "":
             keyfile = None
 
-        port = self.declare_parameter("port", 9090).value
+        port: int = self.declare_parameter("port", 9090).value
         if "--port" in sys.argv:
             idx = sys.argv.index("--port") + 1
             if idx < len(sys.argv):
@@ -119,7 +119,7 @@ class RosbridgeWebsocketNode(Node):
             else:
                 print("--port argument provided without a value.")
                 sys.exit(-1)
-        address = self.declare_parameter("address", "").value
+        address: str = self.declare_parameter("address", "").value
         if "--address" in sys.argv:
             idx = sys.argv.index("--address") + 1
             if idx < len(sys.argv):
@@ -128,7 +128,7 @@ class RosbridgeWebsocketNode(Node):
                 print("--address argument provided without a value.")
                 sys.exit(-1)
 
-        url_path = self.declare_parameter("url_path", "/").value
+        url_path: str = self.declare_parameter("url_path", "/").value
         if "--url_path" in sys.argv:
             idx = sys.argv.index("--url_path") + 1
             if idx < len(sys.argv):
@@ -137,7 +137,9 @@ class RosbridgeWebsocketNode(Node):
                 print("--url_path argument provided without a value.")
                 sys.exit(-1)
 
-        retry_startup_delay = self.declare_parameter("retry_startup_delay", 2.0).value  # seconds.
+        retry_startup_delay: float = self.declare_parameter(
+            "retry_startup_delay", 2.0
+        ).value  # seconds.
         if "--retry_startup_delay" in sys.argv:
             idx = sys.argv.index("--retry_startup_delay") + 1
             if idx < len(sys.argv):
@@ -212,7 +214,7 @@ class RosbridgeWebsocketNode(Node):
             "unregister_timeout", RosbridgeWebSocket.unregister_timeout
         ).value
 
-        bson_only_mode = self.declare_parameter("bson_only_mode", False).value
+        bson_only_mode: bool = self.declare_parameter("bson_only_mode", False).value
 
         RosbridgeWebSocket.client_manager = ClientManager(self)
 
@@ -229,11 +231,11 @@ class RosbridgeWebsocketNode(Node):
         RosbridgeWebSocket.client_count_pub.publish(Int32(data=0))
 
         # Get the glob strings and parse them as arrays.
-        topics_glob = self.declare_parameter("topics_glob", "").value
+        topics_glob: str = self.declare_parameter("topics_glob", "").value
 
-        services_glob = self.declare_parameter("services_glob", "").value
+        services_glob: str = self.declare_parameter("services_glob", "").value
 
-        params_glob = self.declare_parameter("params_glob", "").value
+        params_glob: str = self.declare_parameter("params_glob", "").value
 
         RosbridgeWebSocket.topics_glob = [
             element.strip().strip("'")

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -34,6 +34,7 @@
 
 import sys
 import time
+from typing import TYPE_CHECKING, cast
 
 import rclpy
 from rclpy.node import Node
@@ -52,17 +53,20 @@ from rosbridge_library.capabilities.subscribe import Subscribe
 from rosbridge_library.capabilities.unadvertise_service import UnadvertiseService
 from rosbridge_server import ClientManager, RosbridgeWebSocket
 
+if TYPE_CHECKING:
+    from tornado.routing import _RuleList
 
-def start_hook():
+
+def start_hook() -> None:
     IOLoop.instance().start()
 
 
-def shutdown_hook():
+def shutdown_hook() -> None:
     IOLoop.instance().stop()
 
 
 class RosbridgeWebsocketNode(Node):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("rosbridge_websocket")
 
         RosbridgeWebSocket.node_handle = self
@@ -99,8 +103,8 @@ class RosbridgeWebsocketNode(Node):
 
         # Server and SSL options
         # SSL options, cannot set default to None - rclpy throws warning
-        certfile = self.declare_parameter("certfile", "").value
-        keyfile = self.declare_parameter("keyfile", "").value
+        certfile: str | None = self.declare_parameter("certfile", "").value
+        keyfile: str | None = self.declare_parameter("keyfile", "").value
         # if not set, set to None
         if certfile == "":
             certfile = None
@@ -150,7 +154,12 @@ class RosbridgeWebsocketNode(Node):
         if url_path != "/":
             handlers = [(rf"{url_path}", RosbridgeWebSocket)]
 
-        application = Application(handlers, **tornado_settings)
+        application = Application(
+            handlers=cast("_RuleList", handlers),
+            default_host=None,
+            transforms=None,
+            **tornado_settings,
+        )
 
         connected = False
         while not connected and self.context.ok():
@@ -171,7 +180,7 @@ class RosbridgeWebsocketNode(Node):
                 )
                 time.sleep(retry_startup_delay)
 
-    def protocol_parameter_handling(self):
+    def protocol_parameter_handling(self) -> None:
         RosbridgeWebSocket.use_compression = self.declare_parameter("use_compression", False).value
 
         RosbridgeWebSocket.call_services_in_new_thread = self.declare_parameter(
@@ -195,7 +204,7 @@ class RosbridgeWebsocketNode(Node):
             "delay_between_messages", RosbridgeWebSocket.delay_between_messages
         ).value
 
-        RosbridgeWebSocket.max_message_size = self.declare_parameter(
+        RosbridgeWebSocket.max_message_size = self.declare_parameter(  # type: ignore[method-assign,call-overload]
             "max_message_size", RosbridgeWebSocket.max_message_size
         ).value
 
@@ -262,7 +271,7 @@ class RosbridgeWebsocketNode(Node):
             idx = sys.argv.index("--max_message_size") + 1
             if idx < len(sys.argv):
                 value = sys.argv[idx]
-                RosbridgeWebSocket.max_message_size = int(value)
+                RosbridgeWebSocket.max_message_size = int(value)  # type: ignore[method-assign,assignment]
             else:
                 print("--max_message_size argument provided without a value. (can be <Integer>)")
                 sys.exit(-1)
@@ -332,17 +341,14 @@ class RosbridgeWebsocketNode(Node):
         CallService.services_glob = RosbridgeWebSocket.services_glob
 
 
-def main(args=None):
-    if args is None:
-        args = sys.argv
-
-    rclpy.init(args=args)
+def main() -> None:
+    rclpy.init()
     node = RosbridgeWebsocketNode()
 
     executor = rclpy.executors.SingleThreadedExecutor()
     executor.add_node(node)
 
-    def spin_ros():
+    def spin_ros() -> None:
         if not rclpy.ok():
             shutdown_hook()
             return

--- a/rosbridge_server/src/rosbridge_server/client_manager.py
+++ b/rosbridge_server/src/rosbridge_server/client_manager.py
@@ -29,14 +29,19 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import threading
+from typing import TYPE_CHECKING
 
 from rclpy.clock import ROSClock
-from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import Int32
 
 from rosbridge_msgs.msg import ConnectedClient, ConnectedClients
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
 
 
 class ClientManager:

--- a/rosbridge_server/src/rosbridge_server/client_manager.py
+++ b/rosbridge_server/src/rosbridge_server/client_manager.py
@@ -32,6 +32,7 @@
 import threading
 
 from rclpy.clock import ROSClock
+from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from std_msgs.msg import Int32
 
@@ -39,7 +40,7 @@ from rosbridge_msgs.msg import ConnectedClient, ConnectedClients
 
 
 class ClientManager:
-    def __init__(self, node_handle):
+    def __init__(self, node_handle: Node) -> None:
         qos = QoSProfile(
             depth=1,
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
@@ -56,16 +57,16 @@ class ClientManager:
 
         self._lock = threading.Lock()
         self._client_count = 0
-        self._clients = {}
+        self._clients: dict[str, ConnectedClient] = {}
         self.__publish()
 
-    def __publish(self):
+    def __publish(self) -> None:
         msg = ConnectedClients()
         msg.clients = list(self._clients.values())
         self._conn_clients_pub.publish(msg)
         self._client_count_pub.publish(Int32(data=len(msg.clients)))
 
-    def add_client(self, client_id, ip_address):
+    def add_client(self, client_id: str, ip_address: str) -> None:
         with self._lock:
             client = ConnectedClient()
             client.ip_address = ip_address
@@ -73,7 +74,7 @@ class ClientManager:
             self._clients[client_id] = client
             self.__publish()
 
-    def remove_client(self, client_id, ip_address):  # noqa: ARG002
+    def remove_client(self, client_id: str, ip_address: str) -> None:  # noqa: ARG002
         with self._lock:
             self._clients.pop(client_id, None)
             self.__publish()

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -38,7 +38,7 @@ import traceback
 import uuid
 from collections import deque
 from functools import partial, wraps
-from typing import Callable, Generic, ParamSpec, TypeVar
+from typing import Callable, ParamSpec, TypeVar
 
 from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -191,17 +191,15 @@ class RosbridgeWebSocket(WebSocketHandler):
         )
         self.incoming_queue.finish()
 
-    def send_message(
-        self, message: bson.Binary | bytearray | str, compression: str = "none"
-    ) -> None:
-        if isinstance(message, bson.Binary) or compression in ["cbor", "cbor-raw"]:
+    def send_message(self, message: bson.BSON | bytearray | str, compression: str = "none") -> None:
+        if isinstance(message, bson.BSON) or compression in ["cbor", "cbor-raw"]:
             binary = True
         else:
             binary = False
 
         _io_loop.add_callback(partial(self.prewrite_message, message, binary))
 
-    async def prewrite_message(self, message: bson.Binary | bytearray | str, binary: bool) -> None:
+    async def prewrite_message(self, message: bson.BSON | bytearray | str, binary: bool) -> None:
         assert self.node_handle is not None
         cls = self.__class__
         try:

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -30,12 +30,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import sys
 import threading
 import traceback
 import uuid
 from collections import deque
 from functools import partial, wraps
+from typing import Callable, Generic, ParamSpec, TypeVar
 
 from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
@@ -47,17 +50,21 @@ from rosbridge_library.util import bson
 _io_loop = IOLoop.instance()
 
 
-def _log_exception():
+def _log_exception() -> None:
     """Log the most recent exception to ROS."""
     exc = traceback.format_exception(*sys.exc_info())
     RosbridgeWebSocket.node_handle.get_logger().error("".join(exc))
 
 
-def log_exceptions(f):
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def log_exceptions(f: Callable[P, R]) -> Callable[P, R]:
     """Log exceptions to ROS."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return f(*args, **kwargs)
         except Exception:
@@ -75,16 +82,16 @@ class IncomingQueue(threading.Thread):
     and vice versa.
     """
 
-    def __init__(self, protocol):
+    def __init__(self, protocol: RosbridgeProtocol) -> None:
         threading.Thread.__init__(self)
         self.daemon = True
-        self.queue = deque()
+        self.queue: deque[str] = deque()
         self.protocol = protocol
 
         self.cond = threading.Condition()
         self._finished = False
 
-    def finish(self):
+    def finish(self) -> None:
         """Clear the queue and do not accept further messages."""
         with self.cond:
             self._finished = True
@@ -92,12 +99,12 @@ class IncomingQueue(threading.Thread):
                 self.queue.popleft()
             self.cond.notify()
 
-    def push(self, msg):
+    def push(self, msg: str) -> None:
         with self.cond:
             self.queue.append(msg)
             self.cond.notify()
 
-    def run(self):
+    def run(self) -> None:
         while True:
             with self.cond:
                 if len(self.queue) == 0 and not self._finished:
@@ -127,8 +134,13 @@ class RosbridgeWebSocket(WebSocketHandler):
     bson_only_mode = False
     node_handle = None
 
+    client_id: uuid.UUID
+    protocol: RosbridgeProtocol
+    incoming_queue: IncomingQueue
+
     @log_exceptions
-    def open(self):
+    def open(self, *args: str, **kwargs: str) -> None:  # noqa: ARG002
+        assert self.node_handle is not None
         cls = self.__class__
         parameters = {
             "fragment_timeout": cls.fragment_timeout,
@@ -159,13 +171,14 @@ class RosbridgeWebSocket(WebSocketHandler):
         )
 
     @log_exceptions
-    def on_message(self, message):
+    def on_message(self, message: str | bytes) -> None:
         if isinstance(message, bytes):
             message = message.decode("utf-8")
         self.incoming_queue.push(message)
 
     @log_exceptions
-    def on_close(self):
+    def on_close(self) -> None:
+        assert self.node_handle is not None
         cls = self.__class__
         cls.clients_connected -= 1
         if cls.client_manager:
@@ -175,15 +188,18 @@ class RosbridgeWebSocket(WebSocketHandler):
         )
         self.incoming_queue.finish()
 
-    def send_message(self, message, compression="none"):
-        if isinstance(message, bson.BSON) or compression in ["cbor", "cbor-raw"]:
+    def send_message(
+        self, message: bson.Binary | bytearray | str, compression: str = "none"
+    ) -> None:
+        if isinstance(message, bson.Binary) or compression in ["cbor", "cbor-raw"]:
             binary = True
         else:
             binary = False
 
         _io_loop.add_callback(partial(self.prewrite_message, message, binary))
 
-    async def prewrite_message(self, message, binary):
+    async def prewrite_message(self, message: bson.Binary | bytearray | str, binary: bool) -> None:
+        assert self.node_handle is not None
         cls = self.__class__
         try:
             await self.write_message(message, binary)
@@ -202,11 +218,11 @@ class RosbridgeWebSocket(WebSocketHandler):
             _log_exception()
 
     @log_exceptions
-    def check_origin(self, origin):  # noqa: ARG002
+    def check_origin(self, origin: str) -> bool:  # noqa: ARG002
         return True
 
     @log_exceptions
-    def get_compression_options(self):
+    def get_compression_options(self) -> dict | None:
         # If this method returns None (the default), compression will be disabled.
         # If it returns a dict (even an empty one), it will be enabled.
         cls = self.__class__

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -38,7 +38,7 @@ import traceback
 import uuid
 from collections import deque
 from functools import partial, wraps
-from typing import Callable, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
@@ -46,6 +46,9 @@ from tornado.websocket import WebSocketClosedError, WebSocketHandler
 
 from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
 from rosbridge_library.util import bson
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _io_loop = IOLoop.instance()
 

--- a/rosbridge_server/test/websocket/advertise_action.test.py
+++ b/rosbridge_server/test/websocket/advertise_action.test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
 
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
@@ -11,12 +12,14 @@ from twisted.python import log
 
 sys.path.append(str(Path(__file__).parent))  # enable importing from common.py in this directory
 
-from typing import TYPE_CHECKING
-
 import common
 from common import expect_messages, websocket_test
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.action.client import ClientGoalHandle
     from rclpy.node import Node
     from rclpy.task import Future
 
@@ -29,20 +32,24 @@ class TestAdvertiseAction(unittest.TestCase):
     goal1_result_future: Future | None
     goal2_result_future: Future | None
 
-    def goal1_response_callback(self, future):
+    def goal1_response_callback(self, future: Future[ClientGoalHandle]) -> None:
         goal_handle = future.result()
+        assert goal_handle is not None
         if not goal_handle.accepted:
             return
         self.goal1_result_future = goal_handle.get_result_async()
 
-    def goal2_response_callback(self, future):
+    def goal2_response_callback(self, future: Future[ClientGoalHandle]) -> None:
         goal_handle = future.result()
+        assert goal_handle is not None
         if not goal_handle.accepted:
             return
         self.goal2_result_future = goal_handle.get_result_async()
 
     @websocket_test
-    async def test_two_concurrent_calls(self, node: Node, make_client):
+    async def test_two_concurrent_calls(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         ws_client = await make_client()
         ws_client.sendJson(
             {
@@ -51,14 +58,20 @@ class TestAdvertiseAction(unittest.TestCase):
                 "type": "example_interfaces/Fibonacci",
             }
         )
-        client: ActionClient = ActionClient(node, Fibonacci, "/test_fibonacci_action")
+        client: ActionClient = ActionClient(
+            node,
+            Fibonacci,  # type: ignore[arg-type]
+            "/test_fibonacci_action",
+        )
         client.wait_for_server()
 
+        requests_future: Future[list[dict[str, Any]]]
         requests_future, ws_client.message_handler = expect_messages(
             2, "WebSocket", node.get_logger()
         )
-        assert node.executor is not None
-        requests_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        requests_future.add_done_callback(lambda _: executor.wake())
 
         self.goal1_result_future = None
         goal1_future = client.send_goal_async(Fibonacci.Goal(order=3))
@@ -69,6 +82,7 @@ class TestAdvertiseAction(unittest.TestCase):
         goal2_future.add_done_callback(self.goal2_response_callback)
 
         requests = await requests_future
+        assert requests is not None and len(requests) == 2
 
         self.assertEqual(requests[0]["op"], "send_action_goal")
         self.assertEqual(requests[0]["action"], "/test_fibonacci_action")

--- a/rosbridge_server/test/websocket/advertise_action.test.py
+++ b/rosbridge_server/test/websocket/advertise_action.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
@@ -16,7 +16,7 @@ import common
 from common import expect_messages, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.action.client import ClientGoalHandle

--- a/rosbridge_server/test/websocket/advertise_action_feedback.test.py
+++ b/rosbridge_server/test/websocket/advertise_action_feedback.test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
 
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
@@ -11,14 +12,17 @@ from twisted.python import log
 
 sys.path.append(str(Path(__file__).parent))  # enable importing from common.py in this directory
 
-from typing import TYPE_CHECKING
-
 import common
 from common import expect_messages, websocket_test
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.action.client import ClientGoalHandle
     from rclpy.node import Node
     from rclpy.task import Future
+    from rclpy.type_support import FeedbackMessage
 
 log.startLogging(sys.stderr)
 
@@ -27,19 +31,22 @@ generate_test_description = common.generate_test_description
 
 class TestActionFeedback(unittest.TestCase):
     goal_result_future: Future | None
+    latest_feedback: FeedbackMessage | None
 
-    def goal_response_callback(self, future: Future):
+    def goal_response_callback(self, future: Future[ClientGoalHandle]) -> None:
         goal_handle = future.result()
         assert goal_handle is not None
         if not goal_handle.accepted:
             return
         self.goal_result_future = goal_handle.get_result_async()
 
-    def feedback_callback(self, msg):
+    def feedback_callback(self, msg: FeedbackMessage) -> None:
         self.latest_feedback = msg
 
     @websocket_test
-    async def test_feedback(self, node: Node, make_client):
+    async def test_feedback(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         ws_client = await make_client()
         ws_client.sendJson(
             {
@@ -48,14 +55,20 @@ class TestActionFeedback(unittest.TestCase):
                 "type": "example_interfaces/Fibonacci",
             }
         )
-        client: ActionClient = ActionClient(node, Fibonacci, "/test_fibonacci_action")
+        client: ActionClient = ActionClient(
+            node,
+            Fibonacci,  # type: ignore[arg-type]
+            "/test_fibonacci_action",
+        )
         client.wait_for_server()
 
+        requests_future: Future[list[dict[str, Any]]]
         requests_future, ws_client.message_handler = expect_messages(
             1, "WebSocket", node.get_logger()
         )
-        assert node.executor is not None
-        requests_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        requests_future.add_done_callback(lambda _: executor.wake())
 
         self.goal_result_future = None
         goal_future = client.send_goal_async(
@@ -65,6 +78,7 @@ class TestActionFeedback(unittest.TestCase):
         goal_future.add_done_callback(self.goal_response_callback)
 
         requests = await requests_future
+        assert requests is not None and len(requests) == 1
 
         self.assertEqual(requests[0]["op"], "send_action_goal")
         self.assertEqual(requests[0]["action"], "/test_fibonacci_action")

--- a/rosbridge_server/test/websocket/advertise_action_feedback.test.py
+++ b/rosbridge_server/test/websocket/advertise_action_feedback.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
@@ -16,7 +16,7 @@ import common
 from common import expect_messages, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.action.client import ClientGoalHandle

--- a/rosbridge_server/test/websocket/advertise_service.test.py
+++ b/rosbridge_server/test/websocket/advertise_service.test.py
@@ -1,14 +1,21 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
-from rclpy.node import Node
 from std_srvs.srv import SetBool
 from twisted.python import log
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
     from rclpy.client import Client
+    from rclpy.node import Node
+    from rclpy.task import Future
+
 
 sys.path.append(str(Path(__file__).parent))  # enable importing from common.py in this directory
 
@@ -22,7 +29,9 @@ generate_test_description = common.generate_test_description
 
 class TestAdvertiseService(unittest.TestCase):
     @websocket_test
-    async def test_two_concurrent_calls(self, node: Node, make_client):
+    async def test_two_concurrent_calls(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         ws_client = await make_client()
         ws_client.sendJson(
             {
@@ -31,20 +40,25 @@ class TestAdvertiseService(unittest.TestCase):
                 "service": "/test_service",
             }
         )
-        client: Client = node.create_client(SetBool, "/test_service")
+        client: Client = node.create_client(
+            SetBool,  # type: ignore[arg-type]
+            "/test_service",
+        )
         client.wait_for_service()
 
+        requests_future: Future[list[dict[str, Any]]]
         requests_future, ws_client.message_handler = expect_messages(
             2, "WebSocket", node.get_logger()
         )
-        assert node.executor is not None
-        requests_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        requests_future.add_done_callback(lambda _: executor.wake())
 
         response1_future = client.call_async(SetBool.Request(data=True))
         response2_future = client.call_async(SetBool.Request(data=False))
 
         requests = await requests_future
-        self.assertEqual(len(requests), 2)
+        assert requests is not None and len(requests) == 2
 
         self.assertEqual(requests[0]["op"], "call_service")
         self.assertEqual(requests[0]["service"], "/test_service")

--- a/rosbridge_server/test/websocket/advertise_service.test.py
+++ b/rosbridge_server/test/websocket/advertise_service.test.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from std_srvs.srv import SetBool
 from twisted.python import log
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.client import Client

--- a/rosbridge_server/test/websocket/advertise_service_duplicate.test.py
+++ b/rosbridge_server/test/websocket/advertise_service_duplicate.test.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from std_srvs.srv import SetBool
 from twisted.python import log
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.client import Client

--- a/rosbridge_server/test/websocket/advertise_service_duplicate.test.py
+++ b/rosbridge_server/test/websocket/advertise_service_duplicate.test.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
-from rclpy.node import Node
 from std_srvs.srv import SetBool
 from twisted.python import log
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
     from rclpy.client import Client
+    from rclpy.node import Node
+
 
 sys.path.append(str(Path(__file__).parent))  # enable importing from common.py in this directory
 
@@ -22,7 +28,9 @@ generate_test_description = common.generate_test_description
 
 class TestAdvertiseService(unittest.TestCase):
     @websocket_test
-    async def test_double_advertise(self, node: Node, make_client):
+    async def test_double_advertise(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         ws_client1 = await make_client()
         ws_client1.sendJson(
             {
@@ -31,14 +39,18 @@ class TestAdvertiseService(unittest.TestCase):
                 "service": "/test_service",
             }
         )
-        client: Client = node.create_client(SetBool, "/test_service")
+        client: Client = node.create_client(
+            SetBool,  # type: ignore[arg-type]
+            "/test_service",
+        )
         client.wait_for_service()
 
         requests1_future, ws_client1.message_handler = expect_messages(
             1, "WebSocket 1", node.get_logger()
         )
-        assert node.executor is not None
-        requests1_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        requests1_future.add_done_callback(lambda _: executor.wake())
 
         client.call_async(SetBool.Request(data=True))
 
@@ -72,7 +84,7 @@ class TestAdvertiseService(unittest.TestCase):
         requests2_future, ws_client2.message_handler = expect_messages(
             1, "WebSocket 2", node.get_logger()
         )
-        requests2_future.add_done_callback(lambda _: node.executor.wake())
+        requests2_future.add_done_callback(lambda _: executor.wake())
 
         response2_future = client.call_async(SetBool.Request(data=False))
 

--- a/rosbridge_server/test/websocket/best_effort_publisher.test.py
+++ b/rosbridge_server/test/websocket/best_effort_publisher.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from std_msgs.msg import String
@@ -15,7 +15,7 @@ import common
 from common import expect_messages, sleep, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.node import Node

--- a/rosbridge_server/test/websocket/best_effort_publisher.test.py
+++ b/rosbridge_server/test/websocket/best_effort_publisher.test.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
-from rclpy.node import Node
 from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from std_msgs.msg import String
 from twisted.python import log
@@ -12,6 +14,13 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, sleep, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
@@ -19,7 +28,9 @@ generate_test_description = common.generate_test_description
 
 class TestBestEffortPublisher(unittest.TestCase):
     @websocket_test
-    async def test_best_effort_publisher(self, node: Node, make_client):
+    async def test_best_effort_publisher(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         qos = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
             history=HistoryPolicy.SYSTEM_DEFAULT,
@@ -44,8 +55,9 @@ class TestBestEffortPublisher(unittest.TestCase):
         ws1_completed_future, ws_client1.message_handler = expect_messages(
             1, "WebSocket 1", node.get_logger()
         )
-        assert node.executor is not None
-        ws1_completed_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        ws1_completed_future.add_done_callback(lambda _: executor.wake())
 
         self.assertEqual(
             await ws1_completed_future,

--- a/rosbridge_server/test/websocket/call_service.test.py
+++ b/rosbridge_server/test/websocket/call_service.test.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import sys
 import time
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.node import Node
 from std_srvs.srv import SetBool
 from twisted.python import log
 
@@ -13,6 +15,13 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+    # from rclpy.task import Future
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
@@ -20,23 +29,29 @@ generate_test_description = common.generate_test_description
 
 class TestCallService(unittest.TestCase):
     @websocket_test
-    async def test_one_call(self, node: Node, make_client):
-        def service_cb(req, res):
+    async def test_one_call(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
+        def service_cb(req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
             self.assertTrue(req.data)
             res.success = True
             res.message = "Hello, world!"
             return res
 
         service = node.create_service(
-            SetBool, "/test_service", service_cb, callback_group=ReentrantCallbackGroup()
+            SetBool,  # type: ignore[arg-type]
+            "/test_service",
+            service_cb,
+            callback_group=ReentrantCallbackGroup(),
         )
 
         ws_client = await make_client()
         responses_future, ws_client.message_handler = expect_messages(
             1, "WebSocket", node.get_logger()
         )
-        assert node.executor is not None
-        responses_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        responses_future.add_done_callback(lambda _: executor.wake())
 
         ws_client.sendJson(
             {
@@ -48,7 +63,8 @@ class TestCallService(unittest.TestCase):
         )
 
         responses = await responses_future
-        self.assertEqual(len(responses), 1)
+        assert responses is not None and len(responses) == 1
+
         self.assertEqual(responses[0]["op"], "service_response")
         self.assertEqual(responses[0]["service"], "/test_service")
         self.assertEqual(responses[0]["values"], {"success": True, "message": "Hello, world!"})
@@ -56,7 +72,7 @@ class TestCallService(unittest.TestCase):
 
         node.destroy_service(service)
 
-        def service_long_cb(req, res):
+        def service_long_cb(req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
             time.sleep(0.2)
             self.assertTrue(req.data)
             res.success = True
@@ -64,13 +80,16 @@ class TestCallService(unittest.TestCase):
             return res
 
         service = node.create_service(
-            SetBool, "/test_service_long", service_long_cb, callback_group=ReentrantCallbackGroup()
+            SetBool,  # type: ignore[arg-type]
+            "/test_service_long",
+            service_long_cb,
+            callback_group=ReentrantCallbackGroup(),
         )
 
         responses_future, ws_client.message_handler = expect_messages(
             2, "WebSocket", node.get_logger()
         )
-        responses_future.add_done_callback(lambda _: node.executor.wake())
+        responses_future.add_done_callback(lambda _: executor.wake())
 
         ws_client.sendJson(
             {
@@ -93,7 +112,8 @@ class TestCallService(unittest.TestCase):
         )
 
         responses = await responses_future
-        self.assertEqual(len(responses), 2)
+        assert responses is not None and len(responses) == 2
+
         self.assertEqual(responses[0]["op"], "service_response")
         self.assertEqual(responses[0]["service"], "/test_service_long")
         self.assertEqual(

--- a/rosbridge_server/test/websocket/call_service.test.py
+++ b/rosbridge_server/test/websocket/call_service.test.py
@@ -4,7 +4,7 @@ import sys
 import time
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from rclpy.callback_groups import ReentrantCallbackGroup
 from std_srvs.srv import SetBool
@@ -16,7 +16,7 @@ import common
 from common import expect_messages, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.node import Node

--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -1,14 +1,14 @@
+from __future__ import annotations
+
 import functools
 import json
-from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
-import launch
 import launch_ros
 import rclpy
-import rclpy.task
 from autobahn.twisted.websocket import WebSocketClientFactory, WebSocketClientProtocol
 from launch.launch_description import LaunchDescription
+from launch_testing.actions import ReadyToTest
 from rcl_interfaces.srv import GetParameters
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
@@ -17,7 +17,10 @@ from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from rclpy.client import Client
+    from rclpy.logging import RcutilsLogger
 
 
 class TestClientProtocol(WebSocketClientProtocol):
@@ -25,69 +28,45 @@ class TestClientProtocol(WebSocketClientProtocol):
 
     message_handler: Callable[[Any], None]
 
-    def __init__(self, *args, **kwargs):
-        self.received = []
-        self.connected_future = Future()
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        self.connected_future: Future[None] = Future()
         self.message_handler = lambda _: None
         super().__init__(*args, **kwargs)
 
-    def onOpen(self):
+    def onOpen(self) -> None:
         self.connected_future.set_result(None)
 
-    def sendJson(self, msg_dict, *, times=1):
+    def sendJson(self, msg_dict: dict[str, Any], *, times: int = 1) -> None:
         msg = json.dumps(msg_dict).encode("utf-8")
         for _ in range(times):
-            print(f"WebSocket client sent message: {msg}")
+            print(f"WebSocket client sent message: {msg!r}")
             self.sendMessage(msg)
 
-    def onMessage(self, payload, binary):
+    def onMessage(self, payload: str, binary: bool) -> None:
         print(f"WebSocket client received message: {payload}")
         self.message_handler(payload if binary else json.loads(payload))
 
 
-def _generate_node():
-    try:
-        return launch_ros.actions.Node(
-            executable="rosbridge_websocket",
-            package="rosbridge_server",
-            parameters=[{"port": 0}],
-        )
-    except TypeError:
-        # Deprecated keyword arg node_executable: https://github.com/ros2/launch_ros/pull/140
-        return launch_ros.actions.Node(
-            node_executable="rosbridge_websocket",
-            package="rosbridge_server",
-            parameters=[{"port": 0}],
-        )
+def _generate_node() -> launch_ros.actions.Node:
+    return launch_ros.actions.Node(
+        executable="rosbridge_websocket",
+        package="rosbridge_server",
+        parameters=[{"port": 0}],
+    )
 
 
-try:
-    from launch_testing.actions import ReadyToTest
+def generate_test_description() -> LaunchDescription:
+    """
+    Generate a launch description that runs the websocket server.
 
-    def generate_test_description() -> LaunchDescription:
-        """
-        Generate a launch description that runs the websocket server.
-
-        Re-export this from a test file and use add_launch_test() to run the test.
-        """
-        return LaunchDescription([_generate_node(), ReadyToTest()])
-
-except ImportError:
-
-    def generate_test_description(ready_fn) -> LaunchDescription:  # type: ignore[misc]
-        """
-        Generate a launch description that runs the websocket server.
-
-        Re-export this from a test file and use add_launch_test() to run the test.
-        """
-        return LaunchDescription(
-            [_generate_node(), launch.actions.OpaqueFunction(function=lambda _context: ready_fn())]
-        )
+    Re-export this from a test file and use add_launch_test() to run the test.
+    """
+    return LaunchDescription([_generate_node(), ReadyToTest()])
 
 
 async def get_server_port(node: Node) -> int:
     """Return the port which the WebSocket server is running on."""
-    client: Client = node.create_client(GetParameters, "/rosbridge_websocket/get_parameters")
+    client: Client = node.create_client(GetParameters, "/rosbridge_websocket/get_parameters")  # type: ignore[arg-type]
     try:
         if not client.wait_for_service(5):
             msg = "GetParameters service not available"
@@ -109,7 +88,7 @@ async def connect_to_server(node: Node) -> TestClientProtocol:
     assert executor is not None
     future.add_done_callback(lambda _: executor.wake())
 
-    def connect():
+    def connect() -> None:
         TCP4ClientEndpoint(reactor, "127.0.0.1", port).connect(factory).addCallback(
             future.set_result
         )
@@ -126,16 +105,16 @@ async def connect_to_server(node: Node) -> TestClientProtocol:
 def run_websocket_test(
     node_name: str,
     test_fn: Callable[[Node, Callable[[], Awaitable[TestClientProtocol]]], Awaitable[None]],
-):
+) -> None:
     context = rclpy.Context()
     rclpy.init(context=context)
     executor = SingleThreadedExecutor(context=context)
     node = Node(node_name, context=context)
     executor.add_node(node)
 
-    async def task():
+    async def task() -> None:
         await test_fn(node, lambda: connect_to_server(node))
-        reactor.callFromThread(reactor.stop)
+        reactor.callFromThread(reactor.stop)  # type: ignore[attr-defined]
 
     future = executor.create_task(task)
 
@@ -155,7 +134,7 @@ def sleep(node: Node, duration: float) -> Awaitable[None]:
     """
     future: Future = Future()
 
-    def callback():
+    def callback() -> None:
         future.set_result(None)
         timer.cancel()
         node.destroy_timer(timer)
@@ -164,7 +143,12 @@ def sleep(node: Node, duration: float) -> Awaitable[None]:
     return future
 
 
-def websocket_test(test_fn):
+SelfT = TypeVar("SelfT")
+
+
+def websocket_test(
+    test_fn: Callable[[SelfT, Node, Callable[[], Awaitable[TestClientProtocol]]], Awaitable[None]],
+) -> Callable[[SelfT], None]:
     """
     Decorate tests which use a ROS node and WebSocket server and client.
 
@@ -172,30 +156,35 @@ def websocket_test(test_fn):
     """
 
     @functools.wraps(test_fn)
-    def run_test(self):
+    def run_test(self: SelfT) -> None:
         run_websocket_test(test_fn.__name__, lambda *args: test_fn(self, *args))
 
     return run_test
 
 
-def expect_messages(count: int, description: str, logger):
+MsgT = TypeVar("MsgT")
+
+
+def expect_messages(
+    count: int, description: str, logger: RcutilsLogger
+) -> tuple[Future[list[MsgT]], Callable[[MsgT], None]]:
     """
     Expect a specific number of messages.
 
     Convenience function to create a Future and a message handler function which gathers results
     into a list and waits for the list to have the expected number of items.
     """
-    future: Future = Future()
-    results = []
+    future: Future[list[MsgT]] = Future()
+    results: list[MsgT] = []
 
-    def handler(msg):
+    def handler(msg: MsgT) -> None:
         logger.info(f"Received message on {description}: {msg}")  # noqa: G004
         results.append(msg)
         if len(results) == count:
             logger.info(f"Received all messages on {description}")  # noqa: G004
             future.set_result(results)
         elif len(results) > count:
-            msg = f"Received {len(results)} messages on {description} but expected {count}"
-            raise AssertionError(msg)
+            err_msg = f"Received {len(results)} messages on {description} but expected {count}"
+            raise AssertionError(err_msg)
 
     return future, handler

--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import json
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import launch_ros
 import rclpy
@@ -17,7 +17,7 @@ from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from rclpy.client import Client
     from rclpy.logging import RcutilsLogger

--- a/rosbridge_server/test/websocket/multiple_subscribers.test.py
+++ b/rosbridge_server/test/websocket/multiple_subscribers.test.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
-from rclpy.node import Node
 from std_msgs.msg import String
 from twisted.python import log
 
@@ -11,6 +13,13 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, sleep, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
@@ -18,7 +27,9 @@ generate_test_description = common.generate_test_description
 
 class TestMultipleSubscribers(unittest.TestCase):
     @websocket_test
-    async def test_multiple_subscribers(self, node: Node, make_client):
+    async def test_multiple_subscribers(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         ws_client1 = await make_client()
         ws_client1.sendJson(
             {
@@ -40,12 +51,13 @@ class TestMultipleSubscribers(unittest.TestCase):
         ws1_completed_future, ws_client1.message_handler = expect_messages(
             1, "WebSocket 1", node.get_logger()
         )
-        assert node.executor is not None
-        ws1_completed_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        ws1_completed_future.add_done_callback(lambda _: executor.wake())
         ws2_completed_future, ws_client2.message_handler = expect_messages(
             1, "WebSocket 2", node.get_logger()
         )
-        ws2_completed_future.add_done_callback(lambda _: node.executor.wake())
+        ws2_completed_future.add_done_callback(lambda _: executor.wake())
 
         pub_a = node.create_publisher(String, "/a_topic", 1)
 

--- a/rosbridge_server/test/websocket/multiple_subscribers.test.py
+++ b/rosbridge_server/test/websocket/multiple_subscribers.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from std_msgs.msg import String
 from twisted.python import log
@@ -14,7 +14,7 @@ import common
 from common import expect_messages, sleep, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.node import Node

--- a/rosbridge_server/test/websocket/multiple_subscribers_raw.test.py
+++ b/rosbridge_server/test/websocket/multiple_subscribers_raw.test.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
-from rclpy.node import Node
 from std_msgs.msg import String
 from twisted.python import log
 
@@ -11,6 +13,13 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, sleep, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
@@ -18,7 +27,9 @@ generate_test_description = common.generate_test_description
 
 class TestMultipleSubscribers(unittest.TestCase):
     @websocket_test
-    async def test_multiple_subscribers(self, node: Node, make_client):
+    async def test_multiple_subscribers(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         sub_operation_json = {
             "op": "subscribe",
             "topic": "/a_topic",
@@ -33,12 +44,13 @@ class TestMultipleSubscribers(unittest.TestCase):
         ws1_completed_future, ws_client1.message_handler = expect_messages(
             1, "WebSocket 1", node.get_logger()
         )
-        assert node.executor is not None
-        ws1_completed_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        ws1_completed_future.add_done_callback(lambda _: executor.wake())
         ws2_completed_future, ws_client2.message_handler = expect_messages(
             1, "WebSocket 2", node.get_logger()
         )
-        ws2_completed_future.add_done_callback(lambda _: node.executor.wake())
+        ws2_completed_future.add_done_callback(lambda _: executor.wake())
 
         pub_a = node.create_publisher(String, "/a_topic", 1)
 

--- a/rosbridge_server/test/websocket/multiple_subscribers_raw.test.py
+++ b/rosbridge_server/test/websocket/multiple_subscribers_raw.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from std_msgs.msg import String
 from twisted.python import log
@@ -14,7 +14,7 @@ import common
 from common import expect_messages, sleep, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.node import Node

--- a/rosbridge_server/test/websocket/send_action_goal.test.py
+++ b/rosbridge_server/test/websocket/send_action_goal.test.py
@@ -4,7 +4,7 @@ import sys
 import time
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
@@ -18,7 +18,7 @@ import common
 from common import expect_messages, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.action.server import ServerGoalHandle

--- a/rosbridge_server/test/websocket/send_action_goal.test.py
+++ b/rosbridge_server/test/websocket/send_action_goal.test.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import sys
 import time
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
 from action_msgs.msg import GoalStatus
 from example_interfaces.action import Fibonacci
 from rclpy.action import ActionServer, CancelResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.node import Node
 from twisted.python import log
 
 sys.path.append(str(Path(__file__).parent))  # enable importing from common.py in this directory
@@ -15,16 +17,23 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.action.server import ServerGoalHandle
+    from rclpy.node import Node
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
 
 
 class TestSendActionGoal(unittest.TestCase):
-    def cancel_callback(self, _):
+    def cancel_callback(self, _: ServerGoalHandle) -> CancelResponse:
         return CancelResponse.ACCEPT
 
-    def execute_callback(self, goal):
+    def execute_callback(self, goal: ServerGoalHandle) -> Fibonacci.Result:
         feedback_msg = Fibonacci.Feedback()
         feedback_msg.sequence = [0, 1]
 
@@ -34,20 +43,22 @@ class TestSendActionGoal(unittest.TestCase):
                 return Fibonacci.Result()
 
             feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i - 1])
-            goal.publish_feedback(feedback_msg)
+            goal.publish_feedback(feedback_msg)  # type: ignore[arg-type]
             time.sleep(0.5)
 
         goal.succeed()
         return Fibonacci.Result(sequence=feedback_msg.sequence)
 
     @websocket_test
-    async def test_one_call(self, node: Node, make_client):
+    async def test_one_call(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         action_server = ActionServer(
             node,
-            Fibonacci,
+            Fibonacci,  # type: ignore[arg-type]
             "/test_fibonacci_action",
             execute_callback=self.execute_callback,
-            cancel_callback=self.cancel_callback,
+            cancel_callback=self.cancel_callback,  # type: ignore[arg-type]
             callback_group=ReentrantCallbackGroup(),
         )
 
@@ -55,8 +66,9 @@ class TestSendActionGoal(unittest.TestCase):
         responses_future, ws_client.message_handler = expect_messages(
             5, "WebSocket", node.get_logger()
         )
-        assert node.executor is not None
-        responses_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        responses_future.add_done_callback(lambda _: executor.wake())
 
         ws_client.sendJson(
             {
@@ -70,7 +82,7 @@ class TestSendActionGoal(unittest.TestCase):
 
         responses = await responses_future
         expected_result = [0, 1, 1, 2, 3, 5]
-        self.assertEqual(len(responses), 5)
+        assert responses is not None and len(responses) == 5
 
         for idx in range(4):
             self.assertEqual(responses[idx]["op"], "action_feedback")

--- a/rosbridge_server/test/websocket/smoke.test.py
+++ b/rosbridge_server/test/websocket/smoke.test.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
-from rclpy.node import Node
 from std_msgs.msg import String
 from twisted.python import log
 
@@ -11,6 +13,13 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, sleep, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+    from rclpy.task import Future
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
@@ -18,7 +27,9 @@ generate_test_description = common.generate_test_description
 
 class TestWebsocketSmoke(unittest.TestCase):
     @websocket_test
-    async def test_smoke(self, node: Node, make_client):
+    async def test_smoke(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         ws_client = await make_client()
         # For consistency, the number of messages must not exceed the the protocol
         # Subscriber queue_size.
@@ -30,14 +41,16 @@ class TestWebsocketSmoke(unittest.TestCase):
         B_STRING = "B" * MSG_SIZE
         WARMUP_DELAY = 1.0  # seconds
 
+        sub_completed_future: Future[list[String]]
         sub_completed_future, sub_handler = expect_messages(
             NUM_MSGS, "ROS subscriber", node.get_logger()
         )
         ws_completed_future, ws_client.message_handler = expect_messages(
             NUM_MSGS, "WebSocket", node.get_logger()
         )
-        assert node.executor is not None
-        ws_completed_future.add_done_callback(lambda _: node.executor.wake())
+        executor = node.executor
+        assert executor is not None
+        ws_completed_future.add_done_callback(lambda _: executor.wake())
 
         sub_a = node.create_subscription(String, A_TOPIC, sub_handler, NUM_MSGS)
         pub_b = node.create_publisher(String, B_TOPIC, NUM_MSGS)
@@ -76,6 +89,9 @@ class TestWebsocketSmoke(unittest.TestCase):
 
         ros_received = await sub_completed_future
         ws_received = await ws_completed_future
+
+        assert ros_received is not None
+        assert ws_received is not None
 
         for msg in ws_received:
             self.assertEqual("publish", msg["op"])

--- a/rosbridge_server/test/websocket/smoke.test.py
+++ b/rosbridge_server/test/websocket/smoke.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from std_msgs.msg import String
 from twisted.python import log
@@ -14,7 +14,7 @@ import common
 from common import expect_messages, sleep, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.node import Node

--- a/rosbridge_server/test/websocket/transient_local_publisher.test.py
+++ b/rosbridge_server/test/websocket/transient_local_publisher.test.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import sys
 import unittest
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
-from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile
 from std_msgs.msg import String
 from twisted.python import log
@@ -12,6 +14,13 @@ sys.path.append(str(Path(__file__).parent))  # enable importing from common.py i
 import common
 from common import expect_messages, sleep, websocket_test
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+
+
 log.startLogging(sys.stderr)
 
 generate_test_description = common.generate_test_description
@@ -19,7 +28,9 @@ generate_test_description = common.generate_test_description
 
 class TestTransientLocalPublisher(unittest.TestCase):
     @websocket_test
-    async def test_transient_local_publisher(self, node: Node, make_client):
+    async def test_transient_local_publisher(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
         qos = QoSProfile(
             depth=1,
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
@@ -32,6 +43,9 @@ class TestTransientLocalPublisher(unittest.TestCase):
         pub_a.publish(String(data="hello"))
 
         await sleep(node, 1)
+
+        executor = node.executor
+        assert executor is not None
 
         for num in range(3):
             ws_client = await make_client()
@@ -46,8 +60,7 @@ class TestTransientLocalPublisher(unittest.TestCase):
             ws_completed_future, ws_client.message_handler = expect_messages(
                 1, "WebSocket " + str(num), node.get_logger()
             )
-            assert node.executor is not None
-            ws_completed_future.add_done_callback(lambda _: node.executor.wake())
+            ws_completed_future.add_done_callback(lambda _: executor.wake())
 
             self.assertEqual(
                 await ws_completed_future,

--- a/rosbridge_server/test/websocket/transient_local_publisher.test.py
+++ b/rosbridge_server/test/websocket/transient_local_publisher.test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile
 from std_msgs.msg import String
@@ -15,7 +15,7 @@ import common
 from common import expect_messages, sleep, websocket_test
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
     from common import TestClientProtocol
     from rclpy.node import Node


### PR DESCRIPTION
**Public API Changes**
Aside from specifying type for public API arguments, the names of any arguments are still thead same.


**Description**
This was exhausting to do but IMO worth it. It always bothered me that I had to go back and forth between files to figure out what types does rosbridge implementation expect. 

**Changes**
- Added `from __future__ import annotations` to every source file - for better compatibility and flexibility in type hinting.
- Set `required-python` version to 3.10 - so ruff checks don't try to keep compatibility with earlier versions
- Enabled `flake8-annotations` check rules which enforce type hints for every argument and return types in all functions and methods.
- Fixed ruff check errors and new mypy errors

**Additional changes**
During the process of adding annotations and fixing type errors, I've made a few implementation changes that might affect the behavior of the library. Most notable changes are:

- In `rosbridge_library.capabilities.advertise.Registration` class,  added dummy advertise ID to use in place of None when the client does not provide id of the advertisement
- In `rosbridge_library.capabilities.defragmentation` module, got rid of `ReceivedFragments` singleton class and instead, added `lists` class variable to `Defragment` capability
- Simplified logging in  `rosbridge_library.capabilities.defragmentation.Defragment` class, making use of f-strings where applicable
- Multiple changes to `rosbridge_library.internal.message_conversion` module:
  - The `extract_values` function now calls `_from_object_inst` instead of `_from_inst` and `populate_instance` calls `_to_object_inst` instead of `_to_inst`. We can do this small optimization, assuming the `inst` passed to these function is a ROS message type. 
  - I added `_from_primitive_inst` to split the logic and make it more readable.
  - Improved `_to_time_inst` a little, raising errors when incorrect type name or message, creating Time and Duration message instances directly, instead of calling `rclpy.time.Time().to_msg()`
  - Added isinstance asserts to narrow down union types for static type checking. This can have a small but IMO negligible impact on performance, and can cause some false positives if I didn't predict that some types can be allowed at certain places.
  - Added helper `_remove_list_indicators` function