### PR TITLE
feat: Add timeout parameters to launch

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -17,6 +17,8 @@
   <arg name="unregister_timeout" default="10.0" />
 
   <arg name="use_compression" default="false" />
+  <arg name="websocket_ping_interval" default="0.0" />
+  <arg name="websocket_ping_timeout" default="30.0" />
   <arg name="call_services_in_new_thread" default="true" />
   <arg name="default_call_service_timeout" default="5.0" />
   <arg name="send_action_goals_in_new_thread" default="true" />
@@ -37,6 +39,8 @@
       <param name="url_path" value="$(var url_path)"/>
       <param name="use_events_executor" value="$(var use_events_executor)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>
+      <param name="websocket_ping_interval" value="$(var websocket_ping_interval)"/>
+      <param name="websocket_ping_timeout" value="$(var websocket_ping_timeout)"/>
       <param name="fragment_timeout" value="$(var fragment_timeout)"/>
       <param name="delay_between_messages" value="$(var delay_between_messages)"/>
       <param name="max_message_size" value="$(var max_message_size)"/>
@@ -59,6 +63,8 @@
       <param name="url_path" value="$(var url_path)"/>
       <param name="use_events_executor" value="$(var use_events_executor)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>
+      <param name="websocket_ping_interval" value="$(var websocket_ping_interval)"/>
+      <param name="websocket_ping_timeout" value="$(var websocket_ping_timeout)"/>
       <param name="fragment_timeout" value="$(var fragment_timeout)"/>
       <param name="delay_between_messages" value="$(var delay_between_messages)"/>
       <param name="max_message_size" value="$(var max_message_size)"/>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -66,8 +66,8 @@ SERVER_PARAMETERS = (
     ("certfile", str, "", "Path to the SSL certificate file."),
     ("keyfile", str, "", "Path to the SSL key file."),
     # Tornado settings
-    ("websocket_ping_interval", float, 0, "Interval in seconds for WebSocket ping messages."),
-    ("websocket_ping_timeout", float, 30, "Timeout in seconds for WebSocket ping responses."),
+    ("websocket_ping_interval", float, 0.0, "Interval in seconds for WebSocket ping messages."),
+    ("websocket_ping_timeout", float, 30.0, "Timeout in seconds for WebSocket ping responses."),
     # Websocket handler parameters
     ("use_compression", bool, False, "Enable compression for WebSocket messages."),
     # Executor parameters


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Watchdog timeout args/parameters were not available in launch file and were of the wrong type before. This fixes that.