### PR TITLE
fix: Handle action rejection and server timeout

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -103,10 +103,6 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
             if fut.cancelled():
                 goal.abort()
                 self.protocol.log("info", f"Aborted goal {goal_id}")
-                # Send an empty result to avoid stack traces
-                fut.set_result(
-                    cast("ROSActionResultT", get_action_class(self.action_type).Result())
-                )
             else:
                 if goal_id not in self.goal_statuses:
                     goal.abort()
@@ -138,7 +134,9 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
 
         try:
             result = await future
-            assert result is not None, "Action result cannot be None"
+            if result is None:
+                # Return empty result when cancelled/aborted
+                return cast("ROSActionResultT", get_action_class(self.action_type).Result())
             return result
         finally:
             del self.goal_futures[goal_id]

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -146,7 +146,7 @@ def args_to_action_goal_instance(inst: ROSMessage, args: list | dict[str, Any] |
 class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
     """Helper class to send action goals."""
 
-    result: GetResultServiceResponse[ROSActionResultT] | None = None
+    result: GetResultServiceResponse[ROSActionResultT] | Exception | None = None
 
     def __init__(self, server_timeout_time: float = 1.0, sleep_time: float = 0.001) -> None:
         self.server_timeout_time = server_timeout_time
@@ -166,7 +166,8 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
         assert self.goal_handle is not None
         if not self.goal_handle.accepted:
             msg = "Action goal was rejected"
-            raise Exception(msg)
+            self.result = Exception(msg)
+            return
         result_future: Future[GetResultServiceResponse[ROSActionResultT]] = (
             self.goal_handle.get_result_async()
         )
@@ -204,6 +205,10 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
             time.sleep(self.sleep_time)
 
         client.destroy()
+
+        if isinstance(self.result, Exception):
+            raise self.result
+
         if self.result is not None:
             # Turn the response into JSON and pass to the callback
             json_response = extract_values(self.result)

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -195,7 +195,8 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
         client: ActionClient[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = ActionClient(
             node_handle, action_class, action_name
         )
-        client.wait_for_server(timeout_sec=self.server_timeout_time)
+        if( not client.wait_for_server(timeout_sec=self.server_timeout_time)):
+           raise Exception("No action server available")
         send_goal_future = client.send_goal_async(inst, feedback_callback=feedback_cb)  # type: ignore[arg-type]
         send_goal_future.add_done_callback(self.goal_response_cb)
 

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -196,8 +196,9 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
         client: ActionClient[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = ActionClient(
             node_handle, action_class, action_name
         )
-        if( not client.wait_for_server(timeout_sec=self.server_timeout_time)):
-           raise Exception("No action server available")
+        if not client.wait_for_server(timeout_sec=self.server_timeout_time):
+            msg = "No action server available"
+            raise Exception(msg)
         send_goal_future = client.send_goal_async(inst, feedback_callback=feedback_cb)  # type: ignore[arg-type]
         send_goal_future.add_done_callback(self.goal_response_cb)
 


### PR DESCRIPTION
**Public API Changes**
Actions forward an error when not available/they get cancelled


**Description**
1. When no server is available, I raise an Eexception to get feedback.
2. throwing an exception in goal_response_cb does not work properly, therefore I return it in the self.result. Probably there would be a better option, but this was working for me.
3.  The result was still none when the action was cancelled, so I put the empty result directly in the return of execute_callback.


