### PR TITLE
Fix service timeout parameter not being applied

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/call_service.py
@@ -58,7 +58,7 @@ class CallService(Capability):
     )
 
     services_glob: list[str] | None = None
-    default_timeout: float = 5.0
+    default_call_service_timeout: float = 5.0
     call_services_in_new_thread: bool = True
 
     def __init__(self, protocol: Protocol) -> None:
@@ -89,7 +89,7 @@ class CallService(Capability):
         fragment_size: int | None = message.get("fragment_size")
         compression: str = message.get("compression", "none")
         args: list | dict[str, Any] = message.get("args", [])
-        timeout: float = message.get("timeout", self.default_timeout)
+        timeout: float = message.get("timeout", self.default_call_service_timeout)
 
         if self.services_glob is not None:
             self.protocol.log(


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Bugfix: Use default_call_service_timeout parameter correctly

CallService was using a class attribute named `default_timeout` but the parameter set via the launch  and read here https://github.com/RobotWebTools/rosbridge_suite/blob/c4eb544567d61122b492ff4de0b3562f86cf1528/rosbridge_library/src/rosbridge_library/capability.py#L73-L76  is `default_call_service_timeout`. This causes the passed param to be ignored and the default is always used. This renames  the attribute to match the expected parameter name .