### PR TITLE
fix: Support wstring fields in message conversion

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -64,7 +64,7 @@ type_map = {
         "uint64",
     ),
     "float": ("float32", "float64", "double", "float"),
-    "str": ("string"),
+    "str": ("string", "wstring"),
 }
 primitive_types = (bool, int, float, str)
 list_types = (list, tuple, np.ndarray, array.array)
@@ -92,6 +92,7 @@ ros_primitive_types = (
     "float",
     "double",
     "string",
+    "wstring",
 )
 ros_binary_types = ("uint8[]", "char[]", "sequence<uint8>", "sequence<char>")
 # Remove the list type wrapper, and length specifier, from rostypes i.e. sequence<double, 3>

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -212,6 +212,24 @@ class TestMessageConversion(unittest.TestCase):
         for x in message_conversion.ros_primitive_types:
             self.do_primitive_test(x, "std_msgs/String")
 
+    def test_wstring_msg(self) -> None:
+        for value in ["", "hello", "Grüße 世界"]:
+            with self.subTest(value=value):
+                self.do_test(
+                    {
+                        "data": value,
+                        "values": [value],
+                        "fixed_values": ["", value, "hello"],
+                        "bounded_values": [value],
+                    },
+                    "rosbridge_test_msgs/TestWString",
+                )
+
+    def test_wstring_rejects_number(self) -> None:
+        inst = ros_loader.get_message_instance("rosbridge_test_msgs/TestWString")
+        with self.assertRaises(message_conversion.FieldTypeMismatchException):
+            message_conversion.populate_instance({"data": 42}, inst)
+
     def test_time_msg(self) -> None:
         now_inst = message_conversion._to_inst(
             "now", "builtin_interfaces/Time", "builtin_interfaces/Time"

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/TestFloat32Array.msg
   msg/TestFloat32BoundedArray.msg
   msg/TestNestedBoundedArray.msg
+  msg/TestWString.msg
   srv/AddTwoInts.srv
   srv/SendBytes.srv
   srv/TestArrayRequest.srv

--- a/rosbridge_test_msgs/msg/TestWString.msg
+++ b/rosbridge_test_msgs/msg/TestWString.msg
@@ -1,0 +1,4 @@
+wstring data
+wstring[] values
+wstring[3] fixed_values
+wstring[<=3] bounded_values


### PR DESCRIPTION
**Public API Changes**

None

**Description**

Fixes #1297. Treat `wstring` as a string primitive when converting between JSON and ROS messages.

Adds tests for scalar, fixed-array and sequence fields, including empty and non-ASCII strings and CDR round trips. Tested on Rolling: `rosbridge_library` tests, mypy and pre-commit pass.
