### PR TITLE
fix: numpy.ndarray not handled in CBOR serialization

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -99,7 +99,7 @@ def extract_cbor_values(msg: ROSMessage) -> dict[str, Any]:
             out[slot] = CBORTag(tag=tag, value=packed)
 
         # fixed-size primitive arrays
-        elif hasattr(val, 'tolist'):
+        elif hasattr(val, "tolist"):
             out[slot] = val.tolist()
 
         # array of messages

--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -98,6 +98,10 @@ def extract_cbor_values(msg: ROSMessage) -> dict[str, Any]:
             packed = struct.pack(fmt_to_length, *val)
             out[slot] = CBORTag(tag=tag, value=packed)
 
+        # fixed-size primitive arrays
+        elif hasattr(val, 'tolist'):
+            out[slot] = val.tolist()
+
         # array of messages
         elif type(val) in LIST_TYPES:
             out[slot] = [extract_cbor_values(i) for i in val]

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -205,7 +205,6 @@ class TestCBORConversion(unittest.TestCase):
             self.assertEqual(type(key), str)
 
     def test_numpy_array(self) -> None:
-
         class FakeMsg:
             def get_fields_and_field_types(self) -> dict[str, str]:
                 return {"data": "float64[3]"}

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -5,6 +5,7 @@ import struct
 import unittest
 from array import array
 
+import numpy as np
 from builtin_interfaces.msg import Duration, Time
 from cbor2 import CBORTag
 from rosbridge_library.internal.cbor_conversion import (
@@ -204,18 +205,14 @@ class TestCBORConversion(unittest.TestCase):
             self.assertEqual(type(key), str)
 
     def test_numpy_array(self) -> None:
-        import numpy as np
 
-        # In ROS 2, fixed-size array fields (e.g. float64[3]) are backed by
-        # numpy arrays. Their slot type is not in TAGGED_ARRAY_FORMATS, so they
-        # must be handled separately via .tolist().
         class FakeMsg:
             def get_fields_and_field_types(self) -> dict[str, str]:
                 return {"data": "float64[3]"}
 
             data = np.array([1.0, 2.0, 3.0])
 
-        extracted = extract_cbor_values(FakeMsg())  # type: ignore[arg-type]
+        extracted = extract_cbor_values(FakeMsg())
         self.assertEqual(type(extracted["data"]), list)
         self.assertEqual(extracted["data"], [1.0, 2.0, 3.0])
 

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -203,6 +203,22 @@ class TestCBORConversion(unittest.TestCase):
         for key in keys:
             self.assertEqual(type(key), str)
 
+    def test_numpy_array(self) -> None:
+        import numpy as np
+
+        # In ROS 2, fixed-size array fields (e.g. float64[3]) are backed by
+        # numpy arrays. Their slot type is not in TAGGED_ARRAY_FORMATS, so they
+        # must be handled separately via .tolist().
+        class FakeMsg:
+            def get_fields_and_field_types(self) -> dict[str, str]:
+                return {"data": "float64[3]"}
+
+            data = np.array([1.0, 2.0, 3.0])
+
+        extracted = extract_cbor_values(FakeMsg())  # type: ignore[arg-type]
+        self.assertEqual(type(extracted["data"]), list)
+        self.assertEqual(extracted["data"], [1.0, 2.0, 3.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -5,13 +5,13 @@ import struct
 import unittest
 from array import array
 
-import numpy as np
 from builtin_interfaces.msg import Duration, Time
 from cbor2 import CBORTag
 from rosbridge_library.internal.cbor_conversion import (
     TAGGED_ARRAY_FORMATS,
     extract_cbor_values,
 )
+from sensor_msgs.msg import Imu
 from std_msgs.msg import (
     Bool,
     Float32,
@@ -205,15 +205,11 @@ class TestCBORConversion(unittest.TestCase):
             self.assertEqual(type(key), str)
 
     def test_numpy_array(self) -> None:
-        class FakeMsg:
-            def get_fields_and_field_types(self) -> dict[str, str]:
-                return {"data": "float64[3]"}
-
-            data = np.array([1.0, 2.0, 3.0])
-
-        extracted = extract_cbor_values(FakeMsg())
-        self.assertEqual(type(extracted["data"]), list)
-        self.assertEqual(extracted["data"], [1.0, 2.0, 3.0])
+        msg = Imu()
+        extracted = extract_cbor_values(msg)
+        covariance = extracted["orientation_covariance"]
+        self.assertEqual(type(covariance), list)
+        self.assertEqual(len(covariance), 9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix numpy.ndarray not handled in CBOR serialization

Closes [#965](https://github.com/RobotWebTools/rosbridge_suite/issues/965) 

When `cbor_compression` is enabled, ROS 2 stores fixed-size primitive array fields (e.g. `float64[36]` covariance in `Odometry`/`Imu`, `float32[3]` position in `SportModeState`) as `numpy.ndarray` internally. These types are not covered by `TAGGED_ARRAY_FORMATS`, which only handles `sequence<*>` types, and `numpy.ndarray` is not in `LIST_TYPES`. They fall through to the `else` branch which calls `extract_cbor_values(val)` on the array, triggering:

    AttributeError: 'numpy.ndarray' object has no attribute 'get_fields_and_field_types'

The fix adds one `elif` to the existing type dispatch chain, directly after the `TAGGED_ARRAY_FORMATS` handler where it logically belongs. `hasattr(val, 'tolist')` identifies numpy arrays without requiring an import.

Note: `message_conversion.py` already handles this correctly — its `list_types` includes `np.ndarray`. This PR brings `cbor_conversion.py` into parity.
