### PR TITLE
Fix original message formatting in missing-op error

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -204,7 +204,7 @@ class Protocol:
                     "error",
                     "Received a message without an op. "
                     f"All messages require 'op' field with value one of: {list(self.operations.keys())}. "
-                    "Original message was: {message_string}",
+                    f"Original message was: {message_string}",
                     mid,
                 )
             return

--- a/rosbridge_library/test/internal/test_protocol.py
+++ b/rosbridge_library/test/internal/test_protocol.py
@@ -15,6 +15,7 @@ class TestProtocol(unittest.TestCase):
 
         protocol.incoming(message)
 
+        node.get_logger.return_value.error.assert_called_once()
         logged_message = node.get_logger.return_value.error.call_args.args[0]
         self.assertIn(f"Original message was: {message}", logged_message)
 

--- a/rosbridge_library/test/internal/test_protocol.py
+++ b/rosbridge_library/test/internal/test_protocol.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock
+
+from rosbridge_library.protocol import Protocol
+
+
+class TestProtocol(unittest.TestCase):
+    def test_missing_op_log_includes_malformed_message(self) -> None:
+        node = Mock()
+        protocol = Protocol("test-client", node)
+        message = '{"msg": {"data": 1}'
+
+        protocol.incoming(message)
+
+        logged_message = node.get_logger.return_value.error.call_args.args[0]
+        self.assertIn(f"Original message was: {message}", logged_message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- interpolate the original input in the missing-`op` protocol error
- add a regression test using a truncated outer JSON object

Fixes #1159.

## Testing

- `colcon test --packages-select rosbridge_library --return-code-on-test-failure`
- `colcon test-result --verbose`: 179 tests, 0 errors, 0 failures, 0 skipped
- package mypy check: 64 files, 0 errors

Testing used a disposable ROS 2 Lyrical workspace with discovery restricted to localhost.