### PR TITLE
Encode non-finite float array values as null

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -265,11 +265,14 @@ def _from_list_inst(inst: ListType, rostype: str) -> list:
 
     # Shortcut for primitives
     if base_rostype in ros_primitive_types:
-        # Convert to Built-in integer types to dump as JSON
+        # Convert NumPy numbers to built-in types for JSON encoding
         if isinstance(inst, np.ndarray) and (
             base_rostype in type_map["int"] or base_rostype in type_map["float"]
         ):
-            return inst.tolist()
+            converted_values = inst.tolist()
+            if base_rostype in type_map["int"]:
+                return converted_values
+            inst = converted_values
 
         if base_rostype not in type_map["float"]:
             return list(inst)

--- a/rosbridge_library/test/internal/test_message_conversion.py
+++ b/rosbridge_library/test/internal/test_message_conversion.py
@@ -132,6 +132,14 @@ class TestMessageConversion(unittest.TestCase):
                     dumps({"data": message_conversion._from_inst(msg, rostype)}), '{"data": null}'
                 )
 
+    def test_float_array_special_cases(self) -> None:
+        for dtype, rostype in [(np.float32, "float32[4]"), (np.float64, "float64[4]")]:
+            values = np.array([1.0, float("inf"), -float("inf"), float("nan")], dtype=dtype)
+            extracted = message_conversion._from_inst(values, rostype)
+
+            self.assertEqual(extracted, [1.0, None, None, None])
+            self.assertEqual(dumps(extracted, allow_nan=False), "[1.0, null, null, null]")
+
     def test_signed_int_base_msgs(self) -> None:
         int8s = range(-127, 128)
         for int8 in int8s:


### PR DESCRIPTION
## Summary
- convert NumPy float arrays to Python values before JSON serialization
- route float elements through the existing NaN/Infinity-to-`null` sanitizer
- add regression coverage for float32 and float64 arrays with strict JSON encoding

## Why
The NumPy array shortcut returned `ndarray.tolist()` directly, bypassing the scalar float conversion that maps non-finite values to `None`. As a result, array fields such as `NavSatFix.position_covariance` emitted invalid JSON `NaN` values even though scalar fields correctly emitted `null`.

The integer-array shortcut remains unchanged; only float arrays take the existing element-wise validation path.

## Testing
- regression test reproduced `[1.0, inf, -inf, nan]` before the fix
- focused regression test passes after the fix
- `colcon test --packages-select rosbridge_library --return-code-on-test-failure`: 179 tests, 0 failures
- `uvx pre-commit run --all-files`: passed
- exact `NavSatFix` reproduction serializes all non-finite scalar and covariance values as JSON `null`

Closes #916