### PR TITLE
fix: Don't use MultiThreadedExecutor in tests

### DIFF
--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -10,7 +10,7 @@ from typing import Any
 import rclpy
 from action_msgs.msg import GoalStatus
 from example_interfaces.action._fibonacci import Fibonacci_FeedbackMessage
-from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from rosbridge_library.capabilities.action_feedback import ActionFeedback
@@ -28,7 +28,7 @@ from rosbridge_library.protocol import Protocol
 class TestActionCapabilities(unittest.TestCase):
     def setUp(self) -> None:
         rclpy.init()
-        self.executor = MultiThreadedExecutor()
+        self.executor = SingleThreadedExecutor()
         self.node = Node("test_action_capabilities")
         self.executor.add_node(self.node)
 

--- a/rosbridge_library/test/internal/publishers/test_multi_publisher.py
+++ b/rosbridge_library/test/internal/publishers/test_multi_publisher.py
@@ -7,7 +7,7 @@ from threading import Thread
 from typing import TYPE_CHECKING, Any
 
 import rclpy
-from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from rosbridge_library.internal import ros_loader
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 class TestMultiPublisher(unittest.TestCase):
     def setUp(self) -> None:
         rclpy.init()
-        self.executor = MultiThreadedExecutor(num_threads=2)
+        self.executor = SingleThreadedExecutor()
         self.node = Node("test_multi_publisher")
         self.executor.add_node(self.node)
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Action capability test seems to be flaky again. Changing from MultiThreadedExecutor to SingleThreadedExecutor seems to fix that issue so I replaced it whenever I could find it.
