### PR TITLE
fix: avoid rosapi crash on requesting typedefs for non-existent packages

### DIFF
--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -99,23 +99,49 @@ def get_typedef(type_name: str) -> dict | None:
     try:
         instance = ros_loader.get_message_instance(type_name)
         return _get_typedef(instance)
-    except (ros_loader.InvalidModuleException, ros_loader.InvalidClassException) as e:
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
         logger.error("An error occurred trying to get the type definition for %s: %s", type_name, e)
         return None
 
 
 def get_service_request_typedef(servicetype: str) -> dict | None:
     """Return a typedef dict for the service request class for the specified service type."""
-    # Get an instance of the service request class and return its typedef
-    instance = ros_loader.get_service_request_instance(servicetype)
-    return _get_typedef(instance)
+    try:
+        instance = ros_loader.get_service_request_instance(servicetype)
+        return _get_typedef(instance)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            servicetype,
+            e,
+        )
+        return None
 
 
 def get_service_response_typedef(servicetype: str) -> dict | None:
     """Return a typedef dict for the service response class for the specified service type."""
-    # Get an instance of the service response class and return its typedef
-    instance = ros_loader.get_service_response_instance(servicetype)
-    return _get_typedef(instance)
+    try:
+        instance = ros_loader.get_service_response_instance(servicetype)
+        return _get_typedef(instance)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            servicetype,
+            e,
+        )
+        return None
 
 
 def get_typedef_recursive(type_name: str) -> list[dict]:
@@ -126,51 +152,96 @@ def get_typedef_recursive(type_name: str) -> list[dict]:
 
 def get_service_request_typedef_recursive(servicetype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
-    # Get an instance of the service request class and get its typedef
-    instance = ros_loader.get_service_request_instance(servicetype)
+    try:
+        instance = ros_loader.get_service_request_instance(servicetype)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            servicetype,
+            e,
+        )
+        return []
     typedef = _get_typedef(instance)
-
-    # Return the list of sub-typedefs
     return _get_subtypedefs_recursive(typedef, [])
 
 
 def get_service_response_typedef_recursive(servicetype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
-    # Get an instance of the service response class and get its typedef
-    instance = ros_loader.get_service_response_instance(servicetype)
+    try:
+        instance = ros_loader.get_service_response_instance(servicetype)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            servicetype,
+            e,
+        )
+        return []
     typedef = _get_typedef(instance)
-
-    # Return the list of sub-typedefs
     return _get_subtypedefs_recursive(typedef, [])
 
 
 def get_action_goal_typedef_recursive(actiontype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
-    # Get an instance of the action goal class and get its typedef
-    instance = ros_loader.get_action_goal_instance(actiontype)
+    try:
+        instance = ros_loader.get_action_goal_instance(actiontype)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            actiontype,
+            e,
+        )
+        return []
     typedef = _get_typedef(instance)
-
-    # Return the list of sub-typedefs
     return _get_subtypedefs_recursive(typedef, [])
 
 
 def get_action_result_typedef_recursive(actiontype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
-    # Get an instance of the action result class and get its typedef
-    instance = ros_loader.get_action_result_instance(actiontype)
+    try:
+        instance = ros_loader.get_action_result_instance(actiontype)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            actiontype,
+            e,
+        )
+        return []
     typedef = _get_typedef(instance)
-
-    # Return the list of sub-typedefs
     return _get_subtypedefs_recursive(typedef, [])
 
 
 def get_action_feedback_typedef_recursive(actiontype: str) -> list[dict]:
     """Return a list of typedef dicts for this type and all contained type fields."""
-    # Get an instance of the action feedback class and get its typedef
-    instance = ros_loader.get_action_feedback_instance(actiontype)
+    try:
+        instance = ros_loader.get_action_feedback_instance(actiontype)
+    except (
+        ros_loader.InvalidModuleException,
+        ros_loader.InvalidClassException,
+        ros_loader.InvalidTypeStringException,
+    ) as e:
+        logger.error(
+            "An error occurred trying to get the type definition for %s: %s",
+            actiontype,
+            e,
+        )
+        return []
     typedef = _get_typedef(instance)
-
-    # Return the list of sub-typedefs
     return _get_subtypedefs_recursive(typedef, [])
 
 

--- a/rosapi/test/test_typedefs.py
+++ b/rosapi/test/test_typedefs.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import unittest
 from typing import ClassVar
+from unittest.mock import patch
+
+from rosbridge_library.internal import ros_loader as _ros_loader
 
 from rosapi import objectutils
 
@@ -64,6 +67,67 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(lens, [-1])
         # example should be the stringified value of 123
         self.assertEqual(examples, ["123"])
+
+
+def _make_invalid_module_exc(pkg: str, subname: str) -> _ros_loader.InvalidModuleException:
+    return _ros_loader.InvalidModuleException(
+        pkg, subname, ModuleNotFoundError(f"No module named '{pkg}'")
+    )
+
+
+class TestInvalidTypeHandling(unittest.TestCase):
+    """Regression: objectutils must not propagate ros_loader exceptions to callers."""
+
+    def test_get_typedef_invalid_type_string_returns_none(self) -> None:
+        exc = _ros_loader.InvalidTypeStringException("bad/type")
+        with patch.object(_ros_loader, "get_message_instance", side_effect=exc):
+            self.assertIsNone(objectutils.get_typedef("bad/type"))
+
+    def test_service_request_typedef_returns_none_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "srv")
+        with patch.object(_ros_loader, "get_service_request_instance", side_effect=exc):
+            self.assertIsNone(objectutils.get_service_request_typedef("nonexistent_pkg/srv/Fake"))
+
+    def test_service_response_typedef_returns_none_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "srv")
+        with patch.object(_ros_loader, "get_service_response_instance", side_effect=exc):
+            self.assertIsNone(objectutils.get_service_response_typedef("nonexistent_pkg/srv/Fake"))
+
+    def test_service_request_typedef_recursive_returns_empty_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "srv")
+        with patch.object(_ros_loader, "get_service_request_instance", side_effect=exc):
+            result = objectutils.get_service_request_typedef_recursive("nonexistent_pkg/srv/Fake")
+        self.assertEqual(result, [])
+
+    def test_service_response_typedef_recursive_returns_empty_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "srv")
+        with patch.object(_ros_loader, "get_service_response_instance", side_effect=exc):
+            result = objectutils.get_service_response_typedef_recursive("nonexistent_pkg/srv/Fake")
+        self.assertEqual(result, [])
+
+    def test_action_goal_typedef_recursive_returns_empty_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "action")
+        with patch.object(_ros_loader, "get_action_goal_instance", side_effect=exc):
+            result = objectutils.get_action_goal_typedef_recursive(
+                "nonexistent_pkg/action/FakeAction"
+            )
+        self.assertEqual(result, [])
+
+    def test_action_result_typedef_recursive_returns_empty_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "action")
+        with patch.object(_ros_loader, "get_action_result_instance", side_effect=exc):
+            result = objectutils.get_action_result_typedef_recursive(
+                "nonexistent_pkg/action/FakeAction"
+            )
+        self.assertEqual(result, [])
+
+    def test_action_feedback_typedef_recursive_returns_empty_on_bad_package(self) -> None:
+        exc = _make_invalid_module_exc("nonexistent_pkg", "action")
+        with patch.object(_ros_loader, "get_action_feedback_instance", side_effect=exc):
+            result = objectutils.get_action_feedback_typedef_recursive(
+                "nonexistent_pkg/action/FakeAction"
+            )
+        self.assertEqual(result, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Public API Changes**

Instead of the rosapi_node crashing and dying, it will return an empty typedef list for non existing modules.


**Description**

Calling any of the rosapi type-detail services (`/rosapi/action_goal_details`,
`/rosapi/action_result_details`, `/rosapi/action_feedback_details`,
`/rosapi/service_request_details`, `/rosapi/service_response_details`) with a
type string whose package does not exist causes the entire `rosapi_node` process
to crash with an unhandled `InvalidModuleException`. The node must be
manually restarted, and any concurrent websocket clients lose the rosapi
introspection capability until it is.

**Replication:**

run rosbridge (or the rosapi node):

`ros2 launch rosbridge_server rosbridge_websocket_launch.xml`

send service request:

`ros2 service call /rosapi/action_feedback_details rosapi_msgs/srv/ActionFeedbackDetails "type: 'some_non_existent/action/Action'"`

rosapi node dies:

main log entries:
`rosapi_node-2]   File "/home/user/exchange/rosbridge_ws/install/rosbridge_library/lib/python3.12/site-packages/rosbridge_library/internal/ros_loader.py", line 241, in _load_class
[rosapi_node-2]     raise InvalidModuleException(modname, subname, exc) from exc
[rosapi_node-2] rosbridge_library.internal.ros_loader.InvalidModuleException: Unable to import some_non_existent.action from package some_non_existent. Caused by: No module named 'some_non_existent'
[ERROR] [rosapi_node-2]: process has died [pid 6917, exit code 1, cmd '/home/user/exchange/rosbridge_ws/install/rosapi/lib/rosapi/rosapi_node --ros-args -r __node:=rosapi -r __ns:=/ --params-file /tmp/launch_params_yfa8m6j7 --params-file /tmp/launch_params_br6u4z3k --params-file /tmp/launch_params_qioyr13h --params-file /tmp/launch_params_olwv33io'].
`