### PR TITLE
fix: Invert success check for set_param function

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -178,7 +178,7 @@ async def _set_param(
 
     assert result is not None
     param_results = next(iter(result.results))
-    if param_results.successful:
+    if not param_results.successful:
         raise Exception(param_results.reason)
 
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**
The `successful` field in `set_param` service was set to `false` when setting the parameter was successful. This bug was introduced in #1069
