### PR TITLE
Configurable qos_depth

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -76,6 +76,7 @@ class Subscription(Generic[ROSMessageT]):
         topic: str,
         publish: Callable[[OutgoingMessage[ROSMessageT], int | None, str], None] | None,
         node_handle: Node,
+        qos_depth: int = 10,
     ) -> None:
         """
         Create a subscription.
@@ -92,6 +93,7 @@ class Subscription(Generic[ROSMessageT]):
         self.topic = topic
         self.publish = publish
         self.node_handle = node_handle
+        self.subscriber_qos_depth = qos_depth
 
         self.clients = {}
 
@@ -156,6 +158,7 @@ class Subscription(Generic[ROSMessageT]):
             self.node_handle,
             msg_type=msg_type,
             raw=raw,
+            qos_depth=self.subscriber_qos_depth,
         )
 
     def unsubscribe(self, sid: str | None = None) -> None:
@@ -248,9 +251,10 @@ class Subscribe(Capability):
     )
     unsubscribe_msg_fields = ((True, "topic", str),)
 
-    parameter_names = ("topics_glob",)
+    parameter_names = ("topics_glob", "subscriber_qos_depth")
 
     topics_glob: list[str] | None = None
+    subscriber_qos_depth: int = 10
 
     def __init__(self, protocol: Protocol) -> None:
         # Call superclass constructor
@@ -296,7 +300,7 @@ class Subscribe(Capability):
             client_id = self.protocol.client_id
             cb = partial(self.publish, topic)
             self._subscriptions[topic] = Subscription(
-                client_id, topic, cb, self.protocol.node_handle
+                client_id, topic, cb, self.protocol.node_handle, qos_depth=self.subscriber_qos_depth
             )
 
         # Register the subscriber

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -77,6 +77,7 @@ class MultiSubscriber(Generic[ROSMessageT]):
         node_handle: Node,
         msg_type: str | None = None,
         raw: bool = False,
+        qos_depth: int = 10,
     ) -> None:
         """
         Register a subscriber on the specified topic.
@@ -135,7 +136,7 @@ class MultiSubscriber(Generic[ROSMessageT]):
         # - https://github.com/RobotWebTools/rosbridge_suite/issues/551
         # - https://github.com/RobotWebTools/rosbridge_suite/issues/769
         qos = QoSProfile(
-            depth=10,
+            depth=qos_depth,
             durability=DurabilityPolicy.VOLATILE,
             reliability=ReliabilityPolicy.BEST_EFFORT,
         )
@@ -304,6 +305,7 @@ class SubscriberManager:
         node_handle: Node,
         msg_type: str | None = None,
         raw: bool = False,
+        qos_depth: int = 10,
     ) -> None:
         """
         Subscribe to a topic.
@@ -316,7 +318,13 @@ class SubscriberManager:
         with self._lock:
             if topic not in self._subscribers:
                 self._subscribers[topic] = MultiSubscriber(
-                    topic, client_id, callback, node_handle, msg_type=msg_type, raw=raw
+                    topic,
+                    client_id,
+                    callback,
+                    node_handle,
+                    msg_type=msg_type,
+                    raw=raw,
+                    qos_depth=qos_depth,
                 )
             else:
                 self._subscribers[topic].subscribe(client_id, callback)

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -27,6 +27,7 @@
   <arg name="services_glob" default="" />
   <arg name="params_glob" default="" />
   <arg name="params_timeout" default="5.0" />
+  <arg name="subscriber_qos_depth" default="10" />
 
   <arg name="respawn" default="false"/>
 
@@ -53,6 +54,7 @@
       <param name="topics_glob" value="$(var topics_glob)"/>
       <param name="services_glob" value="$(var services_glob)"/>
       <param name="params_glob" value="$(var params_glob)"/>
+      <param name="subscriber_qos_depth" value="$(var subscriber_qos_depth)"/>
     </node>
   </group>
 
@@ -77,6 +79,7 @@
       <param name="topics_glob" value="$(var topics_glob)"/>
       <param name="services_glob" value="$(var services_glob)"/>
       <param name="params_glob" value="$(var params_glob)"/>
+      <param name="subscriber_qos_depth" value="$(var subscriber_qos_depth)"/>
     </node>
   </group>
 

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -90,6 +90,7 @@ PROTOCOL_PARAMETERS = (
     ("call_services_in_new_thread", bool, True, "Call services in a new threads."),
     ("default_call_service_timeout", float, 5.0, "Default timeout for service calls."),
     ("send_action_goals_in_new_thread", bool, True, "Send action goals in a new threads."),
+    ("subscriber_qos_depth", int, 10, "Default QoS queue depth for topic subscriptions."),
 )
 
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Adds an option to define default bridge subscriber QoS depth at launch time. This was added because in our usecase we do not care about any old data and preferred a queue size of 1.

<!-- Link relevant GitHub issues -->
