### PR TITLE
feat: Add pep8-naming checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ select = [
     "C90",    # mccabe
     "NPY",    # numpy
     "PD",     # pandas-vet
-    # "N",    # pep8-naming, Can't fix without breaking API
+    "N",      # pep8-naming
     "PERF",   # Perflint
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
@@ -95,6 +95,8 @@ ignore = [
     "S101", # assert
     "S110", # try-except-pass
     "S311", # suspicious-non-cryptographic-random-usage
+
+    "N818", # error-suffix-on-exception-name, Would break existing exception names
 
     # Pylint "too-many" errors
     "PLR0911",

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -37,14 +37,14 @@ class TestMultiSubscriber(unittest.TestCase):
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def assertTopicSubscribed(self, topic: str, timeout: float = 1.0) -> None:
+    def assert_topic_subscribed(self, topic: str, timeout: float = 1.0) -> None:
         start_time = time.monotonic()
         while not is_topic_subscribed(self.node, topic):
             time.sleep(0.05)
             if time.monotonic() - start_time > timeout:
                 self.fail(f"Timed out waiting for topic '{topic}' to be subscribed.")
 
-    def assertTopicNotSubscribed(self, topic: str, timeout: float = 1.0) -> None:
+    def assert_topic_not_subscribed(self, topic: str, timeout: float = 1.0) -> None:
         start_time = time.monotonic()
         while is_topic_subscribed(self.node, topic):
             time.sleep(0.05)
@@ -56,22 +56,22 @@ class TestMultiSubscriber(unittest.TestCase):
         topic = "/test_register_multisubscriber"
         msg_type = "std_msgs/String"
 
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         MultiSubscriber(topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
     def test_unregister_multisubscriber(self) -> None:
         """Register and unregister a subscriber on a clean topic with a good msg type."""
         topic = "/test_unregister_multisubscriber"
         msg_type = "std_msgs/String"
 
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         multi: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
         multi.unregister()
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
     def test_verify_type(self) -> None:
         topic = "/test_verify_type"
@@ -101,11 +101,11 @@ class TestMultiSubscriber(unittest.TestCase):
         topic = "/test_subscribe_unsubscribe"
         msg_type = "std_msgs/String"
 
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         multi: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
         self.assertEqual(len(multi.new_subscriptions), 0)
 
         multi.subscribe(self.client_id, lambda _: None)
@@ -115,7 +115,7 @@ class TestMultiSubscriber(unittest.TestCase):
         self.assertEqual(len(multi.new_subscriptions), 0)
 
         multi.unregister()
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
     def test_subscribe_receive_json(self) -> None:
         topic = "/test_subscribe_receive_json"

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -38,14 +38,14 @@ class TestSubscriberManager(unittest.TestCase):
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def assertTopicSubscribed(self, topic: str, timeout: float = 1.0) -> None:
+    def assert_topic_subscribed(self, topic: str, timeout: float = 1.0) -> None:
         start_time = time.monotonic()
         while not is_topic_subscribed(self.node, topic):
             time.sleep(0.05)
             if time.monotonic() - start_time > timeout:
                 self.fail(f"Timed out waiting for topic '{topic}' to be subscribed.")
 
-    def assertTopicNotSubscribed(self, topic: str, timeout: float = 1.0) -> None:
+    def assert_topic_not_subscribed(self, topic: str, timeout: float = 1.0) -> None:
         start_time = time.monotonic()
         while is_topic_subscribed(self.node, topic):
             time.sleep(0.05)
@@ -59,14 +59,14 @@ class TestSubscriberManager(unittest.TestCase):
         client = "client_test_subscribe"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         manager.subscribe(client, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.unsubscribe(client, topic)
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
     def test_register_subscriber_multiclient(self) -> None:
         topic = "/test_register_subscriber_multiclient"
@@ -75,22 +75,22 @@ class TestSubscriberManager(unittest.TestCase):
         client2 = "client_test_register_subscriber_multiclient_2"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         manager.subscribe(client1, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.subscribe(client2, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.unsubscribe(client1, topic)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.unsubscribe(client2, topic)
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
     def test_register_publisher_conflicting_types(self) -> None:
         topic = "/test_register_publisher_conflicting_types"
@@ -99,10 +99,10 @@ class TestSubscriberManager(unittest.TestCase):
         client = "client_test_register_publisher_conflicting_types"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         manager.subscribe(client, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         self.assertRaises(
             TypeConflictException,
@@ -122,39 +122,39 @@ class TestSubscriberManager(unittest.TestCase):
 
         self.assertFalse(topic1 in manager._subscribers)
         self.assertFalse(topic2 in manager._subscribers)
-        self.assertTopicNotSubscribed(topic1)
-        self.assertTopicNotSubscribed(topic2)
+        self.assert_topic_not_subscribed(topic1)
+        self.assert_topic_not_subscribed(topic2)
 
         manager.subscribe(client, topic1, lambda _: None, self.node, msg_type)
         self.assertTrue(topic1 in manager._subscribers)
-        self.assertTopicSubscribed(topic1)
+        self.assert_topic_subscribed(topic1)
         self.assertFalse(topic2 in manager._subscribers)
-        self.assertTopicNotSubscribed(topic2)
+        self.assert_topic_not_subscribed(topic2)
 
         manager.subscribe(client, topic2, lambda _: None, self.node, msg_type)
         self.assertTrue(topic1 in manager._subscribers)
-        self.assertTopicSubscribed(topic1)
+        self.assert_topic_subscribed(topic1)
         self.assertTrue(topic2 in manager._subscribers)
-        self.assertTopicSubscribed(topic2)
+        self.assert_topic_subscribed(topic2)
 
         manager.unsubscribe(client, topic1)
         self.assertFalse(topic1 in manager._subscribers)
-        self.assertTopicNotSubscribed(topic1)
+        self.assert_topic_not_subscribed(topic1)
         self.assertTrue(topic2 in manager._subscribers)
-        self.assertTopicSubscribed(topic2)
+        self.assert_topic_subscribed(topic2)
 
         manager.unsubscribe(client, topic2)
         self.assertFalse(topic1 in manager._subscribers)
-        self.assertTopicNotSubscribed(topic1)
+        self.assert_topic_not_subscribed(topic1)
         self.assertFalse(topic2 in manager._subscribers)
-        self.assertTopicNotSubscribed(topic2)
+        self.assert_topic_not_subscribed(topic2)
 
     def test_register_no_msgtype(self) -> None:
         topic = "/test_register_no_msgtype"
         client = "client_test_register_no_msgtype"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         self.assertRaises(
             TopicNotEstablishedException, manager.subscribe, client, topic, None, self.node
         )
@@ -163,7 +163,7 @@ class TestSubscriberManager(unittest.TestCase):
         topic = "/test_register_infer_topictype"
         client = "client_test_register_infer_topictype"
 
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
         subscriber_qos = QoSProfile(
             depth=10,
@@ -171,16 +171,16 @@ class TestSubscriberManager(unittest.TestCase):
         )
         self.node.create_subscription(String, topic, lambda *_args: None, subscriber_qos)
 
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
         self.assertFalse(topic in manager._subscribers)
 
         manager.subscribe(client, topic, lambda _: None, self.node)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.unsubscribe(client, topic)
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
     def test_register_multiple_notopictype(self) -> None:
         topic = "/test_register_multiple_notopictype"
@@ -189,30 +189,30 @@ class TestSubscriberManager(unittest.TestCase):
         client2 = "client_test_register_multiple_notopictype_2"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
         manager.subscribe(client1, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.subscribe(client2, topic, lambda _: None, self.node)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.unsubscribe(client1, topic)
         self.assertTrue(topic in manager._subscribers)
-        self.assertTopicSubscribed(topic)
+        self.assert_topic_subscribed(topic)
 
         manager.unsubscribe(client2, topic)
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
 
     def test_subscribe_not_registered(self) -> None:
         topic = "/test_subscribe_not_registered"
         client = "client_test_subscribe_not_registered"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assertTopicNotSubscribed(topic)
+        self.assert_topic_not_subscribed(topic)
         self.assertRaises(
             TopicNotEstablishedException, manager.subscribe, client, topic, None, self.node
         )

--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -35,16 +35,16 @@ class TestClientProtocol(WebSocketClientProtocol):
         self.message_handler = lambda _: None
         super().__init__(*args, **kwargs)
 
-    def onOpen(self) -> None:
+    def onOpen(self) -> None:  # noqa: N802
         self.connected_future.set_result(None)
 
-    def sendJson(self, msg_dict: dict[str, Any], *, times: int = 1) -> None:
+    def sendJson(self, msg_dict: dict[str, Any], *, times: int = 1) -> None:  # noqa: N802
         msg = json.dumps(msg_dict).encode("utf-8")
         for _ in range(times):
             print(f"WebSocket client sent message: {msg!r}")
             self.sendMessage(msg)
 
-    def onMessage(self, payload: str, binary: bool) -> None:
+    def onMessage(self, payload: str, binary: bool) -> None:  # noqa: N802
         print(f"WebSocket client received message: {payload}")
         self.message_handler(payload if binary else json.loads(payload))
 

--- a/rosbridge_server/test/websocket/smoke.test.py
+++ b/rosbridge_server/test/websocket/smoke.test.py
@@ -25,22 +25,23 @@ log.startLogging(sys.stderr)
 generate_test_description = common.generate_test_description
 
 
+# For consistency, the number of messages must not exceed the the protocol
+# Subscriber queue_size.
+NUM_MSGS = 10
+MSG_SIZE = 10
+A_TOPIC = "/a_topic"
+B_TOPIC = "/b_topic"
+A_STRING = "A" * MSG_SIZE
+B_STRING = "B" * MSG_SIZE
+WARMUP_DELAY = 1.0  # seconds
+
+
 class TestWebsocketSmoke(unittest.TestCase):
     @websocket_test
     async def test_smoke(
         self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
     ) -> None:
         ws_client = await make_client()
-        # For consistency, the number of messages must not exceed the the protocol
-        # Subscriber queue_size.
-        NUM_MSGS = 10
-        MSG_SIZE = 10
-        A_TOPIC = "/a_topic"
-        B_TOPIC = "/b_topic"
-        A_STRING = "A" * MSG_SIZE
-        B_STRING = "B" * MSG_SIZE
-        WARMUP_DELAY = 1.0  # seconds
-
         sub_completed_future: Future[list[String]]
         sub_completed_future, sub_handler = expect_messages(
             NUM_MSGS, "ROS subscriber", node.get_logger()


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Enforces the naming conventions from PEP8 style guide.
