### PR TITLE
fix: Use new interface base classes for type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
         include:
           # Test supported ROS 2 distributions
           # https://docs.ros.org/en/rolling/Releases.html
-          # NOTE: Humble and Jazzy do not work on the `ros2` branch, so they are tested in their own branches.
-          - ros: kilted
-            os: ubuntu-24.04
+          # NOTE: Humble, Jazzy and Kilted do not work on the `ros2` branch, so they are tested in their own branches.
           - ros: rolling
             os: ubuntu-24.04
 

--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -26,6 +26,7 @@ ROS action, like subscribe, publish, call service, and interact with params.
   <exec_depend>python3-ujson</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosidl_pycommon</exec_depend>
 
   <test_depend>action_msgs</test_depend>
   <test_depend>ament_cmake_mypy</test_depend>

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -33,11 +33,11 @@
 from __future__ import annotations
 
 import fnmatch
-from typing import TYPE_CHECKING, Generic, cast
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 from action_msgs.msg import GoalStatus
 from rclpy.action import ActionServer
-from rclpy.action.server import CancelResponse, ServerGoalHandle
+from rclpy.action.server import CancelResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.task import Future
 
@@ -45,26 +45,29 @@ from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion
 from rosbridge_library.internal.ros_loader import get_action_class
 from rosbridge_library.internal.type_support import (
+    ActionServerType,
     ROSActionFeedbackT,
     ROSActionGoalT,
+    ROSActionImplT,
     ROSActionResultT,
     ROSMessage,
+    ServerGoalHandleType,
 )
 
 if TYPE_CHECKING:
     from rosbridge_library.protocol import Protocol
 
 
-class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
+class AdvertisedActionHandler(
+    Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT]
+):
     id_counter = 1
 
     def __init__(
         self, action_name: str, action_type: str, protocol: Protocol, sleep_time: float = 0.001
     ) -> None:
         self.goal_futures: dict[str, Future[ROSActionResultT]] = {}
-        self.goal_handles: dict[
-            str, ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
-        ] = {}
+        self.goal_handles: dict[str, ServerGoalHandleType] = {}
         self.goal_statuses: dict[str, int] = {}
 
         self.action_name = action_name
@@ -72,15 +75,13 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
         self.protocol = protocol
         self.sleep_time = sleep_time
         # setup the action
-        self.action_server: ActionServer[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = (
-            ActionServer(
-                protocol.node_handle,
-                get_action_class(action_type),
-                action_name,
-                self.execute_callback,  # type: ignore[arg-type]  # rclpy type hint does not support coroutines
-                cancel_callback=self.cancel_callback,  # type: ignore[arg-type]  # rclpy type hint is incorrect
-                callback_group=ReentrantCallbackGroup(),  # https://github.com/ros2/rclpy/issues/834#issuecomment-961331870
-            )
+        self.action_server: ActionServerType = ActionServer(
+            protocol.node_handle,
+            get_action_class(action_type),
+            action_name,
+            self.execute_callback,  # type: ignore[arg-type]  # rclpy type hint does not support coroutines
+            cancel_callback=self.cancel_callback,  # type: ignore[arg-type]  # rclpy type hint is incorrect
+            callback_group=ReentrantCallbackGroup(),  # https://github.com/ros2/rclpy/issues/834#issuecomment-961331870
         )
 
     def next_id(self) -> int:
@@ -88,9 +89,7 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
         self.id_counter += 1
         return next_id_value
 
-    async def execute_callback(
-        self, goal: ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
-    ) -> ROSActionResultT:
+    async def execute_callback(self, goal: ServerGoalHandleType) -> ROSActionResultT:
         """
         Execute action goal.
 
@@ -142,9 +141,7 @@ class AdvertisedActionHandler(Generic[ROSActionGoalT, ROSActionResultT, ROSActio
             del self.goal_futures[goal_id]
             del self.goal_handles[goal_id]
 
-    def cancel_callback(
-        self, goal: ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]
-    ) -> CancelResponse:
+    def cancel_callback(self, goal: ServerGoalHandleType) -> CancelResponse:
         """
         Cancel action goal.
 
@@ -270,8 +267,8 @@ class AdvertiseAction(Capability):
 
         # setup and store the action information
         action_type: str = message["type"]
-        action_handler: AdvertisedActionHandler[ROSMessage, ROSMessage, ROSMessage] = (
-            AdvertisedActionHandler(action_name, action_type, self.protocol)
+        action_handler = AdvertisedActionHandler[ROSMessage, ROSMessage, ROSMessage, Any](
+            action_name, action_type, self.protocol
         )
         self.protocol.external_action_list[action_name] = action_handler
         self.protocol.log("info", f"Advertised action {action_name}")

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_action.py
@@ -45,16 +45,16 @@ from rosbridge_library.capability import Capability
 from rosbridge_library.internal import message_conversion
 from rosbridge_library.internal.ros_loader import get_action_class
 from rosbridge_library.internal.type_support import (
-    ActionServerType,
     ROSActionFeedbackT,
     ROSActionGoalT,
     ROSActionImplT,
     ROSActionResultT,
     ROSMessage,
-    ServerGoalHandleType,
 )
 
 if TYPE_CHECKING:
+    from rclpy.action.server import ServerGoalHandle
+
     from rosbridge_library.protocol import Protocol
 
 
@@ -67,7 +67,10 @@ class AdvertisedActionHandler(
         self, action_name: str, action_type: str, protocol: Protocol, sleep_time: float = 0.001
     ) -> None:
         self.goal_futures: dict[str, Future[ROSActionResultT]] = {}
-        self.goal_handles: dict[str, ServerGoalHandleType] = {}
+        self.goal_handles: dict[
+            str,
+            ServerGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT],
+        ] = {}
         self.goal_statuses: dict[str, int] = {}
 
         self.action_name = action_name
@@ -75,7 +78,9 @@ class AdvertisedActionHandler(
         self.protocol = protocol
         self.sleep_time = sleep_time
         # setup the action
-        self.action_server: ActionServerType = ActionServer(
+        self.action_server = ActionServer[
+            ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+        ](
             protocol.node_handle,
             get_action_class(action_type),
             action_name,
@@ -89,7 +94,12 @@ class AdvertisedActionHandler(
         self.id_counter += 1
         return next_id_value
 
-    async def execute_callback(self, goal: ServerGoalHandleType) -> ROSActionResultT:
+    async def execute_callback(
+        self,
+        goal: ServerGoalHandle[
+            ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+        ],
+    ) -> ROSActionResultT:
         """
         Execute action goal.
 
@@ -141,7 +151,12 @@ class AdvertisedActionHandler(
             del self.goal_futures[goal_id]
             del self.goal_handles[goal_id]
 
-    def cancel_callback(self, goal: ServerGoalHandleType) -> CancelResponse:
+    def cancel_callback(
+        self,
+        goal: ServerGoalHandle[
+            ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+        ],
+    ) -> CancelResponse:
         """
         Cancel action goal.
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
@@ -134,7 +134,7 @@ class SendActionGoal(Capability):
         f_cb = partial(self._feedback, cid, action) if message.get("feedback", False) else None
 
         # Run action client handler in the same thread.
-        client_handler: ActionClientHandler[ROSMessage, ROSMessage, ROSMessage] = (
+        client_handler: ActionClientHandler[ROSMessage, ROSMessage, ROSMessage, Any] = (
             ActionClientHandler(
                 trim_action_name(action),
                 action_type,

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -49,6 +49,7 @@ from rosbridge_library.internal.ros_loader import (
 from rosbridge_library.internal.type_support import (
     ROSActionFeedbackT,
     ROSActionGoalT,
+    ROSActionImplT,
     ROSActionResultT,
 )
 
@@ -56,12 +57,15 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from action_msgs.srv import CancelGoal_Response
-    from rclpy.action.client import ClientGoalHandle
     from rclpy.node import Node
     from rclpy.task import Future
     from rclpy.type_support import FeedbackMessage, GetResultServiceResponse
 
-    from rosbridge_library.internal.type_support import ROSMessage
+    from rosbridge_library.internal.type_support import (
+        ActionClientType,
+        ClientGoalHandleType,
+        ROSMessage,
+    )
 
 
 class InvalidActionException(Exception):
@@ -69,7 +73,9 @@ class InvalidActionException(Exception):
         Exception.__init__(self, f"Action {action_name} does not exist")
 
 
-class ActionClientHandler(Thread, Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
+class ActionClientHandler(
+    Thread, Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT]
+):
     def __init__(
         self,
         action: str,
@@ -104,9 +110,9 @@ class ActionClientHandler(Thread, Generic[ROSActionGoalT, ROSActionResultT, ROSA
         self.error = error_callback
         self.feedback = feedback_callback
         self.node_handle = node_handle
-        self.send_goal_helper: SendGoal[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = (
-            SendGoal()
-        )
+        self.send_goal_helper = SendGoal[
+            ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+        ]()
 
     def run(self) -> None:
         try:
@@ -143,7 +149,7 @@ def args_to_action_goal_instance(inst: ROSMessage, args: list | dict[str, Any] |
     populate_instance(msg, inst)
 
 
-class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
+class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT]):
     """Helper class to send action goals."""
 
     result: GetResultServiceResponse[ROSActionResultT] | Exception | None = None
@@ -151,16 +157,15 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
     def __init__(self, server_timeout_time: float = 1.0, sleep_time: float = 0.001) -> None:
         self.server_timeout_time = server_timeout_time
         self.sleep_time = sleep_time
-        self.goal_handle: (
-            ClientGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] | None
-        ) = None
+        self.goal_handle: ClientGoalHandleType | None = None
         self.goal_canceled = False
 
     def get_result_cb(self, future: Future[GetResultServiceResponse[ROSActionResultT]]) -> None:
         self.result = future.result()
 
     def goal_response_cb(
-        self, future: Future[ClientGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]]
+        self,
+        future: Future[ClientGoalHandleType],
     ) -> None:
         self.goal_handle = future.result()
         assert self.goal_handle is not None
@@ -193,9 +198,7 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT]):
         args_to_action_goal_instance(inst, args)
 
         self.result = None
-        client: ActionClient[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT] = ActionClient(
-            node_handle, action_class, action_name
-        )
+        client: ActionClientType = ActionClient(node_handle, action_class, action_name)
         if not client.wait_for_server(timeout_sec=self.server_timeout_time):
             msg = "No action server available"
             raise Exception(msg)

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -57,15 +57,12 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from action_msgs.srv import CancelGoal_Response
+    from rclpy.action.client import ClientGoalHandle
     from rclpy.node import Node
     from rclpy.task import Future
     from rclpy.type_support import FeedbackMessage, GetResultServiceResponse
 
-    from rosbridge_library.internal.type_support import (
-        ActionClientType,
-        ClientGoalHandleType,
-        ROSMessage,
-    )
+    from rosbridge_library.internal.type_support import ROSMessage
 
 
 class InvalidActionException(Exception):
@@ -157,7 +154,10 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROS
     def __init__(self, server_timeout_time: float = 1.0, sleep_time: float = 0.001) -> None:
         self.server_timeout_time = server_timeout_time
         self.sleep_time = sleep_time
-        self.goal_handle: ClientGoalHandleType | None = None
+        self.goal_handle: (
+            ClientGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT]
+            | None
+        ) = None
         self.goal_canceled = False
 
     def get_result_cb(self, future: Future[GetResultServiceResponse[ROSActionResultT]]) -> None:
@@ -165,7 +165,9 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROS
 
     def goal_response_cb(
         self,
-        future: Future[ClientGoalHandleType],
+        future: Future[
+            ClientGoalHandle[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT]
+        ],
     ) -> None:
         self.goal_handle = future.result()
         assert self.goal_handle is not None
@@ -198,7 +200,9 @@ class SendGoal(Generic[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROS
         args_to_action_goal_instance(inst, args)
 
         self.result = None
-        client: ActionClientType = ActionClient(node_handle, action_class, action_name)
+        client = ActionClient[ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT](
+            node_handle, action_class, action_name
+        )
         if not client.wait_for_server(timeout_sec=self.server_timeout_time):
             msg = "No action server available"
             raise Exception(msg)

--- a/rosbridge_library/src/rosbridge_library/internal/type_support.py
+++ b/rosbridge_library/src/rosbridge_library/internal/type_support.py
@@ -32,36 +32,54 @@
 
 from __future__ import annotations
 
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
+from rclpy.action.client import ActionClient as _ActionClient
+from rclpy.action.client import ClientGoalHandle as _ClientGoalHandle
+from rclpy.action.server import ActionServer as _ActionServer
+from rclpy.action.server import ServerGoalHandle as _ServerGoalHandle
 
-@runtime_checkable
-class ROSMessage(Protocol):
-    """Protocol for ROS message types."""
+try:
+    from rosidl_pycommon.interface_base_classes import (
+        BaseAction,
+        BaseMessage,
+        BaseService,
+    )
 
-    __slots__: list[str]
-    _fields_and_field_types: dict[str, str]
+    ROSMessage = BaseMessage
+    ROSService = BaseService
+    ROSAction = BaseAction
 
-    def get_fields_and_field_types(self) -> dict[str, str]:
-        """Return a dictionary of field names to field types."""
+except ImportError:
+    # Fallback to Protocols if interface base classes are not available
+    # TODO: Remove this fallback once we drop support for Kilted
 
+    @runtime_checkable
+    class ROSMessage(Protocol):  # type: ignore[no-redef]
+        """Protocol for ROS message types."""
 
-@runtime_checkable
-class ROSService(Protocol):
-    """Protocol for ROS service types."""
+        __slots__: list[str]
+        _fields_and_field_types: dict[str, str]
 
-    Request: type[ROSMessage]
-    Response: type[ROSMessage]
-    Event: type[ROSMessage]
+        def get_fields_and_field_types(self) -> dict[str, str]:
+            """Return a dictionary of field names to field types."""
 
+    @runtime_checkable
+    class ROSService(Protocol):  # type: ignore[no-redef]
+        """Protocol for ROS service types."""
 
-@runtime_checkable
-class ROSAction(Protocol):
-    """Protocol for ROS action types."""
+        Request: type[ROSMessage]
+        Response: type[ROSMessage]
+        Event: type[ROSMessage]
 
-    Goal: type[ROSMessage]
-    Result: type[ROSMessage]
-    Feedback: type[ROSMessage]
+    @runtime_checkable
+    class ROSAction(Protocol):  # type: ignore[no-redef]
+        """Protocol for ROS action types."""
+
+        Goal: type[ROSMessage]
+        Result: type[ROSMessage]
+        Feedback: type[ROSMessage]
+        Impl: type[Any]
 
 
 # Type variables for ROS types
@@ -73,3 +91,40 @@ ROSActionT = TypeVar("ROSActionT", bound=ROSAction)
 ROSActionGoalT = TypeVar("ROSActionGoalT", bound=ROSMessage)
 ROSActionResultT = TypeVar("ROSActionResultT", bound=ROSMessage)
 ROSActionFeedbackT = TypeVar("ROSActionFeedbackT", bound=ROSMessage)
+
+try:
+    from rosidl_pycommon.interface_base_classes import BaseImpl
+
+    ROSActionImplT = TypeVar("ROSActionImplT", bound=BaseImpl[Any, Any, Any])
+
+    ActionClientType = _ActionClient[
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+    ]
+    ClientGoalHandleType = _ClientGoalHandle[
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+    ]
+    ActionServerType = _ActionServer[
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+    ]
+    ServerGoalHandleType = _ServerGoalHandle[
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+    ]
+
+except ImportError:
+    # Fallback to old type variables if BaseImpl is not available
+    # TODO: Remove this fallback once we drop support for Kilted
+
+    ROSActionImplT = TypeVar("ROSActionImplT")  # type: ignore[misc]
+
+    ActionClientType = _ActionClient[  # type: ignore[misc]
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
+    ]
+    ClientGoalHandleType = _ClientGoalHandle[  # type: ignore[misc]
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
+    ]
+    ActionServerType = _ActionServer[  # type: ignore[misc]
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
+    ]
+    ServerGoalHandleType = _ServerGoalHandle[  # type: ignore[misc]
+        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
+    ]

--- a/rosbridge_library/src/rosbridge_library/internal/type_support.py
+++ b/rosbridge_library/src/rosbridge_library/internal/type_support.py
@@ -34,10 +34,6 @@ from __future__ import annotations
 
 from typing import Any, TypeAlias, TypeVar
 
-from rclpy.action.client import ActionClient as _ActionClient
-from rclpy.action.client import ClientGoalHandle as _ClientGoalHandle
-from rclpy.action.server import ActionServer as _ActionServer
-from rclpy.action.server import ServerGoalHandle as _ServerGoalHandle
 from rosidl_pycommon.interface_base_classes import BaseAction, BaseImpl, BaseMessage, BaseService
 
 ROSMessage: TypeAlias = BaseMessage
@@ -54,16 +50,3 @@ ROSActionGoalT = TypeVar("ROSActionGoalT", bound=ROSMessage)
 ROSActionResultT = TypeVar("ROSActionResultT", bound=ROSMessage)
 ROSActionFeedbackT = TypeVar("ROSActionFeedbackT", bound=ROSMessage)
 ROSActionImplT = TypeVar("ROSActionImplT", bound=BaseImpl[Any, Any, Any])
-
-ActionClientType: TypeAlias = _ActionClient[
-    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-]
-ClientGoalHandleType: TypeAlias = _ClientGoalHandle[
-    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-]
-ActionServerType: TypeAlias = _ActionServer[
-    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-]
-ServerGoalHandleType: TypeAlias = _ServerGoalHandle[
-    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-]

--- a/rosbridge_library/src/rosbridge_library/internal/type_support.py
+++ b/rosbridge_library/src/rosbridge_library/internal/type_support.py
@@ -32,55 +32,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, TypeAlias, TypeVar
 
 from rclpy.action.client import ActionClient as _ActionClient
 from rclpy.action.client import ClientGoalHandle as _ClientGoalHandle
 from rclpy.action.server import ActionServer as _ActionServer
 from rclpy.action.server import ServerGoalHandle as _ServerGoalHandle
+from rosidl_pycommon.interface_base_classes import BaseAction, BaseImpl, BaseMessage, BaseService
 
-try:
-    from rosidl_pycommon.interface_base_classes import (
-        BaseAction,
-        BaseMessage,
-        BaseService,
-    )
-
-    ROSMessage = BaseMessage
-    ROSService = BaseService
-    ROSAction = BaseAction
-
-except ImportError:
-    # Fallback to Protocols if interface base classes are not available
-    # TODO: Remove this fallback once we drop support for Kilted
-
-    @runtime_checkable
-    class ROSMessage(Protocol):  # type: ignore[no-redef]
-        """Protocol for ROS message types."""
-
-        __slots__: list[str]
-        _fields_and_field_types: dict[str, str]
-
-        def get_fields_and_field_types(self) -> dict[str, str]:
-            """Return a dictionary of field names to field types."""
-
-    @runtime_checkable
-    class ROSService(Protocol):  # type: ignore[no-redef]
-        """Protocol for ROS service types."""
-
-        Request: type[ROSMessage]
-        Response: type[ROSMessage]
-        Event: type[ROSMessage]
-
-    @runtime_checkable
-    class ROSAction(Protocol):  # type: ignore[no-redef]
-        """Protocol for ROS action types."""
-
-        Goal: type[ROSMessage]
-        Result: type[ROSMessage]
-        Feedback: type[ROSMessage]
-        Impl: type[Any]
-
+ROSMessage: TypeAlias = BaseMessage
+ROSService: TypeAlias = BaseService
+ROSAction: TypeAlias = BaseAction
 
 # Type variables for ROS types
 ROSMessageT = TypeVar("ROSMessageT", bound=ROSMessage)
@@ -91,40 +53,17 @@ ROSActionT = TypeVar("ROSActionT", bound=ROSAction)
 ROSActionGoalT = TypeVar("ROSActionGoalT", bound=ROSMessage)
 ROSActionResultT = TypeVar("ROSActionResultT", bound=ROSMessage)
 ROSActionFeedbackT = TypeVar("ROSActionFeedbackT", bound=ROSMessage)
+ROSActionImplT = TypeVar("ROSActionImplT", bound=BaseImpl[Any, Any, Any])
 
-try:
-    from rosidl_pycommon.interface_base_classes import BaseImpl
-
-    ROSActionImplT = TypeVar("ROSActionImplT", bound=BaseImpl[Any, Any, Any])
-
-    ActionClientType = _ActionClient[
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-    ]
-    ClientGoalHandleType = _ClientGoalHandle[
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-    ]
-    ActionServerType = _ActionServer[
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-    ]
-    ServerGoalHandleType = _ServerGoalHandle[
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
-    ]
-
-except ImportError:
-    # Fallback to old type variables if BaseImpl is not available
-    # TODO: Remove this fallback once we drop support for Kilted
-
-    ROSActionImplT = TypeVar("ROSActionImplT")  # type: ignore[misc]
-
-    ActionClientType = _ActionClient[  # type: ignore[misc]
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
-    ]
-    ClientGoalHandleType = _ClientGoalHandle[  # type: ignore[misc]
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
-    ]
-    ActionServerType = _ActionServer[  # type: ignore[misc]
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
-    ]
-    ServerGoalHandleType = _ServerGoalHandle[  # type: ignore[misc]
-        ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT
-    ]
+ActionClientType: TypeAlias = _ActionClient[
+    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+]
+ClientGoalHandleType: TypeAlias = _ClientGoalHandle[
+    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+]
+ActionServerType: TypeAlias = _ActionServer[
+    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+]
+ServerGoalHandleType: TypeAlias = _ServerGoalHandle[
+    ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
+]

--- a/rosbridge_library/test/internal/actions/test_actions.py
+++ b/rosbridge_library/test/internal/actions/test_actions.py
@@ -33,13 +33,8 @@ class ActionTester:
         self.executor = executor
         self.node = Node("action_tester")
         self.executor.add_node(self.node)
-        self.action_server: ActionServer[
-            Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback, Any
-        ] = ActionServer(
-            self.node,
-            Fibonacci,
-            "get_fibonacci_sequence",
-            self.execute_callback,
+        self.action_server = ActionServer(
+            self.node, Fibonacci, "get_fibonacci_sequence", self.execute_callback
         )
 
     def __del__(self) -> None:
@@ -164,13 +159,7 @@ class TestActions(unittest.TestCase):
             received["msg"] = response.result
 
         # First, call the action the 'proper' way
-        client: ActionClient[Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback, Any] = (
-            ActionClient(
-                self.node,
-                Fibonacci,
-                "get_fibonacci_sequence",
-            )
-        )
+        client = ActionClient(self.node, Fibonacci, "get_fibonacci_sequence")
         client.wait_for_server()
         goal = Fibonacci.Goal()
         goal.order = 5

--- a/rosbridge_library/test/internal/actions/test_actions.py
+++ b/rosbridge_library/test/internal/actions/test_actions.py
@@ -33,20 +33,20 @@ class ActionTester:
         self.executor = executor
         self.node = Node("action_tester")
         self.executor.add_node(self.node)
-        self.action_server: ActionServer[Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback] = (
-            ActionServer(
-                self.node,
-                Fibonacci,
-                "get_fibonacci_sequence",
-                self.execute_callback,
-            )
+        self.action_server: ActionServer[
+            Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback, Any
+        ] = ActionServer(
+            self.node,
+            Fibonacci,
+            "get_fibonacci_sequence",
+            self.execute_callback,
         )
 
     def __del__(self) -> None:
         self.executor.remove_node(self.node)
 
     def execute_callback(
-        self, goal: ServerGoalHandle[Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback]
+        self, goal: ServerGoalHandle[Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback, Any]
     ) -> Fibonacci_Result:
         self.goal = goal
         feedback_msg = Fibonacci.Feedback()
@@ -164,10 +164,12 @@ class TestActions(unittest.TestCase):
             received["msg"] = response.result
 
         # First, call the action the 'proper' way
-        client: ActionClient[Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback] = ActionClient(
-            self.node,
-            Fibonacci,
-            "get_fibonacci_sequence",
+        client: ActionClient[Fibonacci_Goal, Fibonacci_Result, Fibonacci_Feedback, Any] = (
+            ActionClient(
+                self.node,
+                Fibonacci,
+                "get_fibonacci_sequence",
+            )
         )
         client.wait_for_server()
         goal = Fibonacci.Goal()


### PR DESCRIPTION
ros2/rosidl#887, ros2/rosidl#912, ros2/rosidl_python#230 and ros2/rosidl_python#241 made it so that all generated interfaces derive from common abstract base classes (finally proper polymorphism). This means we can drop the usage of Protocol classes for type checking. 
 
 The only problem is, the changes are not backported to Kilted (and probably won't be). I tried to make it compatible between distributions but that only made it look ugly and was not working properly. This means we probably need to branch out.