### PR TITLE
chore: Use resolute container and ros2-testing for Rolling, add Lyrical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           path: ros_ws/src
 
-      - uses: ros-tooling/setup-ros@v0.7
+      - uses: ros-tooling/setup-ros@e828240b0cb6e75501cb42c01b38170aad769299
         with:
           use-ros2-testing: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           use-ros2-testing: true
 
-      - uses: ros-tooling/action-ros-ci@v0.4
+      - uses: ros-tooling/action-ros-ci@christophebedard/lyrical
         id: action_ros_ci_step
         with:
           target-ros2-distro: ${{ matrix.ros }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,13 @@ jobs:
           # https://docs.ros.org/en/rolling/Releases.html
           # NOTE: Humble, Jazzy and Kilted do not work on the `ros2` branch, so they are tested in their own branches.
           - ros: rolling
-            os: ubuntu-24.04
+            container: ubuntu:resolute
+          - ros: lyrical
+            container: ubuntu:resolute
 
-    name: ROS 2 ${{ matrix.ros }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: ROS 2 ${{ matrix.ros }} (${{ matrix.container }})
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v6
@@ -41,6 +44,8 @@ jobs:
           path: ros_ws/src
 
       - uses: ros-tooling/setup-ros@v0.7
+        with:
+          use-ros2-testing: true
 
       - uses: ros-tooling/action-ros-ci@v0.4
         id: action_ros_ci_step


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Rolling recently switched to Ubuntu Resolute and Lyrical was made available as well. Since Github does not provide ubuntu-26.04 runner yet, we have to use a container. Also, Rolling and Lyrical packages are not yet available on ros2 package repository so we have to use ros2-testing repo.

Failing tests are not related to CI and will be fixed in another PR