### PR TITLE
fix(rosapi): Keep the param client cache from crashing the node

### DIFF
--- a/rosapi/CMakeLists.txt
+++ b/rosapi/CMakeLists.txt
@@ -24,6 +24,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(${PROJECT_NAME}_test_params test/test_params.py)
   ament_add_pytest_test(${PROJECT_NAME}_test_stringify_field_types test/test_stringify_field_types.py)
   ament_add_pytest_test(${PROJECT_NAME}_test_typedefs test/test_typedefs.py)
 

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -33,6 +33,7 @@
 from __future__ import annotations
 
 import fnmatch
+import time
 from dataclasses import dataclass
 from json import dumps, loads
 from typing import TYPE_CHECKING, cast
@@ -60,7 +61,6 @@ if TYPE_CHECKING:
     from rclpy.client import Client
     from rclpy.node import Node
     from rclpy.task import Future
-    from rclpy.time import Time
 
 """ Methods to interact with the param server.  Values have to be passed
 as JSON in order to facilitate dynamically typed SRV messages """
@@ -94,14 +94,16 @@ class _CachedClient:
 
     :param use_count: The number of ongoing calls using this client.
     :type use_count: int
-    :param last_used_time: The last time this client was used for a call.
-    :type last_used_time: Time
+    :param last_used_time: A time.monotonic() stamp of the last call using this client.
+        This is a resource lifetime, so it is measured monotonically rather than with
+        a ROS clock: no clock types to mix up, and no sensitivity to clock jumps.
+    :type last_used_time: float
     :param client: The cached client instance.
     :type client: Client
     """
 
     use_count: int
-    last_used_time: Time
+    last_used_time: float
     client: Client
 
 
@@ -171,7 +173,7 @@ def _get_client(
         qos_profile=qos_profile_parameters,
     )
     _cached_clients[service_name] = _CachedClient(
-        use_count=0, last_used_time=_node.get_clock().now(), client=client
+        use_count=0, last_used_time=time.monotonic(), client=client
     )
     return client
 
@@ -197,11 +199,12 @@ def _cleanup_timer_callback() -> None:
     different nodes being interacted with.
     """
     assert _node is not None
-    now = _node.get_clock().now()
+    now = time.monotonic()
     to_remove = []
     for service_name, cached_client in _cached_clients.items():
-        if cached_client.use_count == 0 and (now - cached_client.last_used_time).nanoseconds > int(
-            _client_persistence_sec * 1e9
+        if (
+            cached_client.use_count == 0
+            and now - cached_client.last_used_time > _client_persistence_sec
         ):
             _node.destroy_client(cached_client.client)
             to_remove.append(service_name)
@@ -283,7 +286,7 @@ async def _set_param(
         await futures_wait_for(_node, [future], _timeout_sec)
     finally:
         _cached_clients[service_name].use_count -= 1
-        _cached_clients[service_name].last_used_time = _node.get_clock().now()
+        _cached_clients[service_name].last_used_time = time.monotonic()
 
     if not future.done():
         future.cancel()
@@ -347,7 +350,7 @@ async def _get_param(node_name: str, name: str) -> ParameterValue:
         await futures_wait_for(_node, [future], _timeout_sec)
     finally:
         _cached_clients[service_name].use_count -= 1
-        _cached_clients[service_name].last_used_time = _node.get_clock().now()
+        _cached_clients[service_name].last_used_time = time.monotonic()
 
     if not future.done():
         future.cancel()

--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -42,7 +42,6 @@ from rcl_interfaces.srv import GetParameters, ListParameters, SetParameters
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.parameter import get_parameter_value
 from rclpy.qos import qos_profile_parameters
-from rclpy.time import Time
 from ros2node.api import get_absolute_node_name
 
 from rosapi.async_helper import futures_wait_for
@@ -61,6 +60,7 @@ if TYPE_CHECKING:
     from rclpy.client import Client
     from rclpy.node import Node
     from rclpy.task import Future
+    from rclpy.time import Time
 
 """ Methods to interact with the param server.  Values have to be passed
 as JSON in order to facilitate dynamically typed SRV messages """
@@ -170,8 +170,23 @@ def _get_client(
         callback_group=MutuallyExclusiveCallbackGroup(),
         qos_profile=qos_profile_parameters,
     )
-    _cached_clients[service_name] = _CachedClient(use_count=0, last_used_time=Time(), client=client)
+    _cached_clients[service_name] = _CachedClient(
+        use_count=0, last_used_time=_node.get_clock().now(), client=client
+    )
     return client
+
+
+def _drop_client(service_name: str) -> None:
+    """
+    Destroy a cached client and remove it from the cache.
+
+    :param service_name: The name of the service whose client should be dropped.
+    """
+    assert _node is not None
+
+    cached_client = _cached_clients.pop(service_name, None)
+    if cached_client is not None:
+        _node.destroy_client(cached_client.client)
 
 
 def _cleanup_timer_callback() -> None:
@@ -252,8 +267,8 @@ async def _set_param(
     )
 
     if not client.service_is_ready():
-        _node.destroy_client(client)
-        msg = f"Service {client.srv_name} is not available"
+        _drop_client(service_name)
+        msg = f"Service {service_name} is not available"
         raise Exception(msg)
 
     request = SetParameters.Request()
@@ -316,8 +331,8 @@ async def _get_param(node_name: str, name: str) -> ParameterValue:
     )
 
     if not client.service_is_ready():
-        _node.destroy_client(client)
-        msg = f"Service {client.srv_name} is not available"
+        _drop_client(service_name)
+        msg = f"Service {service_name} is not available"
         raise Exception(msg)
 
     request = GetParameters.Request()

--- a/rosapi/test/test_params.py
+++ b/rosapi/test/test_params.py
@@ -25,11 +25,27 @@ class TestParamClientCache(unittest.TestCase):
         self.node.destroy_node()
         rclpy.shutdown()
 
+    def _backdate(self, service_name: str) -> None:
+        """Age a cached client past the persistence window."""
+        params._cached_clients[service_name].last_used_time -= params._client_persistence_sec + 1
+
     def test_cleanup_of_a_freshly_created_client(self) -> None:
-        # The cleanup timer compares against the node clock, so a client cached
-        # with a default Time() (ClockType.SYSTEM_TIME) used to make every
-        # cleanup run raise "Can't subtract times with different clock types".
+        # A client used to be cached with a default Time() (ClockType.SYSTEM_TIME)
+        # while the cleanup timer compared against the node clock, which is a
+        # ROSClock (ClockType.ROS_TIME) whether or not use_sim_time is set. That
+        # subtraction raises "Can't subtract times with different clock types",
+        # out of a timer callback, which takes the whole node down.
         params._get_client(MISSING_SERVICE, GetParameters)
+
+        params._cleanup_timer_callback()
+
+    def test_cleanup_after_an_unavailable_service(self) -> None:
+        # The path that actually reached the comparison above: the caller bumps
+        # use_count right after _get_client, so the cleanup timer's short circuit
+        # normally hides a freshly cached client - except when the service turns
+        # out to be unavailable and the call returns in between.
+        with self.assertRaisesRegex(Exception, "is not available"):
+            asyncio.run(params._get_param(MISSING_NODE, "some_param"))
 
         params._cleanup_timer_callback()
 
@@ -41,3 +57,20 @@ class TestParamClientCache(unittest.TestCase):
             asyncio.run(params._get_param(MISSING_NODE, "some_param"))
 
         self.assertNotIn(MISSING_SERVICE, params._cached_clients)
+
+    def test_idle_client_is_evicted(self) -> None:
+        params._get_client(MISSING_SERVICE, GetParameters)
+        self._backdate(MISSING_SERVICE)
+
+        params._cleanup_timer_callback()
+
+        self.assertNotIn(MISSING_SERVICE, params._cached_clients)
+
+    def test_client_of_an_ongoing_call_is_kept(self) -> None:
+        params._get_client(MISSING_SERVICE, GetParameters)
+        self._backdate(MISSING_SERVICE)
+        params._cached_clients[MISSING_SERVICE].use_count = 1
+
+        params._cleanup_timer_callback()
+
+        self.assertIn(MISSING_SERVICE, params._cached_clients)

--- a/rosapi/test/test_params.py
+++ b/rosapi/test/test_params.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+import rclpy
+from rcl_interfaces.srv import GetParameters
+from rclpy.node import Node
+
+from rosapi import params
+
+# No node by this name is running, so its parameter services are never available.
+MISSING_NODE = "/no_such_node"
+MISSING_SERVICE = f"{MISSING_NODE}/get_parameters"
+
+
+class TestParamClientCache(unittest.TestCase):
+    def setUp(self) -> None:
+        rclpy.init()
+        self.node = Node("test_params")
+        params.init(self.node)
+
+    def tearDown(self) -> None:
+        params._cached_clients.clear()
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_cleanup_of_a_freshly_created_client(self) -> None:
+        # The cleanup timer compares against the node clock, so a client cached
+        # with a default Time() (ClockType.SYSTEM_TIME) used to make every
+        # cleanup run raise "Can't subtract times with different clock types".
+        params._get_client(MISSING_SERVICE, GetParameters)
+
+        params._cleanup_timer_callback()
+
+    def test_client_of_an_unavailable_service_is_dropped(self) -> None:
+        # The client is destroyed when the service turns out to be unavailable,
+        # so it must not stay in the cache - it would be handed out again and
+        # raise InvalidHandle on the next call.
+        with self.assertRaisesRegex(Exception, "is not available"):
+            asyncio.run(params._get_param(MISSING_NODE, "some_param"))
+
+        self.assertNotIn(MISSING_SERVICE, params._cached_clients)


### PR DESCRIPTION
Clients were cached with a default Time() (SYSTEM_TIME), so the cleanup timer's subtraction against the node clock (ROS_TIME) raised TypeError every 0.5s, and the unavailable-service path destroyed a client while leaving it in the cache.

**Public API Changes**
None

**Description**
Since the param client cache was added in #1201, rosapi crashes shortly after the first /rosapi/get_param or /rosapi/set_param call. Clients are cached with a default Time() (SYSTEM_TIME), so the 0.5 s cleanup timer's subtraction against the node clock (ROS_TIME) raises TypeError: Can't subtract times with different clock types, which propagates out of rclpy.spin() and kills rosapi_node. A fresh client is never ready right after create_client(), so the first call takes the "service is not available" path — which destroys the client but leaves it in the cache, both arming the timer crash and handing back a destroyed client (InvalidHandle) on the next call.

Stamps cached clients from the node clock and drops the cache entry when the client is destroyed. Adds regression tests. Please backport.

