### PR TITLE
fix(rosapi): Handle bounded string and sequence field types

### DIFF
--- a/rosapi/src/rosapi/objectutils.py
+++ b/rosapi/src/rosapi/objectutils.py
@@ -66,6 +66,11 @@ atomics = [
 ]
 specials = ["time", "duration"]
 
+# `sequence<T>` / `sequence<T, N>`, where T may itself be bounded.
+_SEQUENCE = re.compile(r"^sequence<(?P<inner>.+?)(?:,\s*\d+)?>$")
+# `string<N>` / `wstring<N>`.
+_BOUNDED_STRING = re.compile(r"^(?P<kind>w?string)<\d+>$")
+
 
 def get_typedef(type_name: str) -> dict | None:
     """
@@ -306,6 +311,18 @@ def _handle_array_information(
     return fieldnames, fieldtypes, fieldarraylen, examples
 
 
+def _strip_bound(field_type: str) -> str:
+    """
+    Drop the size bound from a bounded string type.
+
+    IDL spells a bounded string as `string<N>` (`wstring<N>` for the wide
+    variant). The bound says nothing about the type itself, and everything
+    downstream - `atomics`, `ros_loader` - only knows the plain name.
+    """
+    match = _BOUNDED_STRING.match(field_type)
+    return match.group("kind") if match else field_type
+
+
 def _handle_type_and_array_len(instance: ROSMessage, name: str) -> tuple[str, int]:
     """Extract field type and determine its length if it's an array."""
     # Get original field type using instance's _fields_and_field_types property
@@ -314,10 +331,13 @@ def _handle_type_and_array_len(instance: ROSMessage, name: str) -> tuple[str, in
     # Initialize arraylen
     arraylen = -1
 
-    # If field_type is a sequence, update the `field_type` variable.
-    if matches := re.findall("sequence<([^<]+)>", field_type):
+    # If field_type is a sequence, update the `field_type` variable. A sequence
+    # can carry an upper bound (`sequence<T, N>`) that is not part of the inner
+    # type, and the inner type can itself be bounded (`sequence<string<255>>`),
+    # so neither is matched by `[^<]+`.
+    if match := _SEQUENCE.match(field_type):
         # Extract the inner type and continue processing
-        field_type = matches[0]
+        field_type = match.group("inner")
         arraylen = 0
     elif field_type[-1:] == "]":
         if field_type[-2:-1] == "[":
@@ -328,7 +348,7 @@ def _handle_type_and_array_len(instance: ROSMessage, name: str) -> tuple[str, in
             arraylen = int(field_type[split + 1 : -1])
             field_type = field_type[:split]
 
-    return field_type, arraylen
+    return _strip_bound(field_type), arraylen
 
 
 T = TypeVar("T")
@@ -430,13 +450,16 @@ def _type_name(type_name: str, instance: object) -> str:
     if type_name in atomics or type_name in specials:
         return type_name
 
-    # If the instance is a list, then we can get no more information from the instance.
-    # However, luckily, the 'type' field for list types is usually already inflated to the full type.
-    if isinstance(instance, list):
+    # If the instance is not a message, we can get no more information from it.
+    # Luckily, the 'type' field for those is already the full type. Sequences
+    # reach us as list, array.array or bytes depending on the element type, and
+    # primitives as plain Python values, so this cannot assert on being a
+    # message: rosapi_node runs a bare rclpy.spin(), so an AssertionError here
+    # takes the whole node down and with it every /rosapi/* service.
+    if not isinstance(instance, ROSMessage):
         return type_name
 
     # Otherwise, the type will come from the module and class name of the instance
-    assert isinstance(instance, ROSMessage)
     return _type_name_from_instance(instance)
 
 

--- a/rosapi/test/test_typedefs.py
+++ b/rosapi/test/test_typedefs.py
@@ -69,6 +69,94 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(examples, ["123"])
 
 
+class TestBoundedTypes(unittest.TestCase):
+    """
+    Regression: bounded strings and bounded sequences must be normalised.
+
+    IDL spells these `string<255>` and `sequence<T, N>`. Neither was stripped,
+    so `string<255>` reached `_type_name` as an unknown type whose value is a
+    plain `str`, tripping its `assert isinstance(instance, ROSMessage)` - and
+    since rosapi_node runs a bare `rclpy.spin()`, that AssertionError killed the
+    node and every `/rosapi/*` service with it. Reproducible against any node:
+    `type_description_interfaces/msg/TypeDescription`, reachable from every
+    node's `~/get_type_description` service, has `string<255>` fields.
+    """
+
+    @staticmethod
+    def _mock(field_types: dict[str, str], values: dict[str, object]) -> object:
+        class MockMsg:
+            __slots__ = ["_" + name for name in field_types]
+            _fields_and_field_types: ClassVar = dict(field_types)
+
+            def __init__(self) -> None:
+                for name, value in values.items():
+                    setattr(self, "_" + name, value)
+
+        return MockMsg()
+
+    def test_bounded_string_is_reported_as_string(self) -> None:
+        inst = self._mock({"type_name": "string<255>"}, {"type_name": "some/Type"})
+
+        _, types, lens, _ = objectutils._handle_array_information(inst)
+
+        self.assertEqual(types, ["string"])
+        self.assertEqual(lens, [-1])
+
+    def test_bounded_wstring_is_reported_as_wstring(self) -> None:
+        inst = self._mock({"label": "wstring<64>"}, {"label": "x"})
+
+        _, types, _, _ = objectutils._handle_array_information(inst)
+
+        self.assertEqual(types, ["wstring"])
+
+    def test_bounded_sequence_drops_the_upper_bound(self) -> None:
+        # rcl_interfaces/ParameterDescriptor spells its ranges this way; the
+        # bound used to be captured into the type, so the nested typedef lookup
+        # searched for a message class literally named "FloatingPointRange, 1".
+        inst = self._mock(
+            {"floating_point_range": "sequence<rcl_interfaces/FloatingPointRange, 1>"},
+            {"floating_point_range": []},
+        )
+
+        _, types, lens, _ = objectutils._handle_array_information(inst)
+
+        self.assertEqual(types, ["rcl_interfaces/FloatingPointRange"])
+        self.assertEqual(lens, [0])
+
+    def test_sequence_of_bounded_strings(self) -> None:
+        inst = self._mock({"names": "sequence<string<255>>"}, {"names": []})
+
+        _, types, lens, _ = objectutils._handle_array_information(inst)
+
+        self.assertEqual(types, ["string"])
+        self.assertEqual(lens, [0])
+
+    def test_unbounded_sequence_is_unchanged(self) -> None:
+        inst = self._mock({"sequence": "sequence<int32>"}, {"sequence": []})
+
+        _, types, lens, _ = objectutils._handle_array_information(inst)
+
+        self.assertEqual(types, ["int32"])
+        self.assertEqual(lens, [0])
+
+    def test_fixed_size_array_is_unchanged(self) -> None:
+        inst = self._mock({"uuid": "uint8[16]"}, {"uuid": b"\x00" * 16})
+
+        _, types, lens, _ = objectutils._handle_array_information(inst)
+
+        self.assertEqual(types, ["uint8"])
+        self.assertEqual(lens, [16])
+
+    def test_non_message_value_does_not_raise(self) -> None:
+        # rclpy hands primitive sequences over as array.array, not list, so
+        # _type_name must not assume anything it is given is a message.
+        import array
+
+        self.assertEqual(objectutils._type_name("some/Type", array.array("i", [1, 2])), "some/Type")
+        self.assertEqual(objectutils._type_name("some/Type", "a string"), "some/Type")
+        self.assertEqual(objectutils._type_name("some/Type", b"bytes"), "some/Type")
+
+
 def _make_invalid_module_exc(pkg: str, subname: str) -> _ros_loader.InvalidModuleException:
     return _ros_loader.InvalidModuleException(
         pkg, subname, ModuleNotFoundError(f"No module named '{pkg}'")


### PR DESCRIPTION
Bounded IDL types (`string<255>`, `sequence<T, N>`) are not normalised, so they reach `_type_name` as unresolvable names and trip its `assert isinstance(instance, ROSMessage)`.

**Public API Changes**
None

**Description**
`objectutils` mishandles every IDL type that carries a size bound:

- `sequence<T, N>` — the inner-type regex `sequence<([^<]+)>` swallows the bound as part of the type, so the field type becomes `"string, 5"`.
- `sequence<string<255>>` — `[^<]+` cannot cross the inner `<`, so nothing matches and the field type stays `sequence<string<255>>` whole.
- `string<255>` / `wstring<N>` — the bound is never stripped, and `atomics` / `ros_loader` only know the plain names.

Any of those leaves `_type_name` with a name it cannot resolve, and its `assert isinstance(instance, ROSMessage)` raises. `rosapi_node` runs a bare `rclpy.spin()`, so the `AssertionError` propagates out of the executor and takes *every* `/rosapi/*` service off the graph, not just the failing request. The `list` early return above the assert is also too narrow: sequences arrive as `list`, `array.array` or `bytes` depending on the element type, and primitives as plain Python values.

This is reachable from any client that asks for the definition of a type with a bounded field. `type_description_interfaces/FieldType.nested_type_name` is `string<255>`, and that type sits behind every node's `~/get_type_description` service, so on stock jazzy:

```python
>>> import rosapi.objectutils as ou
>>> ou.get_typedef_recursive("type_description_interfaces/TypeDescription")
AssertionError
```

Parses the sequence bound and the inner type separately, strips the bound off bounded strings, and returns the type name unchanged for anything that is not a message instead of asserting. The call above then resolves `nested_type_name` to `string` and returns its 4 typedefs. Adds regression tests for both bounded forms, the unbounded and fixed-size cases that must stay unchanged, and the non-message value.

Please backport.
