### PR TITLE
fix(rosapi): Resolve action types without ros2cli

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -24,6 +24,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(${PROJECT_NAME}_test_action_type test/test_action_type.py)
   ament_add_pytest_test(${PROJECT_NAME}_test_stringify_field_types test/test_stringify_field_types.py)
   ament_add_pytest_test(${PROJECT_NAME}_test_typedefs test/test_typedefs.py)
 

--- a/rosapi/package.xml
+++ b/rosapi/package.xml
@@ -22,7 +22,6 @@ action servers and managing ROS parameters.
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>ros2action</exec_depend>
   <exec_depend>ros2interface</exec_depend>
   <exec_depend>ros2node</exec_depend>
   <exec_depend>ros2service</exec_depend>
@@ -34,6 +33,7 @@ action servers and managing ROS parameters.
 
   <test_depend>ament_cmake_mypy</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>example_interfaces</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>rmw_dds_common</test_depend>
   <test_depend>sensor_msgs</test_depend>

--- a/rosapi/src/rosapi/proxy.py
+++ b/rosapi/src/rosapi/proxy.py
@@ -32,9 +32,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from ros2action.api import get_action_names_and_types
+from rclpy.action import get_action_names_and_types
 from ros2interface.api import type_completer
 from ros2node.api import (
     get_node_names,
@@ -366,7 +366,7 @@ def get_action_type(action_name: str) -> str:
 
     If the action does not exist, an empty string is returned.
     """
-    names_and_types = get_action_names_and_types(node=_node)
+    names_and_types = get_action_names_and_types(cast("Node", _node))
 
     for name, types in names_and_types:
         if name == action_name and types:

--- a/rosapi/test/test_action_type.py
+++ b/rosapi/test/test_action_type.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import time
+import unittest
+from threading import Thread
+from typing import TYPE_CHECKING
+
+import rclpy
+from example_interfaces.action import Fibonacci
+from rclpy.action import ActionServer
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+
+from rosapi import proxy
+
+if TYPE_CHECKING:
+    from rclpy.action.server import ServerGoalHandle
+
+# Actions are discovered asynchronously, so the happy-path lookup is retried.
+DISCOVERY_TIMEOUT_SEC = 10.0
+DISCOVERY_POLL_SEC = 0.1
+
+
+class TestActionType(unittest.TestCase):
+    def setUp(self) -> None:
+        rclpy.init()
+        self.node = Node("test_action_type")
+        self.executor = SingleThreadedExecutor()
+        self.executor.add_node(self.node)
+        proxy.init(self.node)
+
+        self.exec_thread = Thread(target=self.executor.spin)
+        self.exec_thread.start()
+
+    def tearDown(self) -> None:
+        self.executor.remove_node(self.node)
+        self.executor.shutdown()
+        self.exec_thread.join()
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def execute_callback(self, goal_handle: ServerGoalHandle) -> Fibonacci.Result:
+        goal_handle.succeed()
+        return Fibonacci.Result()
+
+    def test_get_action_type_of_missing_action(self) -> None:
+        # rosapi passes a plain rclpy node, so a lookup going through
+        # ros2action.api used to raise AttributeError here instead of
+        # reporting the action as missing.
+        self.assertEqual(proxy.get_action_type("/no_such_action"), "")
+
+    def test_get_action_type(self) -> None:
+        action_server = ActionServer(self.node, Fibonacci, "/fibonacci", self.execute_callback)
+        try:
+            action_type = ""
+            deadline = time.monotonic() + DISCOVERY_TIMEOUT_SEC
+            while not action_type and time.monotonic() < deadline:
+                action_type = proxy.get_action_type("/fibonacci")
+                if not action_type:
+                    time.sleep(DISCOVERY_POLL_SEC)
+
+            self.assertEqual(action_type, "example_interfaces/action/Fibonacci")
+        finally:
+            action_server.destroy()


### PR DESCRIPTION
**Public API Changes**

No

**Description**

 /rosapi/action_type has never worked since it was added in #1046 (2.4.0). ros2action.api.get_action_names_and_types() is just node.get_action_names_and_types(), which only exists on ros2cli's DirectNode — with rosapi's plain rclpy node it raises AttributeError, so the service never responds and rosapi_node's bare rclpy.spin() dies with it, taking all of rosapi down.

rclpy.action.get_action_names_and_types() queries the graph directly. Adds a regression test and drops the now-unused ros2action dependency. Please backport.