### PR TITLE
feat: Drop support for BSON

### DIFF
--- a/rosbridge_library/package.xml
+++ b/rosbridge_library/package.xml
@@ -19,7 +19,6 @@ ROS action, like subscribe, publish, call service, and interact with params.
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <exec_depend>python3-bson</exec_depend>
   <exec_depend>python3-cbor2</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-pil</exec_depend>

--- a/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/fragmentation.py
@@ -84,7 +84,11 @@ class Fragmentation(Capability):
             mid = str(self.fragmentation_seed)
             self.fragmentation_seed = self.fragmentation_seed + 1
 
-        serialized = self.protocol.serialize(message, mid)
+        serialized: bytes | str | None
+        if isinstance(message, bytes):
+            serialized = message
+        else:
+            serialized = self.protocol.serialize(message, mid)
 
         if serialized is None:
             return []

--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -47,11 +47,8 @@ from std_msgs.msg import Header as HeaderMsg
 
 from rosbridge_library.internal import ros_loader
 from rosbridge_library.internal.type_support import ROSMessage
-from rosbridge_library.util import bson
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from rclpy.clock import Clock
 
 
@@ -108,47 +105,6 @@ ros_binary_types_list_braces = (
     ("uint8[]", re.compile(r"uint8\[[^\]]*\]")),
     ("char[]", re.compile(r"char\[[^\]]*\]")),
 )
-
-module_configured = False
-binary_encoder = None
-bson_only_mode = False
-
-
-def configure(parameters: dict[str, Any] | None = None) -> None:
-    """
-    Configure the message_conversion module.
-
-    :param parameters: A dictionary of parameters to configure the module.
-    :type parameters: dict[str, Any] | None
-    :raises ValueError: If an unknown encoder type is specified.
-    """
-    global binary_encoder, bson_only_mode, module_configured
-
-    if module_configured:
-        return
-
-    binary_encoder_type = "default"
-
-    if parameters is not None:
-        binary_encoder_type = parameters.get("binary_encoder", binary_encoder_type)
-        bson_only_mode = parameters.get("bson_only_mode", bson_only_mode)
-
-    if binary_encoder_type == "bson" or bson_only_mode:
-        binary_encoder = bson.Binary
-    elif binary_encoder_type is None or binary_encoder_type in {"default", "b64"}:
-        binary_encoder = standard_b64encode
-    else:
-        err_msg = f"Unknown encoder type '{binary_encoder_type}'"
-        raise ValueError(err_msg)
-
-    module_configured = True
-
-
-def get_encoder() -> Callable[[ListType], bytes]:
-    assert module_configured and binary_encoder is not None, (
-        "message_conversion module is not configured"
-    )
-    return binary_encoder
 
 
 class InvalidMessageException(Exception):
@@ -239,7 +195,10 @@ def _from_inst(
             if not isinstance(inst, list_types):
                 err_msg = f"inst is not a list type, but a {type(inst)}"
                 raise TypeError(err_msg)
-            encoded = get_encoder()(inst)
+            if isinstance(inst, list | tuple):
+                # Convert non-bytes iterable object to bytes for encoding
+                inst = bytes(inst)
+            encoded = standard_b64encode(inst)
             return encoded.decode("ascii")
 
     # Check for time or duration
@@ -268,9 +227,6 @@ def _from_inst(
 
 
 def _from_primitive_inst(inst: PrimitiveType | bytes, rostype: str) -> PrimitiveType | bytes | None:
-    if bson_only_mode:
-        return inst
-
     # JSON does not support Inf and NaN. They are mapped to None and encoded as null
     if rostype in type_map["float"]:
         if not isinstance(inst, float):

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -36,8 +36,8 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from rosbridge_library.capabilities.fragmentation import Fragmentation
-from rosbridge_library.internal import message_conversion, publishers
-from rosbridge_library.util import bson, json
+from rosbridge_library.internal import publishers
+from rosbridge_library.util import json
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -55,17 +55,6 @@ def is_number(s: object) -> bool | None:
         return True
     except ValueError:
         return False
-
-
-def has_binary(obj: object) -> bool:
-    """Return True if obj is a binary or contains a binary attribute."""
-    if isinstance(obj, list):
-        return any(has_binary(item) for item in obj)
-
-    if isinstance(obj, dict):
-        return any(has_binary(obj[item]) for item in obj)
-
-    return isinstance(obj, bson.binary.Binary)
 
 
 class Protocol:
@@ -98,8 +87,6 @@ class Protocol:
     # .. depends on message_size/bandwidth/performance/client_limits/...
     # !! this might be related to (or even be avoided by using) throttle_rate !!
     delay_between_messages: float = 0.0
-    # Use only BSON for the whole communication if the server has been started with bson_only_mode:=True
-    bson_only_mode: bool = False
 
     parameters: dict[str, Any] | None = None
 
@@ -123,12 +110,11 @@ class Protocol:
         self.external_action_list = {}
 
         if self.parameters:
-            for param_name in ("max_message_size", "delay_between_messages", "bson_only_mode"):
+            for param_name in ("max_message_size", "delay_between_messages"):
                 if param_name in self.parameters:
                     setattr(self, param_name, self.parameters[param_name])
 
         # Configure internal modules
-        message_conversion.configure(self.parameters)
         publishers.configure(self.parameters)
 
         self.fragment_size = self.max_message_size
@@ -157,47 +143,40 @@ class Protocol:
         # (from first opening bracket "{" to next closing bracket "}")
         # .. this causes Exceptions on "inner" closing brackets --> so I suppressed logging of deserialization errors
         except Exception:
-            if self.bson_only_mode:
-                # Since BSON should be used in conjunction with a network handler that receives exactly one full BSON
-                # message. This will then be passed to self.deserialize and shouldn't cause any exceptions because of
-                # fragmented messages (broken or invalid messages might still be sent tough)
-                self.log("error", "Exception in deserialization of BSON")
+            # TODO: handling of partial/multiple/broken json data in incoming buffer
+            # This way is problematic when json contains nested json-objects
+            # ( e.g. { ... { "config": [0,1,2,3] } ...  } )
+            # If outer json is not fully received, stepping through opening brackets will find { "config" : ... }
+            # as a valid json object and pass this "inner" object to rosbridge and throw away the leading part of
+            # the "outer" object. Solution for now: check for "op"-field. I can still imagine cases where a nested
+            # message (e.g. complete service_response fits into the data field of a fragment..) would cause trouble,
+            # but if a response fits as a whole into a fragment, simply do not pack it into a fragment.
+            #
+            # --> from that follows current limitation:
+            #     fragment data must NOT (!) contain a complete json-object that has an "op-field"
+            #
+            # An alternative solution would be to only check from first opening bracket and have a time out on data
+            # in input buffer (to handle broken data)
+            opening_brackets = [i for i, letter in enumerate(self.buffer) if letter == "{"]
+            closing_brackets = [i for i, letter in enumerate(self.buffer) if letter == "}"]
 
-            else:
-                # TODO: handling of partial/multiple/broken json data in incoming buffer
-                # This way is problematic when json contains nested json-objects
-                # ( e.g. { ... { "config": [0,1,2,3] } ...  } )
-                # If outer json is not fully received, stepping through opening brackets will find { "config" : ... }
-                # as a valid json object and pass this "inner" object to rosbridge and throw away the leading part of
-                # the "outer" object. Solution for now: check for "op"-field. I can still imagine cases where a nested
-                # message (e.g. complete service_response fits into the data field of a fragment..) would cause trouble,
-                # but if a response fits as a whole into a fragment, simply do not pack it into a fragment.
-                #
-                # --> from that follows current limitation:
-                #     fragment data must NOT (!) contain a complete json-object that has an "op-field"
-                #
-                # An alternative solution would be to only check from first opening bracket and have a time out on data
-                # in input buffer (to handle broken data)
-                opening_brackets = [i for i, letter in enumerate(self.buffer) if letter == "{"]
-                closing_brackets = [i for i, letter in enumerate(self.buffer) if letter == "}"]
-
-                for start in opening_brackets:
-                    for end in closing_brackets:
-                        try:
-                            msg = self.deserialize(self.buffer[start : end + 1])
-                            if msg.get("op", None) is not None:
-                                # TODO: check if throwing away leading data like this is okay.. loops look okay..
-                                self.buffer = self.buffer[end + 1 : len(self.buffer)]
-                                # jump out of inner loop if json-decode succeeded
-                                break
-                        except Exception:
-                            # debug json-decode errors with this line
-                            # print e
-                            pass
-                    # if load was successful break outer loop, too.
-                    # No need to check if json begins at a "later" opening bracket.
-                    if msg is not None:
-                        break
+            for start in opening_brackets:
+                for end in closing_brackets:
+                    try:
+                        msg = self.deserialize(self.buffer[start : end + 1])
+                        if msg.get("op", None) is not None:
+                            # TODO: check if throwing away leading data like this is okay.. loops look okay..
+                            self.buffer = self.buffer[end + 1 : len(self.buffer)]
+                            # jump out of inner loop if json-decode succeeded
+                            break
+                    except Exception:
+                        # debug json-decode errors with this line
+                        # print e
+                        pass
+                # if load was successful break outer loop, too.
+                # No need to check if json begins at a "later" opening bracket.
+                if msg is not None:
+                    break
 
         # if decoding of buffer failed .. simply return
         if msg is None:
@@ -255,7 +234,7 @@ class Protocol:
             self.old_buffer = self.buffer
             self.incoming()
 
-    def outgoing(self, message: bson.BSON | bytearray | str, compression: str = "none") -> None:
+    def outgoing(self, message: bytes | str, compression: str = "none") -> None:
         """
         Pass an outgoing message to the client.
 
@@ -278,9 +257,12 @@ class Protocol:
         :param message: A dict of message values to be marshalled and sent
         :param cid: (optional) An associated id
         """
-        serialized = (
-            message if compression in ["cbor", "cbor-raw"] else self.serialize(message, cid)
-        )
+        serialized: bytes | str | None
+        if isinstance(message, bytes):
+            serialized = message
+        else:
+            serialized = self.serialize(message, cid)
+
         if serialized is not None:
             if self.png == "png":
                 # TODO: png compression on outgoing messages
@@ -301,10 +283,7 @@ class Protocol:
             # fragment list not empty -> send fragments
             if fragment_list is not None:
                 for fragment in fragment_list:
-                    if self.bson_only_mode:
-                        self.outgoing(bson.BSON.encode(fragment), compression)
-                    else:
-                        self.outgoing(json.dumps(fragment), compression)
+                    self.outgoing(json.dumps(fragment), compression)
                     # okay to use delay here (sender's send()-function) because rosbridge is sending next request only
                     # to service provider when last one had finished. If this was not the case, this delay would need to
                     # be implemented in service-provider's (meaning message receiver's) send_message()-function in
@@ -326,9 +305,9 @@ class Protocol:
 
     def serialize(
         self,
-        msg: bytearray | bson.BSON | dict[str, Any],
+        msg: dict[str, Any],
         cid: str | None = None,  # noqa: ARG002
-    ) -> bson.BSON | bytearray | str | None:
+    ) -> str | None:
         """
         Turn a dictionary of values into the appropriate wire-level representation.
 
@@ -340,16 +319,12 @@ class Protocol:
         :return: a JSON string representing the dictionary
         """
         try:
-            if isinstance(msg, bytearray):
-                return msg
-            if has_binary(msg) or self.bson_only_mode:
-                return bson.BSON.encode(msg)
             return json.dumps(msg)
         except Exception as e:
             self.log("error", f"Unable to serialize message '{msg}': {e}")
             return None
 
-    def deserialize(self, msg: str | bytes | bytearray, cid: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+    def deserialize(self, msg: str, cid: str | None = None) -> dict[str, Any]:  # noqa: ARG002
         """
         Turn the wire-level representation into a dictionary of values.
 
@@ -361,9 +336,6 @@ class Protocol:
         :return: a dictionary of values
         """
         try:
-            if self.bson_only_mode:
-                bson_message = bson.BSON(msg)
-                return bson_message.decode()
             return json.loads(msg)
         except Exception:
             # if we did try to deserialize the whole buffer, first try to let self.incoming check for multiple/partial

--- a/rosbridge_library/src/rosbridge_library/util/__init__.py
+++ b/rosbridge_library/src/rosbridge_library/util/__init__.py
@@ -6,15 +6,3 @@ except ImportError:
         import simplejson as json  # type: ignore[import-untyped, no-redef]
     except ImportError:
         import json  # type: ignore[no-redef] # noqa: F401
-
-import bson
-
-try:
-    _ = bson.BSON
-except AttributeError as exc:
-    msg = (
-        "BSON installation does not support all necessary features. "
-        "Please use the MongoDB BSON implementation. "
-        "See: https://github.com/RobotWebTools/rosbridge_suite/issues/198"
-    )
-    raise Exception(msg) from exc

--- a/rosbridge_library/test/internal/actions/test_actions.py
+++ b/rosbridge_library/test/internal/actions/test_actions.py
@@ -65,10 +65,6 @@ class ActionTester:
 
 
 class TestActions(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        message_conversion.configure()
-
     def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()

--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -100,10 +100,6 @@ class ServiceTester:
 
 
 class TestServices(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        message_conversion.configure()
-
     def setUp(self) -> None:
         rclpy.init()
         self.executor = SingleThreadedExecutor()

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -19,10 +19,6 @@ if TYPE_CHECKING:
 
 
 class TestMessageConversion(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        message_conversion.configure()
-
     def validate_instance(self, inst1: ROSMessage) -> None:
         """
         Validate that the instance is correct by serializing and deserializing it.

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -25,11 +25,8 @@
   <arg name="services_glob" default="" />
   <arg name="params_glob" default="" />
   <arg name="params_timeout" default="5.0" />
-  <arg name="bson_only_mode" default="false" />
 
   <arg name="respawn" default="false"/>
-
-  <arg unless="$(var bson_only_mode)" name="binary_encoder" default="default"/>
 
   <group if="$(var ssl)">
     <node name="rosbridge_websocket" namespace="$(var namespace)" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen" respawn="$(var respawn)" >
@@ -74,8 +71,6 @@
       <param name="topics_glob" value="$(var topics_glob)"/>
       <param name="services_glob" value="$(var services_glob)"/>
       <param name="params_glob" value="$(var params_glob)"/>
-
-      <param name="bson_only_mode" value="$(var bson_only_mode)"/>
     </node>
   </group>
 

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -84,14 +84,6 @@ PROTOCOL_PARAMETERS = (
         10.0,
         "How long to wait before unregistering a client from publisher after unadvertising publisher.",
     ),
-    (
-        "binary_encoder_type",
-        str,
-        "default",
-        "Encoder used for encoding binary data in messages. Available: 'default', 'b64', `bson'. "
-        "Ignored if bson_only_mode is True.",
-    ),
-    ("bson_only_mode", bool, False, "Use BSON only mode for messages."),
     ("topics_glob", str, "", "Glob patterns for topics publish/subscribe."),
     ("services_glob", str, "", "Glob patterns for services call/advertise."),
     ("actions_glob", str, "", "Glob patterns for actions send/advertise."),

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -44,7 +44,6 @@ from typing import TYPE_CHECKING, ClassVar, ParamSpec, TypeVar
 
 from rclpy.node import Node
 from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
-from rosbridge_library.util import bson
 from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError, WebSocketHandler
 
@@ -190,18 +189,18 @@ class RosbridgeWebSocket(WebSocketHandler):
         )
         self.incoming_queue.finish()
 
-    def send_message(self, message: bson.BSON | bytearray | str, compression: str = "none") -> None:
+    def send_message(self, message: bytes | str, compression: str = "none") -> None:
         cls = self.__class__
         assert isinstance(cls.event_loop, AbstractEventLoop), "Event loop was not set"
 
-        if isinstance(message, bson.BSON) or compression in ["cbor", "cbor-raw"]:
+        if compression in ["cbor", "cbor-raw"]:
             binary = True
         else:
             binary = False
 
         asyncio.run_coroutine_threadsafe(self.prewrite_message(message, binary), cls.event_loop)
 
-    async def prewrite_message(self, message: bson.BSON | bytearray | str, binary: bool) -> None:
+    async def prewrite_message(self, message: bytes | str, binary: bool) -> None:
         cls = self.__class__
         assert isinstance(cls.node_handle, Node), "Node handle was not set"
         try:


### PR DESCRIPTION
**Public API Changes**
Removed `binary_encoder_type` and `bson_only_mode` parameters.


**Description**
As discussed in RobotWebTools/roslibjs#1039, #1105 and #1124, there are many reasons for dropping support for BSON and once we figure a way for the server to be able to receive CBOR encoded messages, not only send them, there will be no real advantage of using BSON over CBOR.

Since Lyrical is right around the corner, I figured this is the best time for feature-breaking PRs. This WILL NOT be backported to Kilted or earlier distros.
