### PR TITLE
fix: rejected goal not returning any data.

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -163,8 +163,8 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
         self.goal_handle = future.result()
         assert self.goal_handle is not None
         if not self.goal_handle.accepted:
-            msg = "Action goal was rejected"
-            raise Exception(msg)
+            self.result = Exception("Action goal was rejected")
+            return
         result_future: Future = self.goal_handle.get_result_async()
         result_future.add_done_callback(self.get_result_cb)
 
@@ -197,6 +197,10 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
             time.sleep(self.sleep_time)
 
         client.destroy()
+
+        if isinstance(self.result, Exception):
+            raise self.result
+
         if self.result is not None:
             # Turn the response into JSON and pass to the callback
             json_response = extract_values(self.result)


### PR DESCRIPTION
**Public API Changes**
None

**Description**
I was working with Roslibjs when I realized that when a goal is rejected it was never made clear through the rosbridge. Now it lets you know instead of becoming stuck in a permanent loop.

`{"op":"action_result","action":"\/topological\/move","values":"Action goal was rejected","status":0,"result":false,"id":"send_action_goal:\/topological\/move:18acdc62-9e38-4968-94f1-b471f226c524"}`|

@YannickdeHoop