### PR TITLE
chore: Update rosbridge_test_msgs cmake minimum version to 3.20

### DIFF
--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbridge_test_msgs)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Missed this one package in #1232 