### PR TITLE
chore: Remove jazzy ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
+          # NOTE: Humble and Jazzy do not work on the `ros2` branch, so they are tested in their own branches.
           - ros: kilted
             os: ubuntu-24.04
           - ros: rolling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
         include:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
-          # NOTE: Humble does not work on the `ros2` branch, so it is tested in its own branch.
-          - ros: jazzy
-            os: ubuntu-24.04
           - ros: kilted
             os: ubuntu-24.04
           - ros: rolling


### PR DESCRIPTION
Jazzy has now its separate branch

The failing rolling workflow is not related to this change. It will be fixed in #1069 which is the reason for the Jazzy split so this needs to be merged first