### PR TITLE
feat: Create topic registrations in publish when topic not previously advertised

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -67,7 +67,11 @@ class Registration:
         manager.unregister(self.client_id, self.topic)
 
     def register_advertisement(
-        self, msg_type: str, adv_id: str | None = None, latch: bool = False, queue_size: int = 100
+        self,
+        msg_type: str | None,
+        adv_id: str | None = None,
+        latch: bool = False,
+        queue_size: int = 100,
     ) -> None:
         # Register with the publisher manager, propagating any exception
         manager.register(
@@ -111,8 +115,6 @@ class Advertise(Capability):
         protocol.register_operation("advertise", self.advertise)
         protocol.register_operation("unadvertise", self.unadvertise)
 
-        self._registrations: dict[str, Registration] = {}
-
     def advertise(self, message: dict[str, Any]) -> None:
         # Pull out the ID
         aid = message.get("id")
@@ -144,12 +146,16 @@ class Advertise(Capability):
             self.protocol.log("debug", "No topic security glob, not checking advertisement.")
 
         # Create the Registration if one doesn't yet exist
-        if topic not in self._registrations:
+        if topic not in self.protocol.topic_registrations:
             client_id = self.protocol.client_id
-            self._registrations[topic] = Registration(client_id, topic, self.protocol.node_handle)
-
-        # Register, propagating any exceptions
-        self._registrations[topic].register_advertisement(msg_type, aid, latch, queue_size)
+            registration = Registration(client_id, topic, self.protocol.node_handle)
+            registration.register_advertisement(msg_type, aid, latch, queue_size)
+            self.protocol.topic_registrations[topic] = registration
+        else:
+            # Register, propagating any exceptions
+            self.protocol.topic_registrations[topic].register_advertisement(
+                msg_type, aid, latch, queue_size
+            )
 
     def unadvertise(self, message: dict[str, Any]) -> None:
         # Pull out the ID
@@ -179,18 +185,18 @@ class Advertise(Capability):
             self.protocol.log("debug", "No topic security glob, not checking unadvertisement.")
 
         # Now unadvertise the topic
-        if topic not in self._registrations:
+        if topic not in self.protocol.topic_registrations:
             return
-        self._registrations[topic].unregister_advertisement(aid)
+        self.protocol.topic_registrations[topic].unregister_advertisement(aid)
 
         # Check if the registration is now finished with
-        if self._registrations[topic].is_empty():
-            self._registrations[topic].unregister()
-            del self._registrations[topic]
+        if self.protocol.topic_registrations[topic].is_empty():
+            self.protocol.topic_registrations[topic].unregister()
+            del self.protocol.topic_registrations[topic]
 
     def finish(self) -> None:
-        for registration in self._registrations.values():
+        for registration in self.protocol.topic_registrations.values():
             registration.unregister()
-        self._registrations.clear()
+        self.protocol.topic_registrations.clear()
         self.protocol.unregister_operation("advertise")
         self.protocol.unregister_operation("unadvertise")

--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise.py
@@ -116,8 +116,8 @@ class Advertise(Capability):
         protocol.register_operation("unadvertise", self.unadvertise)
 
     def advertise(self, message: dict[str, Any]) -> None:
-        # Pull out the ID
-        aid = message.get("id")
+        # Pull out the ID of the advertisement, if it exists
+        adv_id = message.get("id")
 
         self.basic_type_check(message, self.advertise_msg_fields)
         topic: str = message["topic"]
@@ -149,12 +149,12 @@ class Advertise(Capability):
         if topic not in self.protocol.topic_registrations:
             client_id = self.protocol.client_id
             registration = Registration(client_id, topic, self.protocol.node_handle)
-            registration.register_advertisement(msg_type, aid, latch, queue_size)
+            registration.register_advertisement(msg_type, adv_id, latch, queue_size)
             self.protocol.topic_registrations[topic] = registration
         else:
             # Register, propagating any exceptions
             self.protocol.topic_registrations[topic].register_advertisement(
-                msg_type, aid, latch, queue_size
+                msg_type, adv_id, latch, queue_size
             )
 
     def unadvertise(self, message: dict[str, Any]) -> None:

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import fnmatch
 from typing import TYPE_CHECKING, Any
 
+from rosbridge_library.capabilities.advertise import Registration
 from rosbridge_library.capability import Capability
 from rosbridge_library.internal.publishers import manager
 
@@ -44,7 +45,13 @@ if TYPE_CHECKING:
 
 
 class Publish(Capability):
-    publish_msg_fields = ((True, "topic", str),)
+    publish_msg_fields = (
+        (True, "topic", str),
+        (False, "type", str),
+        (False, "latch", bool),
+        (False, "queue_size", int),
+        (False, "msg", dict),
+    )
 
     parameter_names = ("topics_glob",)
 
@@ -57,13 +64,12 @@ class Publish(Capability):
         # Register the operations that this capability provides
         protocol.register_operation("publish", self.publish)
 
-        # Save the topics that are published on for the purposes of unregistering
-        self._published: dict[str, bool] = {}
-
     def publish(self, message: dict[str, Any]) -> None:
         # Do basic type checking
         self.basic_type_check(message, self.publish_msg_fields)
+        aid: str | None = message.get("id")
         topic: str = message["topic"]
+        msg_type: str | None = message.get("type")
         latch: bool = message.get("latch", False)
         queue_size: int = message.get("queue_size", 100)
 
@@ -86,16 +92,17 @@ class Publish(Capability):
         else:
             self.protocol.log("debug", "No topic security glob, not checking publish.")
 
-        # Register as a publishing client, propagating any exceptions
         client_id = self.protocol.client_id
-        manager.register(
-            client_id,
-            topic,
-            self.protocol.node_handle,
-            latch=latch,
-            queue_size=queue_size,
-        )
-        self._published[topic] = True
+
+        if topic not in self.protocol.topic_registrations:
+            self.protocol.log(
+                "warn",
+                "Trying to publish to unregistered topic: " + topic + ", creating registration...",
+            )
+            registration = Registration(client_id, topic, self.protocol.node_handle)
+            # Register as a publishing client, propagating any exceptions
+            registration.register_advertisement(msg_type, aid, latch, queue_size)
+            self.protocol.topic_registrations[topic] = registration
 
         # Get the message if one was provided
         msg: dict[str, Any] = message.get("msg", {})
@@ -109,9 +116,3 @@ class Publish(Capability):
             latch=latch,
             queue_size=queue_size,
         )
-
-    def finish(self) -> None:
-        client_id = self.protocol.client_id
-        for topic in self._published:
-            manager.unregister(client_id, topic)
-        self._published.clear()

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -67,7 +67,10 @@ class Publish(Capability):
     def publish(self, message: dict[str, Any]) -> None:
         # Do basic type checking
         self.basic_type_check(message, self.publish_msg_fields)
-        aid: str | None = message.get("id")
+
+        # Pull out the ID of the advertisement, if it exists
+        adv_id: str | None = message.get("id")
+
         topic: str = message["topic"]
         msg_type: str | None = message.get("type")
         latch: bool = message.get("latch", False)
@@ -101,7 +104,7 @@ class Publish(Capability):
             )
             registration = Registration(client_id, topic, self.protocol.node_handle)
             # Register as a publishing client, propagating any exceptions
-            registration.register_advertisement(msg_type, aid, latch, queue_size)
+            registration.register_advertisement(msg_type, adv_id, latch, queue_size)
             self.protocol.topic_registrations[topic] = registration
 
         # Get the message if one was provided

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -96,7 +96,7 @@ class Publish(Capability):
 
         if topic not in self.protocol.topic_registrations:
             self.protocol.log(
-                "warn",
+                "info",
                 "Trying to publish to unregistered topic: " + topic + ", creating registration...",
             )
             registration = Registration(client_id, topic, self.protocol.node_handle)

--- a/rosbridge_library/src/rosbridge_library/capabilities/publish.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/publish.py
@@ -108,11 +108,4 @@ class Publish(Capability):
         msg: dict[str, Any] = message.get("msg", {})
 
         # Publish the message
-        manager.publish(
-            client_id,
-            topic,
-            msg,
-            self.protocol.node_handle,
-            latch=latch,
-            queue_size=queue_size,
-        )
+        manager.publish(topic, msg)

--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -43,6 +43,7 @@ from rosbridge_library.internal import message_conversion, ros_loader
 from rosbridge_library.internal.message_conversion import msg_class_type_repr
 from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
+    TopicNotRegisteredException,
     TypeConflictException,
 )
 from rosbridge_library.internal.type_support import ROSMessage, ROSMessageT
@@ -309,33 +310,18 @@ class PublisherManager:
         for topic in self._publishers:
             self.unregister(client_id, topic)
 
-    def publish(
-        self,
-        client_id: str,
-        topic: str,
-        msg: dict,
-        node_handle: Node,
-        latch: bool = False,
-        queue_size: int = 100,
-    ) -> None:
+    def publish(self, topic: str, msg: dict) -> None:
         """
         Publish a message on the given topic.
 
-        Tries to create a publisher on the topic if one does not already exist.
-
-        :param client_id: The ID of the client making this request
         :param topic: The topic to publish the message on
         :param msg: A JSON-like dict of fields and values
-        :param node_handle: Handle to a rclpy node to create the publisher
-        :param latch: (optional) Whether to make this publisher latched
-        :param queue_size: (optional) Publisher queue_size to use
-
-        :raises Exception: A variety of exceptions are propagated. They can be thrown if there is
-            a problem setting up or getting the publisher, or if the provided msg does not map to
-            the msg class of the publisher.
+        :raises TopicNotRegisteredException: If there is no publisher registered for the given topic
+        :raises TypeError: If the provided msg does not conform to the message type of the publisher
+            for the given topic
         """
         if topic not in self._publishers:
-            self.register(client_id, topic, node_handle, latch=latch, queue_size=queue_size)
+            raise TopicNotRegisteredException(topic)
 
         self._publishers[topic].publish(msg)
 

--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -334,7 +334,8 @@ class PublisherManager:
             a problem setting up or getting the publisher, or if the provided msg does not map to
             the msg class of the publisher.
         """
-        self.register(client_id, topic, node_handle, latch=latch, queue_size=queue_size)
+        if topic not in self._publishers:
+            self.register(client_id, topic, node_handle, latch=latch, queue_size=queue_size)
 
         self._publishers[topic].publish(msg)
 

--- a/rosbridge_library/src/rosbridge_library/internal/publishers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/publishers.py
@@ -317,7 +317,7 @@ class PublisherManager:
         :param topic: The topic to publish the message on
         :param msg: A JSON-like dict of fields and values
         :raises TopicNotRegisteredException: If there is no publisher registered for the given topic
-        :raises TypeError: If the provided msg does not conform to the message type of the publisher
+        :raises Exception: If the provided msg does not conform to the message type of the publisher
             for the given topic
         """
         if topic not in self._publishers:

--- a/rosbridge_library/src/rosbridge_library/internal/topics.py
+++ b/rosbridge_library/src/rosbridge_library/internal/topics.py
@@ -43,6 +43,14 @@ class TopicNotEstablishedException(Exception):
         )
 
 
+class TopicNotRegisteredException(Exception):
+    def __init__(self, topic: str) -> None:
+        Exception.__init__(
+            self,
+            f"Cannot publish to topic {topic} as it is not registered",
+        )
+
+
 class TypeConflictException(Exception):
     def __init__(self, topic: str, orig_type: str, new_type: str) -> None:
         Exception.__init__(

--- a/rosbridge_library/src/rosbridge_library/internal/topics.py
+++ b/rosbridge_library/src/rosbridge_library/internal/topics.py
@@ -47,7 +47,7 @@ class TopicNotRegisteredException(Exception):
     def __init__(self, topic: str) -> None:
         Exception.__init__(
             self,
-            f"Cannot publish to topic {topic} as it is not registered",
+            f"Cannot publish to topic '{topic}' as it is not registered",
         )
 
 

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
+    from rosbridge_library.capabilities.advertise import Registration
     from rosbridge_library.capabilities.advertise_action import AdvertisedActionHandler
     from rosbridge_library.capabilities.advertise_service import AdvertisedServiceHandler
     from rosbridge_library.capability import Capability
@@ -77,6 +78,9 @@ class Protocol:
     buffer = ""
     old_buffer = ""
     busy = False
+
+    # tracks topics advertised by the client
+    topic_registrations: dict[str, Registration]
     # global list of non-ros advertised services
     external_service_list: dict[str, AdvertisedServiceHandler]
     # global list of non-ros advertised actions
@@ -106,6 +110,7 @@ class Protocol:
 
         self.capabilities: list[Capability] = []
         self.operations: dict[str, Callable[[dict[str, Any]], None]] = {}
+        self.topic_registrations = {}
         self.external_service_list = {}
         self.external_action_list = {}
 

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -14,6 +14,7 @@ from rosbridge_library.internal.message_conversion import FieldTypeMismatchExcep
 from rosbridge_library.internal.publishers import manager
 from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
+    TopicNotRegisteredException,
     TypeConflictException,
 )
 from rosbridge_library.util.ros import is_topic_published
@@ -217,13 +218,10 @@ class TestPublisherManager(unittest.TestCase):
     def test_publish_not_registered(self) -> None:
         topic = "/test_publish_not_registered"
         msg = {"data": "test publish not registered"}
-        client = "client_test_publish_not_registered"
 
         self.assertFalse(topic in manager._publishers)
         self.assertFalse(is_topic_published(self.node, topic))
-        self.assertRaises(
-            TopicNotEstablishedException, manager.publish, client, topic, msg, self.node
-        )
+        self.assertRaises(TopicNotRegisteredException, manager.publish, topic, msg)
 
     def test_publisher_manager_publish(self) -> None:
         """Make sure that publishing works."""
@@ -242,7 +240,8 @@ class TestPublisherManager(unittest.TestCase):
         )
         self.node.create_subscription(String, topic, cb, subscriber_qos)
 
-        manager.publish(client, topic, msg, self.node)
+        manager.register(client, topic, self.node)
+        manager.publish(topic, msg)
         time.sleep(0.5)
         self.assertEqual(received["msg"].data, msg["data"])
 
@@ -254,9 +253,7 @@ class TestPublisherManager(unittest.TestCase):
         msg = {"data": 3}
 
         manager.register(client, topic, self.node, msg_type)
-        self.assertRaises(
-            FieldTypeMismatchException, manager.publish, client, topic, msg, self.node
-        )
+        self.assertRaises(FieldTypeMismatchException, manager.publish, topic, msg)
 
 
 if __name__ == "__main__":

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_TESTING)
   set(TEST_FILES
     test/websocket/advertise_action.test.py
     test/websocket/advertise_action_feedback.test.py
+    test/websocket/advertise_publish.test.py
     test/websocket/advertise_service.test.py
     test/websocket/call_service.test.py
     test/websocket/send_action_goal.test.py

--- a/rosbridge_server/test/websocket/advertise_publish.test.py
+++ b/rosbridge_server/test/websocket/advertise_publish.test.py
@@ -211,10 +211,6 @@ class TestAdvertisePublishPublishers(unittest.TestCase):
         # ------------------------------------------------------------------
         # Test 6 - publish can register an advertisement with an ID, which
         # can later be destroyed by unadvertise with the same ID.
-        #
-        # This requires publish.py to forward the "id" field to the Advertise
-        # capability's registration tracking. The test will fail until that
-        # implementation is in place.
         # ------------------------------------------------------------------
         ws6 = await make_client()
         ws6.sendJson(

--- a/rosbridge_server/test/websocket/advertise_publish.test.py
+++ b/rosbridge_server/test/websocket/advertise_publish.test.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import launch_ros
+from launch.actions import DeclareLaunchArgument
+from launch.launch_description import LaunchDescription
+from launch.substitutions import LaunchConfiguration
+from launch_testing.actions import ReadyToTest
+from twisted.python import log
+
+sys.path.append(str(Path(__file__).parent))  # enable importing from common.py in this directory
+
+from common import sleep, websocket_test
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from common import TestClientProtocol
+    from rclpy.node import Node
+
+log.startLogging(sys.stderr)
+
+# Use a short unregister_timeout so we don't have to wait 10 s per unadvertise.
+_UNREGISTER_TIMEOUT = 0.5
+# How long to wait for ROS discovery to propagate after publisher creation or destruction.
+_DISCOVERY_DELAY = 1.0
+
+
+def generate_test_description() -> LaunchDescription:
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "use_events_executor",
+                default_value="false",
+                description="Use EventsExecutor instead of SingleThreadedExecutor",
+            ),
+            launch_ros.actions.Node(
+                executable="rosbridge_websocket",
+                package="rosbridge_server",
+                parameters=[
+                    {
+                        "port": 0,
+                        "use_events_executor": LaunchConfiguration("use_events_executor"),
+                        "unregister_timeout": _UNREGISTER_TIMEOUT,
+                    }
+                ],
+            ),
+            ReadyToTest(),
+        ]
+    )
+
+
+class TestAdvertisePublishPublishers(unittest.TestCase):
+    @websocket_test
+    async def test_advertise_publish_publishers(
+        self, node: Node, make_client: Callable[[], Awaitable[TestClientProtocol]]
+    ) -> None:
+        # ------------------------------------------------------------------
+        # Test 1 - advertise spawns a publisher on the topic.
+        # ------------------------------------------------------------------
+        ws1 = await make_client()
+        ws1.sendJson({"op": "advertise", "topic": "/test_adv_1", "type": "std_msgs/String"})
+        await sleep(node, _DISCOVERY_DELAY)
+
+        self.assertGreater(
+            node.count_publishers("/test_adv_1"),
+            0,
+            "advertise should create a publisher on the topic",
+        )
+
+        # ------------------------------------------------------------------
+        # Test 2 - unadvertise (without ID) removes the publisher when
+        # there are no other clients advertising the same topic.
+        # ------------------------------------------------------------------
+        ws2 = await make_client()
+        ws2.sendJson({"op": "advertise", "topic": "/test_adv_2", "type": "std_msgs/String"})
+        await sleep(node, _DISCOVERY_DELAY)
+        self.assertGreater(node.count_publishers("/test_adv_2"), 0)
+
+        ws2.sendJson({"op": "unadvertise", "topic": "/test_adv_2"})  # no id
+        await sleep(node, _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+
+        self.assertEqual(
+            node.count_publishers("/test_adv_2"),
+            0,
+            "unadvertise without ID should destroy the publisher when no other clients remain",
+        )
+
+        # ------------------------------------------------------------------
+        # Test 3 - multiple advertise with different IDs: the publisher must
+        # survive until *all* IDs are unadvertised (or one unadvertise with
+        # no ID is sent).
+        # ------------------------------------------------------------------
+
+        # Part A: advertise twice with id_a and id_b; unadvertising only
+        # id_a must leave the publisher alive; removing id_b destroys it.
+        ws3 = await make_client()
+        ws3.sendJson(
+            {"op": "advertise", "topic": "/test_adv_3", "type": "std_msgs/String", "id": "id_a"}
+        )
+        ws3.sendJson(
+            {"op": "advertise", "topic": "/test_adv_3", "type": "std_msgs/String", "id": "id_b"}
+        )
+        await sleep(node, _DISCOVERY_DELAY)
+        self.assertGreater(node.count_publishers("/test_adv_3"), 0)
+
+        # Remove id_a - id_b still active, publisher must survive.
+        ws3.sendJson({"op": "unadvertise", "topic": "/test_adv_3", "id": "id_a"})
+        await sleep(node, _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+        self.assertGreater(
+            node.count_publishers("/test_adv_3"),
+            0,
+            "publisher should survive when only one of two advertisement IDs is removed",
+        )
+
+        # Remove id_b - no active IDs left, publisher must be destroyed.
+        ws3.sendJson({"op": "unadvertise", "topic": "/test_adv_3", "id": "id_b"})
+        await sleep(node, _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+        self.assertEqual(
+            node.count_publishers("/test_adv_3"),
+            0,
+            "publisher should be destroyed after all advertisement IDs are unadvertised",
+        )
+
+        # Part B: unadvertise *without* ID clears all IDs at once.
+        ws3b = await make_client()
+        ws3b.sendJson(
+            {"op": "advertise", "topic": "/test_adv_3b", "type": "std_msgs/String", "id": "id_c"}
+        )
+        ws3b.sendJson(
+            {"op": "advertise", "topic": "/test_adv_3b", "type": "std_msgs/String", "id": "id_d"}
+        )
+        await sleep(node, _DISCOVERY_DELAY)
+        self.assertGreater(node.count_publishers("/test_adv_3b"), 0)
+
+        ws3b.sendJson({"op": "unadvertise", "topic": "/test_adv_3b"})  # no id - clears all
+        await sleep(node, _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+        self.assertEqual(
+            node.count_publishers("/test_adv_3b"),
+            0,
+            "unadvertise without ID should destroy the publisher even when multiple IDs were active",
+        )
+
+        # ------------------------------------------------------------------
+        # Test 4 - publish registers a publisher even when no advertise was
+        # called beforehand.
+        # ------------------------------------------------------------------
+        ws4 = await make_client()
+        ws4.sendJson(
+            {
+                "op": "publish",
+                "topic": "/test_pub_4",
+                "type": "std_msgs/String",
+                "msg": {"data": "hello"},
+            }
+        )
+        await sleep(node, _DISCOVERY_DELAY)
+
+        self.assertGreater(
+            node.count_publishers("/test_pub_4"),
+            0,
+            "publish should register a publisher even without a prior advertise",
+        )
+
+        # ------------------------------------------------------------------
+        # Test 5 - when a client disconnects, all its publishers are
+        # destroyed — both those spawned by advertise and by publish.
+        # ------------------------------------------------------------------
+
+        # Case A: publisher spawned by advertise.
+        ws5a = await make_client()
+        ws5a.sendJson({"op": "advertise", "topic": "/test_disc_adv", "type": "std_msgs/String"})
+        await sleep(node, _DISCOVERY_DELAY)
+        self.assertGreater(node.count_publishers("/test_disc_adv"), 0)
+
+        ws5a.sendClose()
+        # Allow time for the close handshake, finish() to run, and the
+        # unregister timer to fire.
+        await sleep(node, 2 * _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+        self.assertEqual(
+            node.count_publishers("/test_disc_adv"),
+            0,
+            "publisher from advertise should be destroyed when the client disconnects",
+        )
+
+        # Case B: publisher spawned by publish.
+        ws5b = await make_client()
+        ws5b.sendJson(
+            {
+                "op": "publish",
+                "topic": "/test_disc_pub",
+                "type": "std_msgs/String",
+                "msg": {"data": "hi"},
+            }
+        )
+        await sleep(node, _DISCOVERY_DELAY)
+        self.assertGreater(node.count_publishers("/test_disc_pub"), 0)
+
+        ws5b.sendClose()
+        await sleep(node, 2 * _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+        self.assertEqual(
+            node.count_publishers("/test_disc_pub"),
+            0,
+            "publisher from publish should be destroyed when the client disconnects",
+        )
+
+        # ------------------------------------------------------------------
+        # Test 6 - publish can register an advertisement with an ID, which
+        # can later be destroyed by unadvertise with the same ID.
+        #
+        # This requires publish.py to forward the "id" field to the Advertise
+        # capability's registration tracking. The test will fail until that
+        # implementation is in place.
+        # ------------------------------------------------------------------
+        ws6 = await make_client()
+        ws6.sendJson(
+            {
+                "op": "publish",
+                "id": "pub_reg_id",
+                "topic": "/test_pub_id",
+                "type": "std_msgs/String",
+                "msg": {"data": "hello"},
+            }
+        )
+        await sleep(node, _DISCOVERY_DELAY)
+        self.assertGreater(node.count_publishers("/test_pub_id"), 0)
+
+        ws6.sendJson({"op": "unadvertise", "id": "pub_reg_id", "topic": "/test_pub_id"})
+        await sleep(node, _DISCOVERY_DELAY + _UNREGISTER_TIMEOUT)
+        self.assertEqual(
+            node.count_publishers("/test_pub_id"),
+            0,
+            "unadvertise with the same ID used in publish should destroy the publisher",
+        )

--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -133,8 +133,10 @@ def run_websocket_test(
     executor.add_node(node)
 
     async def task() -> None:
-        await test_fn(node, lambda: connect_to_server(node))
-        reactor.callFromThread(reactor.stop)  # type: ignore[attr-defined]
+        try:
+            await test_fn(node, lambda: connect_to_server(node))
+        finally:
+            reactor.callFromThread(reactor.stop)  # type: ignore[attr-defined]
 
     future = executor.create_task(task)
 

--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -143,6 +143,10 @@ def run_websocket_test(
     reactor.callInThread(executor.spin_until_future_complete, future)  # type: ignore[attr-defined]
     reactor.run(installSignalHandlers=False)  # type: ignore[attr-defined]
 
+    # Re-raise any exception from the test coroutine so unittest sees a failure
+    # rather than a silent pass.
+    future.result()
+
     executor.remove_node(node)
     node.destroy_node()
     rclpy.shutdown(context=context)


### PR DESCRIPTION
**Public API Changes**
The `publish` message now respects `type` and `id` fields


**Description**
Since `publish` already registers a topic even with no previous call to `advertise`, I figured it would make sense to unify the tracking of topic registration between these two capabilities. `publish` capability now basically becomes an extension of `advertise` capability, supporting the same fields with the addition of `msg`.
