### PR TITLE
Clean up action goals on client disconnect

### DIFF
--- a/ROSBRIDGE_PROTOCOL.md
+++ b/ROSBRIDGE_PROTOCOL.md
@@ -533,6 +533,7 @@ Send an action goal.
 | `args` | optional | object or list | The arguments to pass to the action goal. Can be an object with message fields or a list of field values in the order they appear in the action goal definition. |
 | `feedback` | optional | boolean | Whether to send feedback messages for this goal. Defaults to `false`. |
 | `fragment_size` | optional | integer | (only C → S) The maximum size (in bytes) a message can reach before it is fragmented. |
+| `cancel_on_disconnect` | optional | boolean | (only C → S) Whether to cancel this goal if the client disconnects. Defaults to `false`. |
 
 When a client sends a `send_action_goal` message, the operation fails if either of the following is true:
 

--- a/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import fnmatch
 from functools import partial
-from threading import Thread
+from threading import Lock, Thread
 from typing import TYPE_CHECKING, Any
 
 from action_msgs.msg import GoalStatus
@@ -60,7 +60,7 @@ class SendActionGoal(Capability):
     )
     cancel_action_goal_msg_fields = ((True, "action", str),)
 
-    client_handler_list: dict[str, ActionClientHandler]
+    client_handler_list: dict[str | ActionClientHandler, ActionClientHandler]
 
     parameter_names = ("actions_glob", "send_action_goals_in_new_thread")
 
@@ -72,6 +72,8 @@ class SendActionGoal(Capability):
         Capability.__init__(self, protocol)
 
         self.client_handler_list = {}
+        self._client_handler_lock = Lock()
+        self._finished = False
 
         # Register the operations that this capability provides
         if self.send_action_goals_in_new_thread:
@@ -149,21 +151,39 @@ class SendActionGoal(Capability):
             )
         )
 
-        if cid is not None:
-            self.client_handler_list[cid] = client_handler
+        client_handler_key: str | ActionClientHandler = cid if cid is not None else client_handler
+        with self._client_handler_lock:
+            if self._finished:
+                return
+            self.client_handler_list[client_handler_key] = client_handler
 
         client_handler.run()
 
-        if cid is not None:
-            self.client_handler_list.pop(cid, None)
+        with self._client_handler_lock:
+            self.client_handler_list.pop(client_handler_key, None)
 
     def finish(self) -> None:
-        client_handlers = self.client_handler_list
-        self.client_handler_list = {}
+        with self._client_handler_lock:
+            self._finished = True
+            client_handlers = list(self.client_handler_list.values())
+            self.client_handler_list.clear()
 
-        for client_handler in client_handlers.values():
-            if client_handler.cancel_on_disconnect and client_handler.send_goal_helper is not None:
-                Thread(target=client_handler.send_goal_helper.cancel_goal, daemon=True).start()
+        client_handlers_to_cancel = [
+            client_handler
+            for client_handler in client_handlers
+            if client_handler.cancel_on_disconnect and client_handler.send_goal_helper is not None
+        ]
+        if client_handlers_to_cancel:
+            Thread(
+                target=self._cancel_client_handlers,
+                args=(client_handlers_to_cancel,),
+                daemon=True,
+            ).start()
+
+    @staticmethod
+    def _cancel_client_handlers(client_handlers: list[ActionClientHandler]) -> None:
+        for client_handler in client_handlers:
+            client_handler.send_goal_helper.cancel_goal()
 
     def cancel_action_goal(self, message: dict) -> None:
         # Extract the args
@@ -178,10 +198,12 @@ class SendActionGoal(Capability):
         cid = extract_id(action, cid)
 
         # Cancel the action
-        if cid in self.client_handler_list:
-            client_handler = self.client_handler_list[cid]
-            if client_handler.send_goal_helper is not None:
-                client_handler.send_goal_helper.cancel_goal()
+        client_handler = None
+        if cid is not None:
+            with self._client_handler_lock:
+                client_handler = self.client_handler_list.get(cid)
+        if client_handler is not None and client_handler.send_goal_helper is not None:
+            client_handler.send_goal_helper.cancel_goal()
 
     def _success(
         self,

--- a/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/send_action_goal.py
@@ -56,6 +56,7 @@ class SendActionGoal(Capability):
         (True, "action_type", str),
         (False, "fragment_size", (int, type(None))),
         (False, "compression", str),
+        (False, "cancel_on_disconnect", bool),
     )
     cancel_action_goal_msg_fields = ((True, "action", str),)
 
@@ -103,6 +104,7 @@ class SendActionGoal(Capability):
         action_type: str = message["action_type"]
         fragment_size: int | None = message.get("fragment_size")
         compression: str = message.get("compression", "none")
+        cancel_on_disconnect: bool = message.get("cancel_on_disconnect", False)
         args: list | dict[str, Any] = message.get("args", [])
 
         if self.actions_glob is not None:
@@ -143,6 +145,7 @@ class SendActionGoal(Capability):
                 e_cb,
                 f_cb,
                 self.protocol.node_handle,
+                cancel_on_disconnect=cancel_on_disconnect,
             )
         )
 
@@ -152,7 +155,15 @@ class SendActionGoal(Capability):
         client_handler.run()
 
         if cid is not None:
-            del self.client_handler_list[cid]
+            self.client_handler_list.pop(cid, None)
+
+    def finish(self) -> None:
+        client_handlers = self.client_handler_list
+        self.client_handler_list = {}
+
+        for client_handler in client_handlers.values():
+            if client_handler.cancel_on_disconnect and client_handler.send_goal_helper is not None:
+                Thread(target=client_handler.send_goal_helper.cancel_goal, daemon=True).start()
 
     def cancel_action_goal(self, message: dict) -> None:
         # Extract the args

--- a/rosbridge_library/src/rosbridge_library/internal/actions.py
+++ b/rosbridge_library/src/rosbridge_library/internal/actions.py
@@ -82,6 +82,7 @@ class ActionClientHandler(
         error_callback: Callable[[Exception], None],
         feedback_callback: Callable[[FeedbackMessage[ROSActionFeedbackT]], None] | None,
         node_handle: Node,
+        cancel_on_disconnect: bool = False,
     ) -> None:
         """
         Create a client handler for the specified action.
@@ -97,6 +98,7 @@ class ActionClientHandler(
         :param error_callback: A callback to call if an error occurs. The callback will be passed
             the exception that caused the failure
         :param node_handle: A ROS 2 node handle to call services
+        :param cancel_on_disconnect: Whether to cancel the goal when its rosbridge client disconnects
         """
         Thread.__init__(self)
         self.daemon = True
@@ -107,6 +109,7 @@ class ActionClientHandler(
         self.error = error_callback
         self.feedback = feedback_callback
         self.node_handle = node_handle
+        self.cancel_on_disconnect = cancel_on_disconnect
         self.send_goal_helper = SendGoal[
             ROSActionGoalT, ROSActionResultT, ROSActionFeedbackT, ROSActionImplT
         ]()

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import time
 import unittest
 from json import dumps, loads
-from threading import Thread
+from threading import Event, Thread
 from typing import Any
 
 import rclpy
@@ -13,6 +13,7 @@ from example_interfaces.action._fibonacci import Fibonacci_FeedbackMessage
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+
 from rosbridge_library.capabilities.action_feedback import ActionFeedback
 from rosbridge_library.capabilities.action_result import ActionResult
 from rosbridge_library.capabilities.advertise_action import AdvertiseAction
@@ -23,6 +24,20 @@ from rosbridge_library.internal.exceptions import (
     MissingArgumentException,
 )
 from rosbridge_library.protocol import Protocol
+
+
+class _FakeSendGoal:
+    def __init__(self) -> None:
+        self.cancelled = Event()
+
+    def cancel_goal(self) -> None:
+        self.cancelled.set()
+
+
+class _FakeActionClientHandler:
+    def __init__(self, cancel_on_disconnect: bool = False) -> None:
+        self.cancel_on_disconnect = cancel_on_disconnect
+        self.send_goal_helper = _FakeSendGoal()
 
 
 class TestActionCapabilities(unittest.TestCase):
@@ -98,6 +113,37 @@ class TestActionCapabilities(unittest.TestCase):
     def test_result_invalid_arguments(self) -> None:
         result_msg = loads(dumps({"op": "action_result", "action": 5, "result": "error"}))
         self.assertRaises(InvalidArgumentException, self.result.action_result, result_msg)
+
+    def test_send_goal_rejects_invalid_cancel_on_disconnect(self) -> None:
+        goal_msg = loads(
+            dumps(
+                {
+                    "op": "send_action_goal",
+                    "action": "/fibonacci_action",
+                    "action_type": "example_interfaces/Fibonacci",
+                    "cancel_on_disconnect": "true",
+                }
+            )
+        )
+
+        self.assertRaises(InvalidArgumentException, self.send_goal.send_action_goal, goal_msg)
+
+    def test_finish_drops_action_goal_handlers_without_cancelling_by_default(self) -> None:
+        handler = _FakeActionClientHandler()
+        self.send_goal.client_handler_list["goal"] = handler  # type: ignore[assignment]
+
+        self.send_goal.finish()
+
+        self.assertEqual(self.send_goal.client_handler_list, {})
+        self.assertFalse(handler.send_goal_helper.cancelled.is_set())
+
+    def test_finish_cancels_opted_in_action_goals(self) -> None:
+        handler = _FakeActionClientHandler(cancel_on_disconnect=True)
+        self.send_goal.client_handler_list["goal"] = handler  # type: ignore[assignment]
+
+        self.send_goal.finish()
+
+        self.assertTrue(handler.send_goal_helper.cancelled.wait(timeout=1.0))
 
     def test_advertise_action(self) -> None:
         action_path = "/fibonacci_action_1"

--- a/rosbridge_library/test/capabilities/test_action_capabilities.py
+++ b/rosbridge_library/test/capabilities/test_action_capabilities.py
@@ -13,7 +13,6 @@ from example_interfaces.action._fibonacci import Fibonacci_FeedbackMessage
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
-
 from rosbridge_library.capabilities.action_feedback import ActionFeedback
 from rosbridge_library.capabilities.action_result import ActionResult
 from rosbridge_library.capabilities.advertise_action import AdvertiseAction
@@ -27,17 +26,23 @@ from rosbridge_library.protocol import Protocol
 
 
 class _FakeSendGoal:
-    def __init__(self) -> None:
+    def __init__(self, block_cancel: bool = False) -> None:
+        self.cancel_started = Event()
+        self.continue_cancel = Event()
         self.cancelled = Event()
+        if not block_cancel:
+            self.continue_cancel.set()
 
     def cancel_goal(self) -> None:
+        self.cancel_started.set()
+        self.continue_cancel.wait(timeout=1.0)
         self.cancelled.set()
 
 
 class _FakeActionClientHandler:
-    def __init__(self, cancel_on_disconnect: bool = False) -> None:
+    def __init__(self, cancel_on_disconnect: bool = False, block_cancel: bool = False) -> None:
         self.cancel_on_disconnect = cancel_on_disconnect
-        self.send_goal_helper = _FakeSendGoal()
+        self.send_goal_helper = _FakeSendGoal(block_cancel)
 
 
 class TestActionCapabilities(unittest.TestCase):
@@ -144,6 +149,37 @@ class TestActionCapabilities(unittest.TestCase):
         self.send_goal.finish()
 
         self.assertTrue(handler.send_goal_helper.cancelled.wait(timeout=1.0))
+
+    def test_finish_cancels_action_goals_sequentially(self) -> None:
+        first = _FakeActionClientHandler(cancel_on_disconnect=True, block_cancel=True)
+        second = _FakeActionClientHandler(cancel_on_disconnect=True)
+        self.addCleanup(first.send_goal_helper.continue_cancel.set)
+        self.send_goal.client_handler_list["first"] = first  # type: ignore[assignment]
+        self.send_goal.client_handler_list["second"] = second  # type: ignore[assignment]
+
+        self.send_goal.finish()
+
+        self.assertTrue(first.send_goal_helper.cancel_started.wait(timeout=1.0))
+        self.assertFalse(second.send_goal_helper.cancel_started.wait(timeout=0.1))
+        first.send_goal_helper.continue_cancel.set()
+        self.assertTrue(second.send_goal_helper.cancel_started.wait(timeout=1.0))
+
+    def test_send_goal_does_not_register_after_finish(self) -> None:
+        self.send_goal.finish()
+        goal_msg = loads(
+            dumps(
+                {
+                    "op": "send_action_goal",
+                    "action": "/fibonacci_action",
+                    "action_type": "example_interfaces/Fibonacci",
+                }
+            )
+        )
+
+        self.send_goal.send_action_goal(goal_msg)
+
+        self.assertIsNone(self.received_message)
+        self.assertEqual(self.send_goal.client_handler_list, {})
 
     def test_advertise_action(self) -> None:
         action_path = "/fibonacci_action_1"


### PR DESCRIPTION
## Summary
- add an optional cancel_on_disconnect flag to send_action_goal, defaulting to false for backward compatibility
- clear per-client action handler state during Protocol.finish() and asynchronously cancel only opted-in goals
- avoid the completion/disconnect race by swapping the handler map before cleanup
- document and test the new protocol field and disconnect behavior

## Testing
- Ruff format and lint checks on changed Python files
- fresh ROS 2 Lyrical build of rosbridge_test_msgs and rosbridge_library
- complete rosbridge_library test run: 181 tests, 0 errors, 0 failures, 0 skipped
- mypy: 63 files checked, 0 errors

All testing used local simulated ROS nodes only. No robot, vehicle, or external ROS target was contacted.

Fixes #1291
