### PR TITLE
fix: Prevent event loop starvation by adding a write queue

### DIFF
--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -30,6 +30,10 @@ if(BUILD_TESTING)
     TIMEOUT 60
   )
 
+  # This test is currently failing with EventsExecutor, so we run it only with SingleThreadedExecutor for now.
+  # TODO(bjsowa): Make this test pass with EventsExecutor.
+  add_launch_test(test/websocket/event_loop_starvation.test.py)
+
   # Run each test with both SingleThreadedExecutor and EventsExecutor
   set(TEST_FILES
     test/websocket/advertise_action.test.py

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -16,6 +16,8 @@
   <arg name="max_message_size" default="10000000" />
   <arg name="unregister_timeout" default="10.0" />
 
+  <arg name="incoming_queue_size" default="1000" />
+  <arg name="write_queue_size" default="1000" />
   <arg name="use_compression" default="false" />
   <arg name="websocket_ping_interval" default="0.0" />
   <arg name="websocket_ping_timeout" default="30.0" />
@@ -47,6 +49,8 @@
       <param name="delay_between_messages" value="$(var delay_between_messages)"/>
       <param name="max_message_size" value="$(var max_message_size)"/>
       <param name="unregister_timeout" value="$(var unregister_timeout)"/>
+      <param name="incoming_queue_size" value="$(var incoming_queue_size)"/>
+      <param name="write_queue_size" value="$(var write_queue_size)"/>
       <param name="use_compression" value="$(var use_compression)"/>
       <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
       <param name="default_call_service_timeout" value="$(var default_call_service_timeout)"/>
@@ -73,6 +77,8 @@
       <param name="delay_between_messages" value="$(var delay_between_messages)"/>
       <param name="max_message_size" value="$(var max_message_size)"/>
       <param name="unregister_timeout" value="$(var unregister_timeout)"/>
+      <param name="incoming_queue_size" value="$(var incoming_queue_size)"/>
+      <param name="write_queue_size" value="$(var write_queue_size)"/>
       <param name="use_compression" value="$(var use_compression)"/>
       <param name="call_services_in_new_thread" value="$(var call_services_in_new_thread)"/>
       <param name="default_call_service_timeout" value="$(var default_call_service_timeout)"/>

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -69,6 +69,13 @@ SERVER_PARAMETERS = (
     ("websocket_ping_interval", float, 0.0, "Interval in seconds for WebSocket ping messages."),
     ("websocket_ping_timeout", float, 30.0, "Timeout in seconds for WebSocket ping responses."),
     # Websocket handler parameters
+    (
+        "incoming_queue_size",
+        int,
+        1000,
+        "Size of the per-client queue for processing incoming messages.",
+    ),
+    ("write_queue_size", int, 1000, "Size of the per-client queue for writing messages."),
     ("use_compression", bool, False, "Enable compression for WebSocket messages."),
     # Executor parameters
     ("use_events_executor", bool, False, "Use EventsExecutor instead of SingleThreadedExecutor."),
@@ -134,6 +141,8 @@ class RosbridgeWebsocketNode(Node):
             self.protocol_parameters["services_glob"].append("/rosapi/*")
 
         RosbridgeWebSocket.protocol_parameters = self.protocol_parameters
+        RosbridgeWebSocket.incoming_queue_size = self.incoming_queue_size
+        RosbridgeWebSocket.write_queue_size = self.write_queue_size
         RosbridgeWebSocket.use_compression = self.use_compression
 
         self._start_server()
@@ -200,6 +209,12 @@ class RosbridgeWebsocketNode(Node):
         )
 
         # WebSocket handler parameters
+        self.incoming_queue_size = (
+            self.get_parameter("incoming_queue_size").get_parameter_value().integer_value
+        )
+        self.write_queue_size = (
+            self.get_parameter("write_queue_size").get_parameter_value().integer_value
+        )
         self.use_compression = (
             self.get_parameter("use_compression").get_parameter_value().bool_value
         )

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -81,7 +81,7 @@ def log_exceptions(f: Callable[P, R]) -> Callable[P, R]:
 class IncomingQueue(threading.Thread):
     """Decouples incoming messages from the AsyncIO event loop."""
 
-    def __init__(self, protocol: RosbridgeProtocol, max_queue_size: int = 0) -> None:
+    def __init__(self, protocol: RosbridgeProtocol, max_queue_size: int | None = None) -> None:
         threading.Thread.__init__(self)
         self.daemon = True
         self.queue: deque[str] = deque(maxlen=max_queue_size)

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -44,7 +44,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, ParamSpec, TypeVar
 
 from rclpy.node import Node
 from rosbridge_library.rosbridge_protocol import RosbridgeProtocol
-from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError, WebSocketHandler
 
 if TYPE_CHECKING:
@@ -80,17 +79,12 @@ def log_exceptions(f: Callable[P, R]) -> Callable[P, R]:
 
 
 class IncomingQueue(threading.Thread):
-    """
-    Decouples incoming messages from the Tornado thread.
+    """Decouples incoming messages from the AsyncIO event loop."""
 
-    This mitigates cases where outgoing messages are blocked by incoming,
-    and vice versa.
-    """
-
-    def __init__(self, protocol: RosbridgeProtocol) -> None:
+    def __init__(self, protocol: RosbridgeProtocol, max_queue_size: int = 0) -> None:
         threading.Thread.__init__(self)
         self.daemon = True
-        self.queue: deque[str] = deque()
+        self.queue: deque[str] = deque(maxlen=max_queue_size)
         self.protocol = protocol
 
         self.cond = threading.Condition()
@@ -106,13 +100,18 @@ class IncomingQueue(threading.Thread):
 
     def push(self, msg: str) -> None:
         with self.cond:
+            if self.queue.maxlen is not None and len(self.queue) == self.queue.maxlen:
+                self.protocol.node_handle.get_logger().warning(
+                    "Incoming queue full, dropping oldest message",
+                    throttle_duration_sec=1.0,
+                )
             self.queue.append(msg)
             self.cond.notify()
 
     def run(self) -> None:
         while True:
             with self.cond:
-                if len(self.queue) == 0 and not self._finished:
+                while len(self.queue) == 0 and not self._finished:
                     self.cond.wait()
 
                 if self._finished:
@@ -145,11 +144,17 @@ class RosbridgeWebSocket(WebSocketHandler):
     protocol_parameters: ClassVar[dict[str, Any]] = {}
 
     # Parameters for the WebSocket handler
+    incoming_queue_size: ClassVar[int] = 1000
+    write_queue_size: ClassVar[int] = 1000
     use_compression: ClassVar[bool] = False
 
+    # Instance variables for each connection
     client_id: uuid.UUID
     protocol: RosbridgeProtocol
     incoming_queue: IncomingQueue
+    write_queue: asyncio.Queue
+    write_slots: threading.Semaphore
+    write_task: asyncio.Task
 
     @log_exceptions
     def open(self, *args: str, **kwargs: str) -> None:  # noqa: ARG002
@@ -160,10 +165,13 @@ class RosbridgeWebSocket(WebSocketHandler):
             self.protocol = RosbridgeProtocol(
                 self.client_id, cls.node_handle, parameters=cls.protocol_parameters
             )
-            self.incoming_queue = IncomingQueue(self.protocol)
+            self.incoming_queue = IncomingQueue(self.protocol, cls.incoming_queue_size)
             self.incoming_queue.start()
             self.protocol.outgoing = self.send_message
             self.set_nodelay(True)
+            self.write_queue: asyncio.Queue = asyncio.Queue(maxsize=cls.write_queue_size)
+            self.write_slots = threading.Semaphore(cls.write_queue_size)
+            self.write_task = asyncio.ensure_future(self._drain_write_queue())
             cls.clients_connected += 1
             if cls.client_manager:
                 cls.client_manager.add_client(self.client_id, self.request.remote_ip or "")
@@ -190,6 +198,7 @@ class RosbridgeWebSocket(WebSocketHandler):
         # ROS subscriptions have an inherent race condition with protocol.finish()
         self.protocol.outgoing = lambda *_args, **_kwargs: None
         self.incoming_queue.finish()
+        self.write_task.cancel()
 
         cls.clients_connected -= 1
         if cls.client_manager:
@@ -201,32 +210,36 @@ class RosbridgeWebSocket(WebSocketHandler):
     def send_message(self, message: bytes | str, compression: str = "none") -> None:
         cls = self.__class__
         assert isinstance(cls.event_loop, AbstractEventLoop), "Event loop was not set"
+        binary = compression in ["cbor", "cbor-raw"]
+        if not self.write_slots.acquire(blocking=False):
+            assert isinstance(cls.node_handle, Node), "Node handle was not set"
+            cls.node_handle.get_logger().warning(
+                "Write queue full, dropping outgoing message",
+                throttle_duration_sec=1.0,
+            )
+            return
+        cls.event_loop.call_soon_threadsafe(self.write_queue.put_nowait, (message, binary))
 
-        if compression in ["cbor", "cbor-raw"]:
-            binary = True
-        else:
-            binary = False
-
-        asyncio.run_coroutine_threadsafe(self.prewrite_message(message, binary), cls.event_loop)
-
-    async def prewrite_message(self, message: bytes | str, binary: bool) -> None:
+    async def _drain_write_queue(self) -> None:
+        """Drain the per-connection write queue, serialising all write_message calls."""
         cls = self.__class__
         assert isinstance(cls.node_handle, Node), "Node handle was not set"
         try:
-            await self.write_message(message, binary)
-        except WebSocketClosedError:
-            cls.node_handle.get_logger().warning(
-                "WebSocketClosedError: Tried to write to a closed websocket",
-                throttle_duration_sec=1.0,
-            )
-            # If we end up here, a client has disconnected before its message callback(s) could be removed.
-        except StreamClosedError:
-            cls.node_handle.get_logger().warning(
-                "StreamClosedError: Tried to write to a closed stream",
-                throttle_duration_sec=1.0,
-            )
-        except:  # noqa: E722  # Will log and raise
-            _log_exception()
+            while True:
+                item = await self.write_queue.get()
+                self.write_slots.release()
+                try:
+                    await self.write_message(*item)
+                except WebSocketClosedError:
+                    cls.node_handle.get_logger().warning(
+                        "WebSocketClosedError: Tried to write to a closed websocket",
+                        throttle_duration_sec=1.0,
+                    )
+                    return
+                except Exception:
+                    _log_exception()
+        except asyncio.CancelledError:
+            pass
 
     @log_exceptions
     def check_origin(self, origin: str) -> bool:  # noqa: ARG002

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -236,6 +236,8 @@ class RosbridgeWebSocket(WebSocketHandler):
                         throttle_duration_sec=1.0,
                     )
                     return
+                except asyncio.CancelledError:
+                    raise
                 except Exception:
                     _log_exception()
         except asyncio.CancelledError:

--- a/rosbridge_server/test/websocket/common.py
+++ b/rosbridge_server/test/websocket/common.py
@@ -21,6 +21,7 @@ from twisted.internet.endpoints import TCP4ClientEndpoint
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from launch.action import Action
     from rclpy.client import Client
     from rclpy.logging import RcutilsLogger
 
@@ -40,6 +41,12 @@ class TestClientProtocol(WebSocketClientProtocol):
     def onOpen(self) -> None:  # noqa: N802
         self.connected_future.set_result(None)
 
+    def onClose(self, was_clean: bool, code: int, reason: str) -> None:  # noqa: ARG002, N802
+        if not self.connected_future.done():
+            self.connected_future.set_exception(
+                Exception(f"WebSocket closed before handshake completed: {reason}")
+            )
+
     def sendJson(self, msg_dict: dict[str, Any], *, times: int = 1) -> None:  # noqa: N802
         msg = json.dumps(msg_dict).encode("utf-8")
         for _ in range(times):
@@ -47,34 +54,44 @@ class TestClientProtocol(WebSocketClientProtocol):
             reactor.callFromThread(self.sendMessage, msg)  # type: ignore[attr-defined]
 
     def onMessage(self, payload: str, binary: bool) -> None:  # noqa: N802
-        print(f"WebSocket client received message: {payload}")
         self.message_handler(payload if binary else json.loads(payload))
 
 
-def generate_test_description() -> LaunchDescription:
+def make_test_description(
+    extra_actions: list[Action] | None = None,
+) -> LaunchDescription:
     """
-    Generate a launch description that runs the websocket server.
+    Build a launch description that runs the websocket server.
 
-    Re-export this from a test file and use add_launch_test() to run the test.
+    Call this directly when you need to inject extra launch actions.
+    Re-export `generate_test_description` instead when no extra actions are needed.
     This supports parameterization via the 'use_events_executor' launch argument.
+
+    :param extra_actions: Optional additional launch actions inserted before ReadyToTest().
     """
-    return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "use_events_executor",
-                default_value="false",
-                description="Use EventsExecutor instead of SingleThreadedExecutor",
-            ),
-            launch_ros.actions.Node(
-                executable="rosbridge_websocket",
-                package="rosbridge_server",
-                parameters=[
-                    {"port": 0, "use_events_executor": LaunchConfiguration("use_events_executor")}
-                ],
-            ),
-            ReadyToTest(),
-        ]
-    )
+    actions: list[Action] = [
+        DeclareLaunchArgument(
+            "use_events_executor",
+            default_value="false",
+            description="Use EventsExecutor instead of SingleThreadedExecutor",
+        ),
+        launch_ros.actions.Node(
+            executable="rosbridge_websocket",
+            package="rosbridge_server",
+            parameters=[
+                {"port": 0, "use_events_executor": LaunchConfiguration("use_events_executor")}
+            ],
+        ),
+    ]
+    if extra_actions:
+        actions.extend(extra_actions)
+    actions.append(ReadyToTest())
+    return LaunchDescription(actions)
+
+
+def generate_test_description() -> LaunchDescription:
+    """Re-export this from test files that need no extra launch actions."""
+    return make_test_description()
 
 
 async def get_server_port(node: Node) -> int:

--- a/rosbridge_server/test/websocket/event_loop_starvation.test.py
+++ b/rosbridge_server/test/websocket/event_loop_starvation.test.py
@@ -68,7 +68,7 @@ _PUBLISHER_SCRIPT = str(Path(__file__).parent / "starvation_load_publisher.py")
 
 def generate_test_description() -> LaunchDescription:
     return make_test_description(
-        extra_actions=[ExecuteProcess(cmd=[_PUBLISHER_SCRIPT], output="screen")]
+        extra_actions=[ExecuteProcess(cmd=[sys.executable, _PUBLISHER_SCRIPT], output="screen")]
     )
 
 

--- a/rosbridge_server/test/websocket/event_loop_starvation.test.py
+++ b/rosbridge_server/test/websocket/event_loop_starvation.test.py
@@ -1,0 +1,149 @@
+"""
+Regression test for event-loop starvation when a high-rate load client is connected.
+
+The scenario:
+  1. A "load" client subscribes to N high-frequency topics.
+  2. While messages are flowing, a second "probe" client connects and subscribes
+     to a low-rate heartbeat topic.
+  3. The test asserts that:
+     - The probe client can connect at all (handshake not starved).
+     - The probe client receives the expected number of heartbeats within the
+       measurement window (delivery not starved).
+
+If the event loop is starved the probe client will either time out during the
+WebSocket handshake or receive far fewer heartbeats than expected.
+
+NOTE: in a loopback environment with fast hardware this test may pass even with
+a regressed implementation, because socket writes complete near-instantly and the
+event loop never accumulates a meaningful backlog.  Reliability improves with
+larger payloads (LOAD_PAYLOAD_DOUBLES) and a slower or more loaded machine.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from launch.actions import ExecuteProcess
+from twisted.python import log
+
+sys.path.append(str(Path(__file__).parent))  # enable importing from common.py
+
+from common import make_test_description, sleep, websocket_test
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from common import TestClientProtocol
+    from launch import LaunchDescription
+    from rclpy.node import Node
+
+log.startLogging(sys.stderr)
+
+# Load parameters.
+N_LOAD_TOPICS = 20
+
+# Probe parameters.
+PROBE_RATE_HZ = 10
+PROBE_TOPIC = "/starvation_probe"
+
+# How long to let the load saturate the server before the probe client connects.
+# Needs to be long enough for the server's write queues to fill up under load.
+LOAD_WARMUP_S = 3.0
+
+# How long after the probe client connects to wait before subscribing.
+PROBE_SUBSCRIBE_DELAY_S = 5.0
+
+# Measurement window.
+PROBE_WINDOW_S = 5.0
+
+# Minimum fraction of expected heartbeats that must arrive.
+# Allow generous margin for scheduling jitter; starvation typically delivers 0.
+MIN_DELIVERY_FRACTION = 0.90
+
+_PUBLISHER_SCRIPT = str(Path(__file__).parent / "starvation_load_publisher.py")
+
+
+def generate_test_description() -> LaunchDescription:
+    return make_test_description(
+        extra_actions=[ExecuteProcess(cmd=[_PUBLISHER_SCRIPT], output="screen")]
+    )
+
+
+class TestEventLoopStarvation(unittest.TestCase):
+    @websocket_test
+    async def test_probe_receives_heartbeats_under_load(
+        self,
+        node: Node,
+        make_client: Callable[[], Awaitable[TestClientProtocol]],
+    ) -> None:
+        # ------------------------------------------------------------------ #
+        # Load client: subscribe to all load topics.                          #
+        # ------------------------------------------------------------------ #
+        load_client = await make_client()
+        for i in range(N_LOAD_TOPICS):
+            load_client.sendJson(
+                {
+                    "op": "subscribe",
+                    "topic": f"/starvation_load_{i}",
+                    "type": "std_msgs/msg/Float64MultiArray",
+                }
+            )
+
+        # Let the load flow for a while so the event loop is under stress
+        # when the probe client attempts to connect.
+        await sleep(node, LOAD_WARMUP_S)
+
+        # ------------------------------------------------------------------ #
+        # Probe client: connect while load is running.                        #
+        # ------------------------------------------------------------------ #
+        # If the event loop is starved, make_client() will raise here because
+        # the TCP accept / WebSocket handshake never gets scheduled.
+        try:
+            probe_client = await make_client()
+        except Exception as exc:
+            self.fail(
+                f"Event-loop starvation detected: probe client could not connect under load: {exc}"
+            )
+
+        # Wait with the connection open but without subscribing yet, so the
+        # load is still flowing hard when we finally ask for probe messages.
+        # Mirrors the asyncio.sleep(6) in bridge_starvation_client.py.
+        await sleep(node, PROBE_SUBSCRIBE_DELAY_S)
+
+        probe_client.sendJson(
+            {
+                "op": "subscribe",
+                "topic": PROBE_TOPIC,
+                "type": "std_msgs/msg/String",
+            }
+        )
+
+        # ------------------------------------------------------------------ #
+        # Count heartbeats delivered during the measurement window.           #
+        # ------------------------------------------------------------------ #
+        received: list[object] = []
+
+        def on_probe_message(msg: object) -> None:
+            if isinstance(msg, dict) and msg.get("topic") == PROBE_TOPIC:
+                received.append(msg)
+
+        probe_client.message_handler = on_probe_message
+
+        await sleep(node, PROBE_WINDOW_S)
+
+        # ------------------------------------------------------------------ #
+        # Assertions.                                                         #
+        # ------------------------------------------------------------------ #
+        expected = int(PROBE_RATE_HZ * PROBE_WINDOW_S)
+        min_required = int(expected * MIN_DELIVERY_FRACTION)
+
+        self.assertGreaterEqual(
+            len(received),
+            min_required,
+            f"Event-loop starvation detected: received only {len(received)}/{expected} "
+            f"probe heartbeats (minimum required: {min_required}). "
+            "The event loop is likely blocked by high-rate outgoing message scheduling.",
+        )

--- a/rosbridge_server/test/websocket/starvation_load_publisher.py
+++ b/rosbridge_server/test/websocket/starvation_load_publisher.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Standalone publisher node for the event-loop starvation regression test.
+
+Runs as a separate process launched alongside rosbridge so that the load and
+probe topics are produced independently of the test process.
+"""
+
+from __future__ import annotations
+
+import rclpy
+from std_msgs.msg import Float64MultiArray, String
+
+N_LOAD_TOPICS = 20
+LOAD_RATE_HZ = 100
+LOAD_PAYLOAD_DOUBLES = 2048
+PROBE_RATE_HZ = 10
+PROBE_TOPIC = "/starvation_probe"
+
+
+def main() -> None:
+    rclpy.init()
+    node = rclpy.create_node("starvation_load_publisher")
+
+    load_pubs = [
+        node.create_publisher(Float64MultiArray, f"/starvation_load_{i}", 10)
+        for i in range(N_LOAD_TOPICS)
+    ]
+    probe_pub = node.create_publisher(String, PROBE_TOPIC, 10)
+
+    load_msg = Float64MultiArray(data=[0.0] * LOAD_PAYLOAD_DOUBLES)
+    probe_msg = String(data="heartbeat")
+
+    def _publish_load() -> None:
+        for pub in load_pubs:
+            pub.publish(load_msg)
+
+    node.create_timer(1.0 / LOAD_RATE_HZ, _publish_load)
+    node.create_timer(1.0 / PROBE_RATE_HZ, lambda: probe_pub.publish(probe_msg))
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Public API Changes**
Added `incoming_queue_size` and `write_queue_size` ROS parameters


**Description**
Fixes #1243

Previously, each rosbridge message send operation was scheduled to the asyncio event loop by a call to `call_coroutine_threadsafe`. When a large number of messages was sent, the event loop was quickly overfilled as the next tasks spawned faster than they could be processed and the number of tasks increased indefinitely.

This caused other client to be unable to open connection or receive any messages.

This has been fixed by adding a write queue and a task which drains this queue. When a new message is to be sent, it is scheduled to be put into the queue (by call to `call_coroutine_threadsafe`) ONLY if the queue is not full, otherwise it is dropped. The write task yields the execution to other tasks by call to `await` for each message, so the other clients don't starve, even when the server is unable to process all messages in time.

The incoming queue was also limited in size to prevent the possibility of memory exhaustion.

The starvation test fails on EventExecutor but for a different reason which I won't cover in this PR.