### PR TITLE
fix: mypy errors and flaky subscriber/publisher tests

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/subscribe.py
@@ -58,7 +58,7 @@ try:
     from ujson import dumps as encode_json  # type: ignore[import-untyped]
 except ImportError:
     try:
-        from simplejson import dumps as encode_json  # type: ignore[import-untyped]
+        from simplejson import dumps as encode_json  # type: ignore[import-untyped, no-redef]
     except ImportError:
         from json import dumps as encode_json  # type: ignore[assignment]
 

--- a/rosbridge_library/src/rosbridge_library/util/ros.py
+++ b/rosbridge_library/src/rosbridge_library/util/ros.py
@@ -32,23 +32,51 @@
 
 from __future__ import annotations
 
+from threading import Event
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from rclpy.executors import Executor
     from rclpy.node import Node
 
 
 def is_topic_published(node: Node, topic_name: str) -> bool:
-    """Check if a topic is published on a node."""
-    published_topic_data = node.get_publisher_names_and_types_by_node(
-        node.get_name(), node.get_namespace()
-    )
-    return any(topic[0] == topic_name for topic in published_topic_data)
+    """
+    Check if a node has at least one publisher on the given topic.
+
+    Reads ``node.publishers`` (the local entity list) rather than the rmw graph
+    cache. The local list is populated synchronously inside ``create_publisher``
+    and cleared inside ``destroy_publisher``, so the result is deterministic
+    with respect to the calling thread — no DDS-discovery round-trip is
+    involved.
+    """
+    return any(pub.topic_name == topic_name for pub in node.publishers)
 
 
 def is_topic_subscribed(node: Node, topic_name: str) -> bool:
-    """Check if a topic is subscribed to by a node."""
-    subscribed_topic_data = node.get_subscriber_names_and_types_by_node(
-        node.get_name(), node.get_namespace()
-    )
-    return any(topic[0] == topic_name for topic in subscribed_topic_data)
+    """
+    Check if a node has at least one subscription on the given topic.
+
+    Reads ``node.subscriptions`` (the local entity list) rather than the rmw
+    graph cache; see ``is_topic_published`` for why this matters.
+    """
+    return any(sub.topic_name == topic_name for sub in node.subscriptions)
+
+
+def wait_for_executor_idle(executor: Executor, timeout: float = 5.0) -> None:
+    """
+    Block until all tasks already queued on ``executor`` have been processed.
+
+    Used by tests that schedule work on the executor and then need to assert
+    on the post-condition from a different thread. Submits a no-op task and
+    waits for it to run: tasks are FIFO on ``SingleThreadedExecutor``, so when
+    the no-op completes every task enqueued before it has also completed.
+
+    Raises ``TimeoutError`` if the executor does not drain within ``timeout``
+    seconds, which usually means it is not being spun.
+    """
+    done = Event()
+    executor.create_task(done.set)
+    if not done.wait(timeout=timeout):
+        msg = f"Executor did not become idle within {timeout}s"
+        raise TimeoutError(msg)

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -135,7 +135,7 @@ class TestActionCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.send_goal.send_action_goal, args=(goal_msg,)).start()
+        Thread(target=self.send_goal.send_action_goal, args=(goal_msg,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -244,7 +244,7 @@ class TestActionCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.send_goal.send_action_goal, args=(goal_msg,)).start()
+        Thread(target=self.send_goal.send_action_goal, args=(goal_msg,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -335,7 +335,7 @@ class TestActionCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.send_goal.send_action_goal, args=(goal_msg,)).start()
+        Thread(target=self.send_goal.send_action_goal, args=(goal_msg,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -381,7 +381,7 @@ class TestActionCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.send_goal.send_action_goal, args=(goal_msg_after,)).start()
+        Thread(target=self.send_goal.send_action_goal, args=(goal_msg_after,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -410,7 +410,11 @@ class TestActionCapabilities(unittest.TestCase):
             )
         )
 
-        Thread(target=self.send_goal.send_action_goal, args=(goal_msg_after_readvertise,)).start()
+        Thread(
+            target=self.send_goal.send_action_goal,
+            args=(goal_msg_after_readvertise,),
+            daemon=True,
+        ).start()
 
         start_time = time.monotonic()
         while self.received_message is None:

--- a/rosbridge_library/test/capabilities/test_qos.py
+++ b/rosbridge_library/test/capabilities/test_qos.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import time
 import unittest
-from threading import Thread
+from threading import Event, Thread
 from typing import Any
 
 import rclpy
@@ -170,14 +170,22 @@ class TestQoS(unittest.TestCase):
         self.assertEqual(qos_profile.durability, DurabilityPolicy.TRANSIENT_LOCAL)
         self.assertEqual(qos_profile.depth, 1)
 
-        # Late-joining subscriber should receive the latched message
+        # Late-joining subscriber should receive the latched message. Block on
+        # a threading.Event set in the callback instead of sleeping, so the
+        # test does not flake when DDS discovery + late-joining delivery
+        # overrun a short sleep on slower middleware setups.
         received: dict[str, Any] = {"msg": None}
+        msg_received = Event()
 
         def cb(msg: String) -> None:
             received["msg"] = msg
+            msg_received.set()
 
         self.node.create_subscription(String, topic, cb, qos_profile)
-        time.sleep(0.1)
+        self.assertTrue(
+            msg_received.wait(timeout=5.0),
+            "Late-joining subscriber did not receive latched message within 5 s",
+        )
         self.assertEqual(received["msg"].data, msg["data"])
 
     def test_publish_qos_works(self) -> None:

--- a/rosbridge_library/test/capabilities/test_service_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_service_capabilities.py
@@ -122,7 +122,7 @@ class TestServiceCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.call_service.call_service, args=(call_msg,)).start()
+        Thread(target=self.call_service.call_service, args=(call_msg,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -188,7 +188,7 @@ class TestServiceCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.call_service.call_service, args=(call_msg,)).start()
+        Thread(target=self.call_service.call_service, args=(call_msg,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -243,7 +243,7 @@ class TestServiceCapabilities(unittest.TestCase):
             )
         )
         self.received_message = None
-        Thread(target=self.call_service.call_service, args=(call_msg,)).start()
+        Thread(target=self.call_service.call_service, args=(call_msg,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:
@@ -295,7 +295,7 @@ class TestServiceCapabilities(unittest.TestCase):
                 }
             )
         )
-        Thread(target=self.call_service.call_service, args=(call_msg2,)).start()
+        Thread(target=self.call_service.call_service, args=(call_msg2,), daemon=True).start()
 
         start_time = time.monotonic()
         while self.received_message is None:

--- a/rosbridge_library/test/internal/publishers/test_publisher_manager.py
+++ b/rosbridge_library/test/internal/publishers/test_publisher_manager.py
@@ -170,7 +170,6 @@ class TestPublisherManager(unittest.TestCase):
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
         self.node.create_publisher(String, topic, publisher_qos)
-        time.sleep(0.1)
 
         self.assertTrue(is_topic_published(self.node, topic))
         self.assertFalse(topic in manager._publishers)

--- a/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
+++ b/rosbridge_library/test/internal/subscribers/test_multi_subscriber.py
@@ -12,7 +12,7 @@ from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from rosbridge_library.internal.subscribers import MultiSubscriber
 from rosbridge_library.internal.topics import TypeConflictException
-from rosbridge_library.util.ros import is_topic_subscribed
+from rosbridge_library.util.ros import is_topic_subscribed, wait_for_executor_idle
 from std_msgs.msg import Int32, String
 
 if TYPE_CHECKING:
@@ -37,41 +37,30 @@ class TestMultiSubscriber(unittest.TestCase):
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def assert_topic_subscribed(self, topic: str, timeout: float = 1.0) -> None:
-        start_time = time.monotonic()
-        while not is_topic_subscribed(self.node, topic):
-            time.sleep(0.05)
-            if time.monotonic() - start_time > timeout:
-                self.fail(f"Timed out waiting for topic '{topic}' to be subscribed.")
-
-    def assert_topic_not_subscribed(self, topic: str, timeout: float = 1.0) -> None:
-        start_time = time.monotonic()
-        while is_topic_subscribed(self.node, topic):
-            time.sleep(0.05)
-            if time.monotonic() - start_time > timeout:
-                self.fail(f"Timed out waiting for topic '{topic}' to be unsubscribed.")
-
     def test_register_multisubscriber(self) -> None:
         """Register a subscriber on a clean topic with a good msg type."""
         topic = "/test_register_multisubscriber"
         msg_type = "std_msgs/String"
 
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         MultiSubscriber(topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
     def test_unregister_multisubscriber(self) -> None:
         """Register and unregister a subscriber on a clean topic with a good msg type."""
         topic = "/test_unregister_multisubscriber"
         msg_type = "std_msgs/String"
 
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         multi: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
         multi.unregister()
-        self.assert_topic_not_subscribed(topic)
+        # MultiSubscriber.unregister schedules destroy_subscription on the executor;
+        # drain the executor before asserting the entity is gone.
+        wait_for_executor_idle(self.executor)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
     def test_verify_type(self) -> None:
         topic = "/test_verify_type"
@@ -101,11 +90,11 @@ class TestMultiSubscriber(unittest.TestCase):
         topic = "/test_subscribe_unsubscribe"
         msg_type = "std_msgs/String"
 
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         multi: MultiSubscriber[String] = MultiSubscriber(
             topic, self.client_id, lambda *_args: None, self.node, msg_type=msg_type
         )
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
         self.assertEqual(len(multi.new_subscriptions), 0)
 
         multi.subscribe(self.client_id, lambda _: None)
@@ -115,7 +104,8 @@ class TestMultiSubscriber(unittest.TestCase):
         self.assertEqual(len(multi.new_subscriptions), 0)
 
         multi.unregister()
-        self.assert_topic_not_subscribed(topic)
+        wait_for_executor_idle(self.executor)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
     def test_subscribe_receive_json(self) -> None:
         topic = "/test_subscribe_receive_json"

--- a/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
+++ b/rosbridge_library/test/internal/subscribers/test_subscriber_manager.py
@@ -15,7 +15,7 @@ from rosbridge_library.internal.topics import (
     TopicNotEstablishedException,
     TypeConflictException,
 )
-from rosbridge_library.util.ros import is_topic_subscribed
+from rosbridge_library.util.ros import is_topic_subscribed, wait_for_executor_idle
 from std_msgs.msg import String
 
 if TYPE_CHECKING:
@@ -38,20 +38,6 @@ class TestSubscriberManager(unittest.TestCase):
         self.executor.shutdown()
         rclpy.shutdown()
 
-    def assert_topic_subscribed(self, topic: str, timeout: float = 1.0) -> None:
-        start_time = time.monotonic()
-        while not is_topic_subscribed(self.node, topic):
-            time.sleep(0.05)
-            if time.monotonic() - start_time > timeout:
-                self.fail(f"Timed out waiting for topic '{topic}' to be subscribed.")
-
-    def assert_topic_not_subscribed(self, topic: str, timeout: float = 1.0) -> None:
-        start_time = time.monotonic()
-        while is_topic_subscribed(self.node, topic):
-            time.sleep(0.05)
-            if time.monotonic() - start_time > timeout:
-                self.fail(f"Timed out waiting for topic '{topic}' to be unsubscribed.")
-
     def test_subscribe(self) -> None:
         """Register a publisher on a clean topic with a good msg type."""
         topic = "/test_subscribe"
@@ -59,14 +45,17 @@ class TestSubscriberManager(unittest.TestCase):
         client = "client_test_subscribe"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         manager.subscribe(client, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.unsubscribe(client, topic)
+        # manager.unsubscribe schedules destroy_subscription on the executor;
+        # drain the executor before asserting the entity is gone.
+        wait_for_executor_idle(self.executor)
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
     def test_register_subscriber_multiclient(self) -> None:
         topic = "/test_register_subscriber_multiclient"
@@ -75,22 +64,23 @@ class TestSubscriberManager(unittest.TestCase):
         client2 = "client_test_register_subscriber_multiclient_2"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         manager.subscribe(client1, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.subscribe(client2, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.unsubscribe(client1, topic)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.unsubscribe(client2, topic)
+        wait_for_executor_idle(self.executor)
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
     def test_register_publisher_conflicting_types(self) -> None:
         topic = "/test_register_publisher_conflicting_types"
@@ -99,10 +89,10 @@ class TestSubscriberManager(unittest.TestCase):
         client = "client_test_register_publisher_conflicting_types"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         manager.subscribe(client, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         self.assertRaises(
             TypeConflictException,
@@ -122,39 +112,41 @@ class TestSubscriberManager(unittest.TestCase):
 
         self.assertFalse(topic1 in manager._subscribers)
         self.assertFalse(topic2 in manager._subscribers)
-        self.assert_topic_not_subscribed(topic1)
-        self.assert_topic_not_subscribed(topic2)
+        self.assertFalse(is_topic_subscribed(self.node, topic1))
+        self.assertFalse(is_topic_subscribed(self.node, topic2))
 
         manager.subscribe(client, topic1, lambda _: None, self.node, msg_type)
         self.assertTrue(topic1 in manager._subscribers)
-        self.assert_topic_subscribed(topic1)
+        self.assertTrue(is_topic_subscribed(self.node, topic1))
         self.assertFalse(topic2 in manager._subscribers)
-        self.assert_topic_not_subscribed(topic2)
+        self.assertFalse(is_topic_subscribed(self.node, topic2))
 
         manager.subscribe(client, topic2, lambda _: None, self.node, msg_type)
         self.assertTrue(topic1 in manager._subscribers)
-        self.assert_topic_subscribed(topic1)
+        self.assertTrue(is_topic_subscribed(self.node, topic1))
         self.assertTrue(topic2 in manager._subscribers)
-        self.assert_topic_subscribed(topic2)
+        self.assertTrue(is_topic_subscribed(self.node, topic2))
 
         manager.unsubscribe(client, topic1)
+        wait_for_executor_idle(self.executor)
         self.assertFalse(topic1 in manager._subscribers)
-        self.assert_topic_not_subscribed(topic1)
+        self.assertFalse(is_topic_subscribed(self.node, topic1))
         self.assertTrue(topic2 in manager._subscribers)
-        self.assert_topic_subscribed(topic2)
+        self.assertTrue(is_topic_subscribed(self.node, topic2))
 
         manager.unsubscribe(client, topic2)
+        wait_for_executor_idle(self.executor)
         self.assertFalse(topic1 in manager._subscribers)
-        self.assert_topic_not_subscribed(topic1)
+        self.assertFalse(is_topic_subscribed(self.node, topic1))
         self.assertFalse(topic2 in manager._subscribers)
-        self.assert_topic_not_subscribed(topic2)
+        self.assertFalse(is_topic_subscribed(self.node, topic2))
 
     def test_register_no_msgtype(self) -> None:
         topic = "/test_register_no_msgtype"
         client = "client_test_register_no_msgtype"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         self.assertRaises(
             TopicNotEstablishedException, manager.subscribe, client, topic, None, self.node
         )
@@ -163,7 +155,7 @@ class TestSubscriberManager(unittest.TestCase):
         topic = "/test_register_infer_topictype"
         client = "client_test_register_infer_topictype"
 
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
         subscriber_qos = QoSProfile(
             depth=10,
@@ -171,16 +163,18 @@ class TestSubscriberManager(unittest.TestCase):
         )
         self.node.create_subscription(String, topic, lambda *_args: None, subscriber_qos)
 
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
         self.assertFalse(topic in manager._subscribers)
 
         manager.subscribe(client, topic, lambda _: None, self.node)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.unsubscribe(client, topic)
+        wait_for_executor_idle(self.executor)
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        # The direct create_subscription above still holds the topic.
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
     def test_register_multiple_notopictype(self) -> None:
         topic = "/test_register_multiple_notopictype"
@@ -189,30 +183,31 @@ class TestSubscriberManager(unittest.TestCase):
         client2 = "client_test_register_multiple_notopictype_2"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
         manager.subscribe(client1, topic, lambda _: None, self.node, msg_type)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.subscribe(client2, topic, lambda _: None, self.node)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.unsubscribe(client1, topic)
         self.assertTrue(topic in manager._subscribers)
-        self.assert_topic_subscribed(topic)
+        self.assertTrue(is_topic_subscribed(self.node, topic))
 
         manager.unsubscribe(client2, topic)
+        wait_for_executor_idle(self.executor)
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
 
     def test_subscribe_not_registered(self) -> None:
         topic = "/test_subscribe_not_registered"
         client = "client_test_subscribe_not_registered"
 
         self.assertFalse(topic in manager._subscribers)
-        self.assert_topic_not_subscribed(topic)
+        self.assertFalse(is_topic_subscribed(self.node, topic))
         self.assertRaises(
             TopicNotEstablishedException, manager.subscribe, client, topic, None, self.node
         )

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -40,7 +40,7 @@ import uuid
 from asyncio.events import AbstractEventLoop
 from collections import deque
 from functools import wraps
-from typing import TYPE_CHECKING, ClassVar, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, ParamSpec, TypeVar
 
 from rclpy.node import Node
 from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
@@ -56,7 +56,9 @@ if TYPE_CHECKING:
 def _log_exception() -> None:
     """Log the most recent exception to ROS."""
     exc = traceback.format_exception(*sys.exc_info())
-    RosbridgeWebSocket.node_handle.get_logger().error("".join(exc))
+    node_handle = RosbridgeWebSocket.node_handle
+    assert isinstance(node_handle, Node), "Node handle was not set"
+    node_handle.get_logger().error("".join(exc))
 
 
 P = ParamSpec("P")
@@ -140,7 +142,7 @@ class RosbridgeWebSocket(WebSocketHandler):
     node_handle: ClassVar[Node | None] = None
 
     # Parameters to pass to RosbridgeProtocol when opening a connection
-    protocol_parameters: ClassVar = {}
+    protocol_parameters: ClassVar[dict[str, Any]] = {}
 
     # Parameters for the WebSocket handler
     use_compression: ClassVar[bool] = False
@@ -164,7 +166,7 @@ class RosbridgeWebSocket(WebSocketHandler):
             self.set_nodelay(True)
             cls.clients_connected += 1
             if cls.client_manager:
-                cls.client_manager.add_client(self.client_id, self.request.remote_ip)
+                cls.client_manager.add_client(self.client_id, self.request.remote_ip or "")
         except Exception as exc:
             cls.node_handle.get_logger().error(
                 f"Unable to accept incoming connection.  Reason: {exc}"
@@ -191,7 +193,7 @@ class RosbridgeWebSocket(WebSocketHandler):
 
         cls.clients_connected -= 1
         if cls.client_manager:
-            cls.client_manager.remove_client(self.client_id, self.request.remote_ip)
+            cls.client_manager.remove_client(self.client_id, self.request.remote_ip or "")
         cls.node_handle.get_logger().info(
             f"Client disconnected. {cls.clients_connected} clients total."
         )


### PR DESCRIPTION
## Summary

Pre-existing CI hygiene on Rolling and Lyrical that has been red on `ros2` since the move to `ubuntu:resolute`:

- **Newer mypy (in `resolute`'s package set) flags 5 latent typing issues** that older mypy let slide — one in `rosbridge_library/capabilities/subscribe.py`, four in `rosbridge_server/websocket_handler.py`. None are caused by the changes in this branch; they are simply now load-bearing for any PR that touches a Rolling/Lyrical job.
- **DDS discovery on `resolute` overran the topic-existence test deadlines.** The helpers in `rosbridge_library/util/ros.py` polled the rmw graph cache via `get_(publisher|subscriber)_names_and_types_by_node`, which requires a discovery round-trip even for self-queries. Different subscriber / publisher tests flaked across different runs.

## Dependency

This PR stacks on top of #1255 (the service / action lifecycle race fix). #1255 must land first; without it `test_action_capabilities` SIGSEGVs and the rest of the Rolling/Lyrical job is moot.

## Approach

### mypy

Smallest possible patches at each error site — no broader refactor, no library-wide annotation pass.

- `subscribe.py:61` — extend the `type: ignore` on the `simplejson` fallback to also cover `no-redef`. The chained `from X import Y as encode_json` pattern legitimately rebinds the name; the new mypy version requires the suppression to say so.
- `websocket_handler.py::_log_exception` — narrow `RosbridgeWebSocket.node_handle` with the same `assert isinstance(..., Node)` pattern already used in `open()` / `on_close()` before calling `.get_logger()`.
- `websocket_handler.py::protocol_parameters` — annotate the bare `ClassVar` as `ClassVar[dict[str, Any]]` to match the value it's actually assigned in `rosbridge_websocket.py`.
- `websocket_handler.py::open` / `on_close` — pass `self.request.remote_ip or ""` to `ClientManager.add_client` / `remove_client`. Tornado types `remote_ip` as `Any | None`; the manager signature is `str`.

### Topic-existence checks

The polling-based `assert_topic_(not_)subscribed` helpers, and the rmw-graph-cache queries they were built around, were always going to flake. The graph cache is updated by DDS discovery events; even for a node querying its own subscriptions, that's an asynchronous round-trip, and the `resolute` package set's defaults make the round-trip slower.

The deterministic alternative — and the one this PR adopts — is to read the node's own entity list directly:

- `is_topic_published(node, name)` → `any(p.topic_name == name for p in node.publishers)`
- `is_topic_subscribed(node, name)` → `any(s.topic_name == name for s in node.subscriptions)`

Both `node.publishers` and `node.subscriptions` are populated synchronously inside `create_publisher` / `create_subscription` and cleared inside `destroy_publisher` / `destroy_subscription`, so the result is correct as soon as the calling thread has the entity handle — no DDS involvement.

The one remaining asynchrony is that `MultiSubscriber.unregister` routes `destroy_subscription` through `executor.create_task` (added in #1194). After `manager.unsubscribe`, the destroy task is queued but may not have run yet from the test thread's point of view. `wait_for_executor_idle` handles this: it submits a no-op task and waits for it to run. `SingleThreadedExecutor` processes tasks FIFO, so when the no-op completes every task enqueued before it has also completed.

### Why not `launch_testing`?

`launch_testing` is for testing systems that span processes. The tests here exercise the in-process `SubscriberManager` / `PublisherManager` API on a single node — moving them under `launch_testing` would impose a per-test process boundary and a much larger refactor without changing the determinism story. `node.publishers` / `node.subscriptions` give the same guarantee with no new infrastructure.

## What changed

- `rosbridge_library/util/ros.py` — rewrite `is_topic_published` / `is_topic_subscribed` against `node.publishers` / `node.subscriptions`; add `wait_for_executor_idle`.
- Drop the `assert_topic_(not_)subscribed` polling helpers from the two subscriber test files; replace with direct `assertTrue` / `assertFalse` against `is_topic_subscribed`. Add `wait_for_executor_idle(self.executor)` after each `manager.unsubscribe` / `multi.unregister` before asserting the entity is gone.
- Remove the `time.sleep(0.1)` before `is_topic_published` in `test_publisher_manager.test_register_infer_topictype` — `create_publisher` is now reflected immediately. The `time.sleep(manager.unregister_timeout + 1.0)` waits stay; those wait on `threading.Timer`, not graph propagation.
- `subscribe.py`, `websocket_handler.py` — the mypy fixes described above.

## Local validation

Reproduced on a `ros:rolling-perception` container with current rclpy:

- `test/internal/subscribers/` + `test/internal/publishers/` — 44/44 pass (the previously flaky `test_register_infer_topictype` / `test_register_subscriber_multiclient` etc. now resolve as soon as `create_subscription` returns instead of polling).
- `test/capabilities/` — 46/46 pass with #1255 applied (without #1255, `test_action_capabilities` SIGSEGVs before reaching anything in this PR's scope).