### PR TITLE
fix: numpy.ndarray not handled in CBOR serialization (backport #1161)

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/cbor_conversion.py
@@ -98,6 +98,10 @@ def extract_cbor_values(msg: ROSMessage) -> dict[str, Any]:
             packed = struct.pack(fmt_to_length, *val)
             out[slot] = CBORTag(tag=tag, value=packed)
 
+        # fixed-size primitive arrays
+        elif hasattr(val, "tolist"):
+            out[slot] = val.tolist()
+
         # array of messages
         elif type(val) in LIST_TYPES:
             out[slot] = [extract_cbor_values(i) for i in val]

--- a/rosbridge_library/test/internal/test_cbor_conversion.py
+++ b/rosbridge_library/test/internal/test_cbor_conversion.py
@@ -11,6 +11,7 @@ from rosbridge_library.internal.cbor_conversion import (
     TAGGED_ARRAY_FORMATS,
     extract_cbor_values,
 )
+from sensor_msgs.msg import Imu
 from std_msgs.msg import (
     Bool,
     Float32,
@@ -202,6 +203,13 @@ class TestCBORConversion(unittest.TestCase):
         keys = extracted.keys()
         for key in keys:
             self.assertEqual(type(key), str)
+
+    def test_numpy_array(self) -> None:
+        msg = Imu()
+        extracted = extract_cbor_values(msg)
+        covariance = extracted["orientation_covariance"]
+        self.assertEqual(type(covariance), list)
+        self.assertEqual(len(covariance), 9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fix numpy.ndarray not handled in CBOR serialization

* Add test for numpy.ndarray handling in CBOR conversion

