### PR TITLE
fix: Correct regex patterns in test_stringify_field_types

### DIFF
--- a/rosapi/test/test_stringify_field_types.py
+++ b/rosapi/test/test_stringify_field_types.py
@@ -24,8 +24,8 @@ class TestObjectUtils(unittest.TestCase):
         self.assertRegex(
             stringify_field_types("std_msgs/ByteMultiArray"),
             r"""(?s)
-MultiArrayLayout  layout.*
-byte\[\]            data.*
+MultiArrayLayout\s+layout.*
+byte\[\]\s+data.*
 
 ================================================================================
 MSG: std_msgs/MultiArrayLayout
@@ -76,9 +76,9 @@ uint32 height.*
 uint32 width.*
 string distortion_model.*
 float64\[\] d.*
-float64\[9\]  k.*
-float64\[9\]  r.*
-float64\[12\] p.*
+float64\[9\]\s+k.*
+float64\[9\]\s+r.*
+float64\[12\]\s+p.*
 uint32 binning_x.*
 uint32 binning_y.*
 RegionOfInterest roi.*


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Fixes the rosapi test after ros2/common_interfaces#332
