### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/rosbridge_library/test/internal/services/test_services.py
+++ b/rosbridge_library/test/internal/services/test_services.py
@@ -76,7 +76,7 @@ class ServiceTester:
         assert isinstance(gen, dict)
         try:
             res = message_conversion.populate_instance(gen, res)
-        except:  # Will print() and raise
+        except Exception:  # Will print() and raise
             print("populating instance")
             print(res)
             print("populating with")

--- a/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscription_modifiers.py
@@ -120,7 +120,7 @@ class TestMessageHandlers(unittest.TestCase):
 
         try:
             self.assertEqual([msgs[0], *list(msgs[-queue_length:])], received["msgs"])
-        except:  # Will finish and raise
+        except Exception:  # Will finish and raise
             handler.finish()
             raise
 
@@ -260,7 +260,7 @@ class TestMessageHandlers(unittest.TestCase):
             for x in range(10):
                 self.assertEqual(x, received["msg"])
                 time.sleep(throttle_rate_sec)
-        except:  # Will finish and raise
+        except Exception:  # Will finish and raise
             handler.finish()
             raise
 

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -223,7 +223,7 @@ class RosbridgeWebSocket(WebSocketHandler):
                 "StreamClosedError: Tried to write to a closed stream",
                 throttle_duration_sec=1.0,
             )
-        except:  # noqa: E722  # Will log and raise
+        except Exception:  # noqa: E722  # Will log and raise
             _log_exception()
 
     @log_exceptions


### PR DESCRIPTION
Replaces 4 bare `except:` with `except Exception:` in 3 files: test_subscription_modifiers.py (2), test_services.py (1), websocket_handler.py (1).