### PR TITLE
chore: disable colcon-powershell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    # container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
     name: ROS 2 ${{ matrix.ros }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    container: ubuntu:noble
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
     runs-on: ubuntu-24.04
-    # container: ${{ matrix.container }}
+    container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: ros-tooling/setup-ros@v0.7
 
       - uses: ros-tooling/action-ros-ci@v0.4
+        id: action_ros_ci_step
         with:
           target-ros2-distro: ${{ matrix.ros }}
 
@@ -69,3 +70,10 @@ jobs:
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"
           cmake --version
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: colcon-logs
+          path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/log
+        if: always()
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
           which python3
           echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
           python3 -c "import sys;print(sys.path)"
+          echo -e "\e[35;1mpython3 -c \"import os; import pprint;pprint.pprint(dict(os.environ), indent=4)\"\e[0m"
+          python3 -c "import os; import pprint;pprint.pprint(dict(os.environ), indent=4)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
           python3 -c "import ament_package;print(ament_package.__file__)" || true
           echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
@@ -83,6 +85,8 @@ jobs:
           which python3
           echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
           python3 -c "import sys;print(sys.path)"
+          echo -e "\e[35;1mpython3 -c \"import os; import pprint;pprint.pprint(dict(os.environ), indent=4)\"\e[0m"
+          python3 -c "import os; import pprint;pprint.pprint(dict(os.environ), indent=4)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
           python3 -c "import ament_package;print(ament_package.__file__)" || true
           echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
@@ -113,6 +117,8 @@ jobs:
           which python3
           echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
           python3 -c "import sys;print(sys.path)"
+          echo -e "\e[35;1mpython3 -c \"import os; import pprint;pprint.pprint(dict(os.environ), indent=4)\"\e[0m"
+          python3 -c "import os; import pprint;pprint.pprint(dict(os.environ), indent=4)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
           python3 -c "import ament_package;print(ament_package.__file__)" || true
           echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
         run: |
           echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
           source /opt/ros/${{ matrix.ros }}/setup.bash
-          echo -e "\e[35;1mecho -e "printenv | sort\e[0m"
-          echo -e "printenv | sort
+          echo -e "\e[35;1mprintenv | sort\e[0m"
+          printenv | sort
           echo -e "\e[35;1mwhich pip3\e[0m"
           which pip3
           echo -e "\e[35;1mpip3 freeze\e[0m"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           path: ros_ws/src
 
+      - name: Install CMake
+        uses: ssrobins/install-cmake@v1
+        with:
+          version: 3.28.3
+
       - uses: ros-tooling/setup-ros@v0.7
 
       - uses: ros-tooling/action-ros-ci@v0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,57 @@ jobs:
         with:
           path: ros_ws/src
 
+      - name: Show environment
+        if: always()
+        continue-on-error: true
+        run: |
+          echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
+          source /opt/ros/${{ matrix.ros }}/setup.bash
+          echo -e "\e[35;1mprintenv | sort\e[0m"
+          printenv | sort
+          echo -e "\e[35;1mwhich pip3\e[0m"
+          which pip3
+          echo -e "\e[35;1mpip3 freeze\e[0m"
+          pip3 freeze
+          echo -e "\e[35;1mwhich python3\e[0m"
+          which python3
+          echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
+          python3 -c "import sys;print(sys.path)"
+          echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
+          python3 -c "import ament_package;print(ament_package.__file__)"
+          echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
+          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
+          echo -e "\e[35;1mwhich cmake\e[0m"
+          which cmake
+          echo -e "\e[35;1mcmake --version\e[0m"
+          cmake --version
+
       - uses: ros-tooling/setup-ros@v0.7
+
+      - name: Show environment
+        if: always()
+        continue-on-error: true
+        run: |
+          echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
+          source /opt/ros/${{ matrix.ros }}/setup.bash
+          echo -e "\e[35;1mprintenv | sort\e[0m"
+          printenv | sort
+          echo -e "\e[35;1mwhich pip3\e[0m"
+          which pip3
+          echo -e "\e[35;1mpip3 freeze\e[0m"
+          pip3 freeze
+          echo -e "\e[35;1mwhich python3\e[0m"
+          which python3
+          echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
+          python3 -c "import sys;print(sys.path)"
+          echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
+          python3 -c "import ament_package;print(ament_package.__file__)"
+          echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
+          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
+          echo -e "\e[35;1mwhich cmake\e[0m"
+          which cmake
+          echo -e "\e[35;1mcmake --version\e[0m"
+          cmake --version
 
       - uses: ros-tooling/action-ros-ci@v0.4
         id: action_ros_ci_step
@@ -48,7 +98,8 @@ jobs:
           target-ros2-distro: ${{ matrix.ros }}
 
       - name: Show environment
-        if: ${{ always() }}
+        if: always()
+        continue-on-error: true
         run: |
           echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
           source /opt/ros/${{ matrix.ros }}/setup.bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
           # https://docs.ros.org/en/rolling/Releases.html
           # NOTE: Humble and Jazzy do not work on the `ros2` branch, so they are tested in their own branches.
           - ros: kilted
-            os: ubuntu-24.04
+            container: ubuntu:noble
           - ros: rolling
-            os: ubuntu-24.04
+            container: ubuntu:noble
 
-    name: ROS 2 ${{ matrix.ros }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    container: ubuntu:noble
+    name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,6 @@ jobs:
         with:
           path: ros_ws/src
 
-      - name: Install CMake
-        uses: ssrobins/install-cmake@v1
-        with:
-          version: 3.28.3
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
       - uses: ros-tooling/setup-ros@v0.7
 
       - uses: ros-tooling/action-ros-ci@v0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,4 @@ jobs:
           source /opt/ros/${{ matrix.ros }}/setup.bash
           printenv | sort
           pip3 freeze
+          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,6 @@ jobs:
 
       - uses: actions/upload-artifact@v6
         with:
-          name: colcon-logs
+          name: colcon-logs-${{ matrix.ros }}
           path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             container: ubuntu:noble
 
     name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # container: ${{ matrix.container }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 env:
-  PSModulePath: ""
+  COLCON_EXTENSION_BLOCKLIST: colcon_core.shell.powershell
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           version: 3.28.3
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       - uses: ros-tooling/setup-ros@v0.7
 
       - uses: ros-tooling/action-ros-ci@v0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         continue-on-error: true
         run: |
           echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
-          source /opt/ros/${{ matrix.ros }}/setup.bash
+          source /opt/ros/${{ matrix.ros }}/setup.bash || true
           echo -e "\e[35;1mprintenv | sort\e[0m"
           printenv | sort
           echo -e "\e[35;1mwhich pip3\e[0m"
@@ -63,7 +63,7 @@ jobs:
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"
-          cmake --version
+          cmake --version || true
 
       - uses: ros-tooling/setup-ros@v0.7
 
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: true
         run: |
           echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
-          source /opt/ros/${{ matrix.ros }}/setup.bash
+          source /opt/ros/${{ matrix.ros }}/setup.bash || true
           echo -e "\e[35;1mprintenv | sort\e[0m"
           printenv | sort
           echo -e "\e[35;1mwhich pip3\e[0m"
@@ -90,7 +90,7 @@ jobs:
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"
-          cmake --version
+          cmake --version || true
 
       - uses: ros-tooling/action-ros-ci@v0.4
         id: action_ros_ci_step
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: true
         run: |
           echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
-          source /opt/ros/${{ matrix.ros }}/setup.bash
+          source /opt/ros/${{ matrix.ros }}/setup.bash || true
           echo -e "\e[35;1mprintenv | sort\e[0m"
           printenv | sort
           echo -e "\e[35;1mwhich pip3\e[0m"
@@ -120,7 +120,7 @@ jobs:
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"
-          cmake --version
+          cmake --version || true
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,10 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.4
         with:
           target-ros2-distro: ${{ matrix.ros }}
+
+      - name: Show environment
+        if: ${{ always() }}
+        run: |
+          source /opt/ros/${{ matrix.ros }}/setup.bash
+          printenv | sort
+          pip3 freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,106 +30,24 @@ jobs:
           # https://docs.ros.org/en/rolling/Releases.html
           # NOTE: Humble and Jazzy do not work on the `ros2` branch, so they are tested in their own branches.
           - ros: kilted
-            container: ubuntu:noble
+            os: ubuntu-24.04
           - ros: rolling
-            container: ubuntu:noble
+            os: ubuntu-24.04
 
-    name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
-    runs-on: ubuntu-24.04
-    # container: ${{ matrix.container }}
+    name: ROS 2 ${{ matrix.ros }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v6
         with:
           path: ros_ws/src
 
-      - name: Show environment
-        if: always()
-        continue-on-error: true
-        run: |
-          echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
-          source /opt/ros/${{ matrix.ros }}/setup.bash || true
-          echo -e "\e[35;1mprintenv | sort\e[0m"
-          printenv | sort
-          echo -e "\e[35;1mwhich pip3\e[0m"
-          which pip3
-          echo -e "\e[35;1mpip3 freeze\e[0m"
-          pip3 freeze
-          echo -e "\e[35;1mwhich python3\e[0m"
-          which python3
-          echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
-          python3 -c "import sys;print(sys.path)"
-          echo -e "\e[35;1mpython3 -c \"import os; import pprint;pprint.pprint(dict(os.environ), indent=4)\"\e[0m"
-          python3 -c "import os; import pprint;pprint.pprint(dict(os.environ), indent=4)"
-          echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
-          python3 -c "import ament_package;print(ament_package.__file__)" || true
-          echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
-          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')" || true
-          echo -e "\e[35;1mwhich cmake\e[0m"
-          which cmake
-          echo -e "\e[35;1mcmake --version\e[0m"
-          cmake --version || true
-
       - uses: ros-tooling/setup-ros@v0.7
-
-      - name: Show environment
-        if: always()
-        continue-on-error: true
-        run: |
-          echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
-          source /opt/ros/${{ matrix.ros }}/setup.bash || true
-          echo -e "\e[35;1mprintenv | sort\e[0m"
-          printenv | sort
-          echo -e "\e[35;1mwhich pip3\e[0m"
-          which pip3
-          echo -e "\e[35;1mpip3 freeze\e[0m"
-          pip3 freeze
-          echo -e "\e[35;1mwhich python3\e[0m"
-          which python3
-          echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
-          python3 -c "import sys;print(sys.path)"
-          echo -e "\e[35;1mpython3 -c \"import os; import pprint;pprint.pprint(dict(os.environ), indent=4)\"\e[0m"
-          python3 -c "import os; import pprint;pprint.pprint(dict(os.environ), indent=4)"
-          echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
-          python3 -c "import ament_package;print(ament_package.__file__)" || true
-          echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
-          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')" || true
-          echo -e "\e[35;1mwhich cmake\e[0m"
-          which cmake
-          echo -e "\e[35;1mcmake --version\e[0m"
-          cmake --version || true
 
       - uses: ros-tooling/action-ros-ci@v0.4
         id: action_ros_ci_step
         with:
           target-ros2-distro: ${{ matrix.ros }}
-
-      - name: Show environment
-        if: always()
-        continue-on-error: true
-        run: |
-          echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
-          source /opt/ros/${{ matrix.ros }}/setup.bash || true
-          echo -e "\e[35;1mprintenv | sort\e[0m"
-          printenv | sort
-          echo -e "\e[35;1mwhich pip3\e[0m"
-          which pip3
-          echo -e "\e[35;1mpip3 freeze\e[0m"
-          pip3 freeze
-          echo -e "\e[35;1mwhich python3\e[0m"
-          which python3
-          echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
-          python3 -c "import sys;print(sys.path)"
-          echo -e "\e[35;1mpython3 -c \"import os; import pprint;pprint.pprint(dict(os.environ), indent=4)\"\e[0m"
-          python3 -c "import os; import pprint;pprint.pprint(dict(os.environ), indent=4)"
-          echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
-          python3 -c "import ament_package;print(ament_package.__file__)" || true
-          echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
-          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')" || true
-          echo -e "\e[35;1mwhich cmake\e[0m"
-          which cmake
-          echo -e "\e[35;1mcmake --version\e[0m"
-          cmake --version || true
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,3 @@ jobs:
           name: colcon-logs
           path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/log
         if: always()
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request, workflow_dispatch]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           python3 -c "import sys;print(sys.path)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
           python3 -c "import ament_package;print(ament_package.__file__)"
-          echo -e "\e[35;1mpython3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"\e[0m"
+          echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
           python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,4 @@ jobs:
           printenv | sort
           pip3 freeze
           python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
+          which cmake && cmake --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  PSModulePath: ""
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
           echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
           python3 -c "import sys;print(sys.path)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
-          python3 -c "import ament_package;print(ament_package.__file__)"
+          python3 -c "import ament_package;print(ament_package.__file__)" || true
           echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
-          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
+          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')" || true
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"
@@ -84,9 +84,9 @@ jobs:
           echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
           python3 -c "import sys;print(sys.path)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
-          python3 -c "import ament_package;print(ament_package.__file__)"
+          python3 -c "import ament_package;print(ament_package.__file__)" || true
           echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
-          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
+          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')" || true
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"
@@ -114,9 +114,9 @@ jobs:
           echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
           python3 -c "import sys;print(sys.path)"
           echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
-          python3 -c "import ament_package;print(ament_package.__file__)"
+          python3 -c "import ament_package;print(ament_package.__file__)" || true
           echo -e "\e[35;1mpython3 -c \"from ament_package.templates import get_environment_hook_template_path;print('done')\"\e[0m"
-          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
+          python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')" || true
           echo -e "\e[35;1mwhich cmake\e[0m"
           which cmake
           echo -e "\e[35;1mcmake --version\e[0m"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
     runs-on: ubuntu-24.04
-    container: ${{ matrix.container }}
+    # container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,23 @@ jobs:
       - name: Show environment
         if: ${{ always() }}
         run: |
+          echo -e "\e[35;1msource /opt/ros/${{ matrix.ros }}/setup.bash\e[0m"
           source /opt/ros/${{ matrix.ros }}/setup.bash
-          printenv | sort
+          echo -e "\e[35;1mecho -e "printenv | sort\e[0m"
+          echo -e "printenv | sort
+          echo -e "\e[35;1mwhich pip3\e[0m"
+          which pip3
+          echo -e "\e[35;1mpip3 freeze\e[0m"
           pip3 freeze
+          echo -e "\e[35;1mwhich python3\e[0m"
+          which python3
+          echo -e "\e[35;1mpython3 -c \"import sys;print(sys.path)\"\e[0m"
+          python3 -c "import sys;print(sys.path)"
+          echo -e "\e[35;1mpython3 -c \"import ament_package;print(ament_package.__file__)\"\e[0m"
+          python3 -c "import ament_package;print(ament_package.__file__)"
+          echo -e "\e[35;1mpython3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"\e[0m"
           python3 -c "from ament_package.templates import get_environment_hook_template_path;print('done')"
-          which cmake && cmake --version
+          echo -e "\e[35;1mwhich cmake\e[0m"
+          which cmake
+          echo -e "\e[35;1mcmake --version\e[0m"
+          cmake --version


### PR DESCRIPTION
This is a hotfix for the CI failing due to `ModuleNotFoundError: No module named 'ament_package'` error (see [here](
https://github.com/RobotWebTools/rosbridge_suite/actions/runs/21110984875/job/60709468192#step:4:5589) for example). The workflow has been failing for about a month now and I suspect it is due to some recent change to the Github runner images. I couldn't find any other solution than running the job in a container.

The other test is failing due to recent changes in rclpy that changed some executor behavior (which I authored :sweat_smile:). It will be fixed in another PR later.